### PR TITLE
Add order timeline and mock fallbacks

### DIFF
--- a/app/admin/collections/page.tsx
+++ b/app/admin/collections/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { getCollections, mockFabrics } from "@/lib/mock-collections"
+import { getCollections } from "@/lib/mock-collections"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -28,9 +28,8 @@ export default function AdminCollectionsPage() {
       name: "",
       slug: "",
       description: "",
-      price_range: "",
-      thumbnail_images: [],
-      all_images: [],
+      priceRange: "",
+      images: [],
       id: "",
     },
   })
@@ -38,20 +37,15 @@ export default function AdminCollectionsPage() {
   useEffect(() => {
     const fetchCollections = async () => {
       const cols = await getCollections()
-      const map: Record<string, { id: string; name: string }[]> = {}
-      mockFabrics.forEach((f) => {
-        if (!map[f.collection_id]) map[f.collection_id] = []
-        map[f.collection_id].push({ id: f.id, name: f.name })
-      })
       setCollections(
-        cols.map((c) => ({ ...c, fabrics: map[c.id] || [] })) as CollectionWithFabrics[],
+        cols.map((c) => ({ ...c, fabrics: [] })) as CollectionWithFabrics[],
       )
     }
     fetchCollections()
   }, [])
 
   const resetForm = () => {
-    form.reset({ id: "", name: "", slug: "", description: "", price_range: "", thumbnail_images: [], all_images: [] })
+    form.reset({ id: "", name: "", slug: "", description: "", priceRange: "", images: [] })
   }
 
   const handleSubmit = (values: Collection) => {
@@ -160,7 +154,7 @@ export default function AdminCollectionsPage() {
                     )}
                   />
                   <FormField
-                    name="price_range"
+                    name="priceRange"
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>ช่วงราคา</FormLabel>
@@ -171,28 +165,13 @@ export default function AdminCollectionsPage() {
                     )}
                   />
                   <FormField
-                    name="thumbnail_images"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>รูปตัวอย่าง (คั่นด้วย comma)</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="url1,url2"
-                            value={field.value.join(',')}
-                            onChange={(e) => field.onChange(e.target.value.split(','))}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    name="all_images"
+                    name="images"
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>รูปทั้งหมด (คั่นด้วย comma)</FormLabel>
                         <FormControl>
                           <Input
-                            placeholder="url1,url2" 
+                            placeholder="url1,url2"
                             value={field.value.join(',')}
                             onChange={(e) => field.onChange(e.target.value.split(','))}
                           />
@@ -244,7 +223,7 @@ export default function AdminCollectionsPage() {
                   <TableRow key={collection.id}>
                     <TableCell>
                       <Image
-                        src={collection.thumbnail_images[0] || "/placeholder.svg"}
+                        src={collection.images[0] || "/placeholder.svg"}
                         alt={collection.name}
                         width={50}
                         height={50}

--- a/app/admin/orders/create/page.tsx
+++ b/app/admin/orders/create/page.tsx
@@ -92,7 +92,7 @@ export default function CreateOrderPage() {
         {
           timestamp: new Date().toISOString(),
           status: "pendingPayment",
-          user: "admin@nutlove.co",
+          updatedBy: "admin@nutlove.co",
           note: "Order created",
         },
       ],

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
   } else {
     const { data: dbData, error } = await supabase
       .from("collections")
-      .select("name, slug, price_range, description, all_images")
+      .select("id, name, slug, price_range, description, all_images")
       .eq("slug", params.slug)
       .single()
 
@@ -26,18 +26,25 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
       notFound()
     }
 
-    data = dbData
+    data = {
+      id: dbData.id,
+      name: dbData.name,
+      slug: dbData.slug,
+      priceRange: dbData.price_range,
+      description: dbData.description,
+      images: dbData.all_images || [],
+    }
   }
 
-  const images: string[] = (data as any).all_images || []
+  const images: string[] = (data as any).images || []
 
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
       <div className="container mx-auto px-4 py-8 flex-1">
         <h1 className="text-3xl font-bold mb-2">{data.name}</h1>
