### PR TITLE
Fix manual order subtotals

### DIFF
--- a/app/admin/orders/manual/create/page.tsx
+++ b/app/admin/orders/manual/create/page.tsx
@@ -53,7 +53,10 @@ export default function CreateManualOrderPage() {
     return null
   }
 
-  const subtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+  const subtotal = items.reduce(
+    (sum, item) => sum + item.price * item.quantity * (1 - (item.discount ?? 0) / 100),
+    0
+  )
   const total = subtotal - discount + shippingCost + tax
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/admin/orders/manual/edit/[id]/page.tsx
+++ b/app/admin/orders/manual/edit/[id]/page.tsx
@@ -102,7 +102,10 @@ export default function EditManualOrderPage({ params }: EditManualOrderPageProps
     return null
   }
 
-  const subtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+  const subtotal = items.reduce(
+    (sum, item) => sum + item.price * item.quantity * (1 - (item.discount ?? 0) / 100),
+    0
+  )
   const total = subtotal - discount + shippingCost + tax
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- include per-item discounts when computing subtotals
- update subtotal logic in manual order create/edit pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68723a80303c8325acd1c4884029e7f3