-        {data.price_range && (
-          <p className="text-gray-700 mb-2">{data.price_range}</p>
+        {data.priceRange && (
+          <p className="text-gray-700 mb-2">{data.priceRange}</p>
         )}
         {data.description && (
           <p className="text-gray-600 mb-8 whitespace-pre-line">{data.description}</p>

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -60,7 +60,7 @@ export default function CollectionsPage() {
                 className="border rounded-lg overflow-hidden hover:shadow transition bg-white"
               >
                 <div className="grid grid-cols-2 gap-0 border-b">
-                  {collection.all_images.slice(0, 4).map((img, idx) => (
+                  {collection.images.slice(0, 4).map((img, idx) => (
                     <div key={idx} className="relative aspect-square">
                       <Image src={img || "/placeholder.svg"} alt={collection.name} fill className="object-cover" />
                     </div>
@@ -70,7 +70,7 @@ export default function CollectionsPage() {
                   <h3 className="font-semibold text-sm md:text-base truncate">
                     {collection.name}
                   </h3>
-                  <p className="text-xs text-gray-600 mt-1">{collection.price_range}</p>
+                  <p className="text-xs text-gray-600 mt-1">{collection.priceRange}</p>
                 </div>
               </Link>
             ))}

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image"
 import Link from "next/link"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
+import { mockFabrics } from "@/lib/mock-fabrics"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 
 export const metadata: Metadata = {
@@ -20,28 +21,29 @@ interface Fabric {
 }
 
 export default async function FabricsPage() {
+  let fabrics: Fabric[] = []
   if (!supabase) {
-    return (
-      <div className="min-h-screen">
-        <Navbar />
-        <div className="container mx-auto px-4 py-8 text-red-500">Supabase client not configured</div>
-        <Footer />
-      </div>
-    )
-  }
+    fabrics = mockFabrics.map((f) => ({
+      id: f.id,
+      slug: f.slug,
+      name: f.name,
+      image_urls: f.images,
+    }))
+  } else {
+    const { data, error } = await supabase
+      .from("fabrics")
+      .select("id, slug, name, image_url, image_urls")
 
-  const { data: fabrics, error } = await supabase
-    .from("fabrics")
-    .select("id, slug, name, image_url, image_urls")
-
-  if (error || !fabrics) {
-    return (
-      <div className="min-h-screen">
-        <Navbar />
-        <div className="container mx-auto px-4 py-8 text-red-500">ไม่สามารถโหลดข้อมูลผ้าได้</div>
-        <Footer />
-      </div>
-    )
+    if (error || !data) {
+      return (
+        <div className="min-h-screen">
+          <Navbar />
+          <div className="container mx-auto px-4 py-8 text-red-500">ไม่สามารถโหลดข้อมูลผ้าได้</div>
+          <Footer />
+        </div>
+      )
+    }
+    fabrics = data as Fabric[]
   }
 
   return (

--- a/app/order/public/[publicLink]/page.tsx
+++ b/app/order/public/[publicLink]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import Link from "next/link"
 import { CheckCircle, Clock, Package, Truck, MapPin, Phone, Mail, Calendar } from "lucide-react"
+import { OrderTimeline } from "@/components/order/OrderTimeline"
 import type { ManualOrder, OrderStatus } from "@/types/order"
 import { orderDb } from "@/lib/order-database"
 
@@ -247,6 +248,10 @@ export default function PublicOrderPage({ params }: PublicOrderPageProps) {
               >
                 <Button>สอบถามสถานะทาง Messenger</Button>
               </Link>
+            </div>
+            <div className="mt-6">
+              <h4 className="font-semibold mb-4">ไทม์ไลน์สถานะ</h4>
+              <OrderTimeline timeline={order.timeline} />
             </div>
           </CardContent>
         </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default async function HomePage() {
               >
                 <div className="relative w-full h-40">
                   <Image
-                    src={col.all_images[0] || "/placeholder.svg"}
+                    src={col.images[0] || "/placeholder.svg"}
                     alt={col.name}
                     fill
                     className="object-cover"
@@ -115,7 +115,7 @@ export default async function HomePage() {
                 </div>
                 <div className="p-4">
                   <h3 className="font-semibold text-base truncate">{col.name}</h3>
-                  <p className="text-sm text-gray-600 mt-1">{col.price_range}</p>
+                  <p className="text-sm text-gray-600 mt-1">{col.priceRange}</p>
                 </div>
               </Link>
             ))}

--- a/components/order/OrderTimeline.tsx
+++ b/components/order/OrderTimeline.tsx
@@ -18,7 +18,7 @@ interface TimelineEntry {
   timestamp: string
   status: OrderStatus
   note?: string
-  user: string
+  updatedBy: string
 }
 
 interface OrderTimelineProps {
@@ -39,7 +39,7 @@ export function OrderTimeline({ timeline, editable = false, onAddEntry }: OrderT
         status,
         note: note || undefined,
         timestamp: new Date().toISOString(),
-        user: "admin@nutlove.co",
+        updatedBy: "admin@nutlove.co",
       })
       setNote("")
     }

--- a/lib/mock-collections.ts
+++ b/lib/mock-collections.ts
@@ -4,144 +4,35 @@ export interface Collection {
   id: string
   name: string
   slug: string
-  price_range: string
-  thumbnail_images: string[]
-  all_images: string[]
+  priceRange: string
   description: string
-}
-
-export interface Fabric {
-  id: string
-  name: string
-  collection_id: string
-  image_urls: string[]
-  price_min: number
-  price_max: number
+  images: string[]
 }
 
 export const mockCollections: Collection[] = [
   {
     id: '1',
-    name: 'คอลเลกชันฤดูร้อน',
-    slug: 'summer',
-    price_range: '฿100 - ฿300',
-    thumbnail_images: [
-      '/placeholder.svg?height=200&width=200',
-    ],
-    all_images: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    description: 'ลายผ้าสดใสเหมาะกับหน้าร้อน',
+    name: 'Cozy Earth',
+    slug: 'cozy-earth',
+    priceRange: '890–2190',
+    description: 'ผ้านุ่มสบาย สไตล์มินิมอล',
+    images: ['/images/035.jpg', '/images/036.jpg', '/images/037.jpg', '/images/038.jpg'],
   },
   {
     id: '2',
-    name: 'คอลเลกชันมินิมอล',
-    slug: 'minimal',
-    price_range: '฿150 - ฿350',
-    thumbnail_images: [
-      '/placeholder.svg?height=200&width=200',
-    ],
-    all_images: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    description: 'ลายเรียบง่ายสไตล์มินิมอล',
-  },
-]
-
-export const mockFabrics: Fabric[] = [
-  {
-    id: 'f1',
-    name: 'ลายดอกไม้ A',
-    collection_id: '1',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 100,
-    price_max: 200,
+    name: 'Modern Loft',
+    slug: 'modern-loft',
+    priceRange: '990–1990',
+    description: 'โทนเข้ม มีสไตล์',
+    images: ['/images/039.jpg', '/images/040.jpg', '/images/041.jpg', '/images/042.jpg'],
   },
   {
-    id: 'f2',
-    name: 'ลายดอกไม้ B',
-    collection_id: '1',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 120,
-    price_max: 220,
-  },
-  {
-    id: 'f3',
-    name: 'ลายกราฟิก A',
-    collection_id: '1',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 150,
-    price_max: 250,
-  },
-  {
-    id: 'f4',
-    name: 'ลายกราฟิก B',
-    collection_id: '1',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 180,
-    price_max: 280,
-  },
-  {
-    id: 'f5',
-    name: 'ลายเรียบ A',
-    collection_id: '2',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 200,
-    price_max: 300,
-  },
-  {
-    id: 'f6',
-    name: 'ลายเรียบ B',
-    collection_id: '2',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 220,
-    price_max: 320,
-  },
-  {
-    id: 'f7',
-    name: 'ลายเส้น A',
-    collection_id: '2',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 250,
-    price_max: 350,
-  },
-  {
-    id: 'f8',
-    name: 'ลายเส้น B',
-    collection_id: '2',
-    image_urls: [
-      '/placeholder.svg?height=300&width=300',
-      '/placeholder.svg?height=300&width=300',
-    ],
-    price_min: 280,
-    price_max: 380,
+    id: '3',
+    name: 'Vintage Vibes',
+    slug: 'vintage-vibes',
+    priceRange: '890–2590',
+    description: 'ลายวินเทจคลาสสิก',
+    images: ['/images/043.jpg', '/images/044.jpg', '/images/045.jpg', '/images/046.jpg'],
   },
 ]
 
@@ -149,13 +40,22 @@ export async function getCollections(): Promise<Collection[]> {
   if (!supabase) {
     return Promise.resolve(mockCollections)
   }
-
-  const { data, error } = await supabase.from('collections').select('id, name, slug, price_range, thumbnail_images, all_images, description').order('created_at', { ascending: false })
+  const { data, error } = await supabase
+    .from('collections')
+    .select('id, name, slug, price_range, description, all_images')
+    .order('created_at', { ascending: false })
 
   if (error || !data) {
     console.error('Supabase fetch collections error', error)
     return mockCollections
   }
 
-  return data as Collection[]
+  return data.map((c) => ({
+    id: c.id,
+    name: c.name,
+    slug: c.slug,
+    priceRange: c.price_range,
+    description: c.description,
+    images: c.all_images || [],
+  })) as Collection[]
 }

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -1,0 +1,65 @@
+import { supabase } from './supabase'
+
+export interface Fabric {
+  id: string
+  name: string
+  slug: string
+  color: string
+  price: number
+  images: string[]
+}
+
+export const mockFabrics: Fabric[] = [
+  {
+    id: 'f01',
+    name: 'Soft Linen',
+    slug: 'soft-linen',
+    color: 'ครีม',
+    price: 990,
+    images: ['/images/039.jpg', '/images/040.jpg'],
+  },
+  {
+    id: 'f02',
+    name: 'Cozy Cotton',
+    slug: 'cozy-cotton',
+    color: 'เทา',
+    price: 1090,
+    images: ['/images/041.jpg', '/images/042.jpg'],
+  },
+  {
+    id: 'f03',
+    name: 'Velvet Dream',
+    slug: 'velvet-dream',
+    color: 'น้ำเงิน',
+    price: 1290,
+    images: ['/images/043.jpg', '/images/044.jpg'],
+  },
+  {
+    id: 'f04',
+    name: 'Classic Stripe',
+    slug: 'classic-stripe',
+    color: 'กรม',
+    price: 1190,
+    images: ['/images/045.jpg', '/images/046.jpg'],
+  },
+  {
+    id: 'f05',
+    name: 'Floral Muse',
+    slug: 'floral-muse',
+    color: 'ชมพู',
+    price: 1090,
+    images: ['/images/047.jpg', '/images/035.jpg'],
+  },
+]
+
+export async function getFabrics() {
+  if (!supabase) {
+    return Promise.resolve(mockFabrics)
+  }
+  const { data, error } = await supabase.from('fabrics').select('*')
+  if (error || !data) {
+    console.error('Supabase fetch fabrics error', error)
+    return mockFabrics
+  }
+  return data as Fabric[]
+}

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -40,7 +40,7 @@ const initialMockOrders: Order[] = [
       {
         timestamp: "2024-01-15T10:30:00Z",
         status: "depositPaid",
-        user: "admin@nutlove.co",
+        updatedBy: "admin@nutlove.co",
         note: "Order created",
       },
     ],
@@ -81,7 +81,7 @@ const initialMockOrders: Order[] = [
       {
         timestamp: "2024-01-14T14:20:00Z",
         status: "paid",
-        user: "admin@nutlove.co",
+        updatedBy: "admin@nutlove.co",
         note: "Order created",
       },
     ],

--- a/lib/order-database.ts
+++ b/lib/order-database.ts
@@ -53,7 +53,7 @@ const manualOrders: ManualOrder[] = [
       {
         timestamp: "2024-01-15T10:30:00Z",
         status: "confirmed",
-        user: "admin@nutlove.co",
+        updatedBy: "admin@nutlove.co",
         note: "Order created",
       },
     ],
@@ -95,7 +95,7 @@ const manualOrders: ManualOrder[] = [
       {
         timestamp: "2024-01-16T09:15:00Z",
         status: "processing",
-        user: "admin@nutlove.co",
+        updatedBy: "admin@nutlove.co",
         note: "Order created",
       },
     ],
@@ -161,7 +161,7 @@ export const orderDb = {
             {
               timestamp: new Date().toISOString(),
               status: orderData.status || "draft",
-              user: "admin@nutlove.co",
+              updatedBy: "admin@nutlove.co",
               note: "Order created",
             },
           ],
@@ -188,7 +188,7 @@ export const orderDb = {
           current.timeline.push({
             timestamp: new Date().toISOString(),
             status: updates.status,
-            user: "admin@nutlove.co",
+            updatedBy: "admin@nutlove.co",
           })
         }
 

--- a/types/collection.ts
+++ b/types/collection.ts
@@ -2,8 +2,7 @@ export interface Collection {
   id: string
   name: string
   slug: string
-  price_range: string
-  thumbnail_images: string[]
-  all_images: string[]
+  priceRange: string
   description: string
+  images: string[]
 }

--- a/types/order.ts
+++ b/types/order.ts
@@ -88,7 +88,7 @@ export interface Order {
     timestamp: string
     status: OrderStatus
     note?: string
-    user: string
+    updatedBy: string
   }>
 }
 
@@ -117,7 +117,7 @@ export interface ManualOrder {
     timestamp: string
     status: OrderStatus
     note?: string
-    user: string
+    updatedBy: string
   }>
 }
 


### PR DESCRIPTION
## Summary
- extend order timeline types with `updatedBy`
- add mock collections and fabrics data
- support fallback data on collections and fabrics pages
- show order timeline on public order page
- update admin pages to the new mock data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68728cfdd7e08325b7b20b04c5d5512d