### PR TITLE
Add wishlist and fabric compare with Messenger link

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import { supabase } from "@/lib/supabase"
 import { getCollections } from "@/lib/mock-collections"
+import { WishlistButton } from "@/components/WishlistButton"
 
 export default async function CollectionDetailPage({ params }: { params: { slug: string } }) {
   let data: any
@@ -42,13 +43,27 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
     <div className="min-h-screen flex flex-col">
       <Navbar />
       <div className="container mx-auto px-4 py-8 flex-1">
-        <h1 className="text-3xl font-bold mb-2">{data.name}</h1>
+        <div className="flex items-center mb-2 space-x-2">
+          <h1 className="text-3xl font-bold">{data.name}</h1>
+          <WishlistButton slug={data.slug} />
+        </div>
         {data.priceRange && (
           <p className="text-gray-700 mb-2">{data.priceRange}</p>
         )}
         {data.description && (
-          <p className="text-gray-600 mb-8 whitespace-pre-line">{data.description}</p>
+          <p className="text-gray-600 mb-4 whitespace-pre-line">{data.description}</p>
         )}
+        <div className="mb-6">
+          <a
+            href={`https://m.me/elfsofacover?text=${encodeURIComponent(
+              `สนใจลายผ้า ${data.slug} ครับ`,
+            )}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button size="sm">💬 สอบถามผ่าน Facebook</Button>
+          </a>
+        </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
           {images.slice(0, 12).map((img, idx) => (
             <div key={idx} className="space-y-2">
@@ -56,7 +71,9 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
                 <Image src={img || "/placeholder.svg"} alt={`fabric ${idx + 1}`} fill className="object-cover" />
               </div>
               <a
-                href={`https://m.me/nutsofacover?ref=${data.slug}-${idx + 1}`}
+                href={`https://m.me/elfsofacover?text=${encodeURIComponent(
+                  `สนใจลายผ้า ${data.slug} ครับ`,
+                )}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,80 +1,41 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
+import Image from "next/image"
+import Link from "next/link"
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { X, Star, ShoppingCart, Plus } from "lucide-react"
-import Link from "next/link"
-import Image from "next/image"
-import { useSearchParams } from "next/navigation"
-import { db } from "@/lib/database"
-import { useCart } from "@/contexts/cart-context"
-import { useToast } from "@/hooks/use-toast"
-import { DevelopmentNotice } from "@/components/development-notice"
+import { useCompare } from "@/contexts/compare-context"
+import { mockFabrics } from "@/lib/mock-fabrics"
+
+interface Fabric {
+  id: string
+  slug: string
+  name: string
+  color: string
+  price: number
+  images: string[]
+}
 
 export default function ComparePage() {
-  const searchParams = useSearchParams()
-  const productIds = searchParams.get("products")?.split(",") || []
-  const [products, setProducts] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
-  const [showNotice, setShowNotice] = useState(true)
-  const { dispatch } = useCart()
-  const { toast } = useToast()
+  const { items, clear } = useCompare()
+  const [fabrics, setFabrics] = useState<Fabric[]>([])
 
   useEffect(() => {
-    loadProducts()
-  }, [productIds])
+    setFabrics(mockFabrics.filter((f) => items.includes(f.slug)))
+  }, [items])
 
-  const loadProducts = async () => {
-    try {
-      const loadedProducts = []
-      for (const id of productIds) {
-        const product = await db.getProductById(id)
-        if (product) {
-          loadedProducts.push(product)
-        }
-      }
-      setProducts(loadedProducts)
-    } catch (error) {
-      console.error("Error loading products:", error)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const removeProduct = (productId: string) => {
-    setProducts(products.filter((p) => p.id !== productId))
-  }
-
-  const addToCart = (product: any) => {
-    dispatch({
-      type: "ADD_ITEM",
-      payload: {
-        id: product.id,
-        name: product.name,
-        price: product.price,
-        image: product.images[0],
-        quantity: 1,
-      },
-    })
-
-    toast({
-      title: "เพิ่มลงตะกร้าแล้ว",
-      description: `${product.name} ถูกเพิ่มลงตะกร้าเรียบร้อยแล้ว`,
-    })
-  }
-
-  if (loading) {
+  if (fabrics.length === 0) {
     return (
       <div className="min-h-screen">
         <Navbar />
         <div className="container mx-auto px-4 py-16 text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
-          <p className="mt-4 text-gray-600">กำลังโหลดข้อมูลเปรียบเทียบ...</p>
+          <div className="text-6xl mb-4">🔍</div>
+          <p className="text-gray-600">ไม่มีรายการเปรียบเทียบ</p>
+          <Link href="/fabrics">
+            <Button className="mt-4">เลือกผ้า</Button>
+          </Link>
         </div>
         <Footer />
       </div>
@@ -84,260 +45,61 @@ export default function ComparePage() {
   return (
     <div className="min-h-screen">
       <Navbar />
-
       <div className="container mx-auto px-4 py-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-4">เปรียบเทียบสินค้า</h1>
-          <p className="text-gray-600">เปรียบเทียบคุณสมบัติและราคาของสินค้าที่คุณสนใจ</p>
+        <h1 className="text-3xl font-bold mb-6">เปรียบเทียบลายผ้า</h1>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-center border">
+            <thead>
+              <tr>
+                <th className="px-4 py-2">รายละเอียด</th>
+                {fabrics.map((f) => (
+                  <th key={f.slug} className="px-4 py-2">
+                    <Image
+                      src={f.images[0] || "/placeholder.svg"}
+                      alt={f.name}
+                      width={100}
+                      height={100}
+                      className="mx-auto rounded"
+                    />
+                    <p className="mt-2 font-medium">{f.name}</p>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="font-medium">สี</td>
+                {fabrics.map((f) => (
+                  <td key={f.slug}>{f.color}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="font-medium">ราคา</td>
+                {fabrics.map((f) => (
+                  <td key={f.slug}>฿{f.price.toLocaleString()}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="font-medium">ความรู้สึก</td>
+                {fabrics.map((f) => (
+                  <td key={f.slug}>นุ่มสบาย</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="font-medium">ผิวสัมผัส</td>
+                {fabrics.map((f) => (
+                  <td key={f.slug}>ผิวละเอียด</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
         </div>
-
-        {showNotice && (
-          <div className="mb-6">
-            <DevelopmentNotice
-              feature="ระบบเปรียบเทียบสินค้า"
-              description="ฟีเจอร์เปรียบเทียบสินค้าแบบละเอียดยังอยู่ระหว่างการพัฒนา ขณะนี้แสดงข้อมูลพื้นฐานเท่านั้น"
-              onClose={() => setShowNotice(false)}
-            />
-          </div>
-        )}
-
-        {products.length === 0 ? (
-          <div className="text-center py-16">
-            <div className="text-6xl mb-6">🔍</div>
-            <h2 className="text-2xl font-bold mb-4">ไม่มีสินค้าให้เปรียบเทียบ</h2>
-            <p className="text-gray-600 mb-8">เลือกสินค้าที่ต้องการเปรียบเทียบจากหน้ารายการสินค้า</p>
-            <Link href="/products">
-              <Button size="lg">
-                <Plus className="mr-2 h-4 w-4" />
-                เลือกสินค้า
-              </Button>
-            </Link>
-          </div>
-        ) : (
-          <div className="space-y-8">
-            {/* Product Cards Overview */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {products.map((product) => (
-                <Card key={product.id} className="relative">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="absolute top-2 right-2 z-10"
-                    onClick={() => removeProduct(product.id)}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-
-                  <CardContent className="p-4">
-                    <div className="relative mb-4">
-                      <Image
-                        src={product.images[0] || "/placeholder.svg"}
-                        alt={product.name}
-                        width={300}
-                        height={200}
-                        className="w-full h-48 object-cover rounded-lg"
-                      />
-                      {product.originalPrice && (
-                        <Badge className="absolute top-2 left-2 bg-red-500">
-                          ลด {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}%
-                        </Badge>
-                      )}
-                    </div>
-
-                    <h3 className="font-semibold text-lg mb-2 line-clamp-2">{product.name}</h3>
-
-                    <div className="flex items-center space-x-1 mb-2">
-                      <div className="flex">
-                        {[...Array(5)].map((_, i) => (
-                          <Star
-                            key={i}
-                            className={`h-4 w-4 ${
-                              i < Math.floor(product.rating) ? "text-yellow-400 fill-current" : "text-gray-300"
-                            }`}
-                          />
-                        ))}
-                      </div>
-                      <span className="text-sm text-gray-600">({product.reviews})</span>
-                    </div>
-
-                    <div className="flex items-center space-x-2 mb-4">
-                      <span className="text-2xl font-bold text-primary">฿{product.price.toLocaleString()}</span>
-                      {product.originalPrice && (
-                        <span className="text-sm text-gray-500 line-through">
-                          ฿{product.originalPrice.toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="flex space-x-2">
-                      <Link href={`/products/${product.slug}`} className="flex-1">
-                        <Button variant="outline" className="w-full bg-transparent">
-                          ดูรายละเอียด
-                        </Button>
-                      </Link>
-                      <Button onClick={() => addToCart(product)} className="flex-1">
-                        <ShoppingCart className="mr-2 h-4 w-4" />
-                        เพิ่มลงตะกร้า
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-
-            {/* Detailed Comparison Table */}
-            <Card>
-              <CardHeader>
-                <CardTitle>เปรียบเทียบรายละเอียด</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-32">รายการ</TableHead>
-                        {products.map((product) => (
-                          <TableHead key={product.id} className="text-center min-w-48">
-                            <div className="space-y-2">
-                              <Image
-                                src={product.images[0] || "/placeholder.svg"}
-                                alt={product.name}
-                                width={80}
-                                height={80}
-                                className="w-20 h-20 object-cover rounded-lg mx-auto"
-                              />
-                              <p className="font-medium text-sm line-clamp-2">{product.name}</p>
-                            </div>
-                          </TableHead>
-                        ))}
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      <TableRow>
-                        <TableCell className="font-medium">ราคา</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <div className="space-y-1">
-                              <div className="text-lg font-bold text-primary">฿{product.price.toLocaleString()}</div>
-                              {product.originalPrice && (
-                                <div className="text-sm text-gray-500 line-through">
-                                  ฿{product.originalPrice.toLocaleString()}
-                                </div>
-                              )}
-                            </div>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">คะแนน</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <div className="flex items-center justify-center space-x-1">
-                              <div className="flex">
-                                {[...Array(5)].map((_, i) => (
-                                  <Star
-                                    key={i}
-                                    className={`h-4 w-4 ${
-                                      i < Math.floor(product.rating) ? "text-yellow-400 fill-current" : "text-gray-300"
-                                    }`}
-                                  />
-                                ))}
-                              </div>
-                              <span className="text-sm">({product.reviews})</span>
-                            </div>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">หมวดหมู่</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <Badge variant="outline">{product.category}</Badge>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">วัสดุ</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            {product.material}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">ขนาดที่มี</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <div className="space-y-1">
-                              {product.sizes.map((size: string, index: number) => (
-                                <Badge key={index} variant="secondary" className="text-xs">
-                                  {size}
-                                </Badge>
-                              ))}
-                            </div>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">สีที่มี</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <div className="space-y-1">
-                              {product.colors.slice(0, 3).map((color: string, index: number) => (
-                                <Badge key={index} variant="outline" className="text-xs">
-                                  {color}
-                                </Badge>
-                              ))}
-                              {product.colors.length > 3 && (
-                                <div className="text-xs text-gray-500">+{product.colors.length - 3} อื่นๆ</div>
-                              )}
-                            </div>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">คุณสมบัติ</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <div className="space-y-1">
-                              {product.features.slice(0, 3).map((feature: string, index: number) => (
-                                <div key={index} className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded">
-                                  {feature}
-                                </div>
-                              ))}
-                              {product.features.length > 3 && (
-                                <div className="text-xs text-gray-500">+{product.features.length - 3} อื่นๆ</div>
-                              )}
-                            </div>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-
-                      <TableRow>
-                        <TableCell className="font-medium">สถานะสินค้า</TableCell>
-                        {products.map((product) => (
-                          <TableCell key={product.id} className="text-center">
-                            <Badge variant={product.inStock ? "default" : "destructive"}>
-                              {product.inStock ? "มีสินค้า" : "หมด"}
-                            </Badge>
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
+        <div className="mt-6 text-center">
+          <Button variant="outline" onClick={clear}>
+            ล้างรายการเปรียบเทียบ
+          </Button>
+        </div>
       </div>
-
       <Footer />
     </div>
   )

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
 import Link from "next/link"
+import { WishlistButton } from "@/components/WishlistButton"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
@@ -117,7 +118,10 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
             />
           </div>
           <div className="space-y-4">
-            <h1 className="text-3xl font-bold">{fabric.name}</h1>
+            <div className="flex items-center space-x-2">
+              <h1 className="text-3xl font-bold">{fabric.name}</h1>
+              <WishlistButton slug={fabric.slug || fabric.id} />
+            </div>
             {fabric.price_min && fabric.price_max && (
               <p className="text-lg text-gray-700">
                 ฿{fabric.price_min.toLocaleString()} - ฿{fabric.price_max.toLocaleString()}
@@ -136,9 +140,18 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
             )}
             {fabric.description && <p className="text-gray-700 whitespace-pre-line">{fabric.description}</p>}
             <div className="flex space-x-4 pt-2">
-              <Button className="flex-1" size="lg">
-                <MessageSquare className="h-5 w-5 mr-2" />สอบถามลายนี้
-              </Button>
+              <a
+                href={`https://m.me/elfsofacover?text=${encodeURIComponent(
+                  `สนใจลายผ้า ${fabric.slug || fabric.id} ครับ`,
+                )}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1"
+              >
+                <Button className="w-full" size="lg">
+                  <MessageSquare className="h-5 w-5 mr-2" />สอบถามผ่าน Facebook
+                </Button>
+              </a>
               <Button variant="outline" size="lg">
                 <Receipt className="h-5 w-5 mr-2" />เปิดบิล
               </Button>

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -1,7 +1,6 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
-import Image from "next/image"
-import Link from "next/link"
+import { FabricsList } from "@/components/FabricsList"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
@@ -51,29 +50,7 @@ export default async function FabricsPage() {
       <Navbar />
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">แกลเลอรี่ลายผ้า</h1>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
-          {fabrics.map((fabric: Fabric) => (
-            <Link
-              key={fabric.id}
-              href={`/fabrics/${fabric.slug || fabric.id}`}
-              className="border rounded-lg overflow-hidden bg-white hover:shadow transition"
-            >
-              <div className="relative aspect-square">
-                <Image
-                  src={
-                    fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"
-                  }
-                  alt={fabric.name}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-              <div className="p-2 text-center">
-                <p className="font-medium line-clamp-2">{fabric.name}</p>
-              </div>
-            </Link>
-          ))}
-        </div>
+        <FabricsList fabrics={fabrics} />
       </div>
       <Footer />
       <AnalyticsTracker event="ViewContent" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import "./globals.css"
 import { Toaster } from "@/components/ui/toaster"
 import { CartProvider } from "@/contexts/cart-context"
 import { AuthProvider } from "@/contexts/auth-context"
+import { WishlistProvider } from "@/contexts/wishlist-context"
+import { CompareProvider } from "@/contexts/compare-context"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -24,8 +26,12 @@ export default function RootLayout({
       <body className={inter.className}>
         <AuthProvider>
           <CartProvider>
-            {children}
-            <Toaster />
+            <WishlistProvider>
+              <CompareProvider>
+                {children}
+                <Toaster />
+              </CompareProvider>
+            </WishlistProvider>
           </CartProvider>
         </AuthProvider>
       </body>

--- a/app/order/public/[publicLink]/page.tsx
+++ b/app/order/public/[publicLink]/page.tsx
@@ -241,12 +241,12 @@ export default function PublicOrderPage({ params }: PublicOrderPageProps) {
             )}
             <div className="mt-4 flex justify-center">
               <Link
-                href={`https://m.me/nutsofacover?ref=${order.orderNumber}&text=${encodeURIComponent(
-                  `Hi, I'm checking on my order #${order.orderNumber}`,
+                href={`https://m.me/elfsofacover?text=${encodeURIComponent(
+                  `สอบถามสถานะออเดอร์ ${order.orderNumber}`,
                 )}`}
                 target="_blank"
               >
-                <Button>สอบถามสถานะทาง Messenger</Button>
+                <Button>สอบถามผ่าน Facebook</Button>
               </Link>
             </div>
             <div className="mt-6">

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -1,247 +1,52 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import Image from "next/image"
+import Link from "next/link"
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Heart, ShoppingCart, Trash2, Star } from "lucide-react"
-import Link from "next/link"
-import Image from "next/image"
-import { useAuth } from "@/contexts/auth-context"
-import { useCart } from "@/contexts/cart-context"
-import { useToast } from "@/hooks/use-toast"
-import { db, type Product } from "@/lib/database"
+import { useWishlist } from "@/contexts/wishlist-context"
+import { mockFabrics } from "@/lib/mock-fabrics"
+import { mockCollections } from "@/lib/mock-collections"
 
 export default function WishlistPage() {
-  const { user, isAuthenticated } = useAuth()
-  const { dispatch } = useCart()
-  const { toast } = useToast()
-  const router = useRouter()
-  const [wishlistItems, setWishlistItems] = useState<Product[]>([])
-  const [loading, setLoading] = useState(true)
+  const { wishlist } = useWishlist()
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      router.push("/login")
-      return
-    }
-    loadWishlist()
-  }, [isAuthenticated, user])
-
-  const loadWishlist = async () => {
-    if (!user) return
-
-    try {
-      const items = await db.getUserWishlist(user.id)
-      setWishlistItems(items)
-    } catch (error) {
-      console.error("Error loading wishlist:", error)
-      toast({
-        title: "เกิดข้อผิดพลาด",
-        description: "ไม่สามารถโหลดรายการโปรดได้",
-        variant: "destructive",
-      })
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const removeFromWishlist = async (productId: string) => {
-    if (!user) return
-
-    try {
-      await db.removeFromWishlist(user.id, productId)
-      setWishlistItems((items) => items.filter((item) => item.id !== productId))
-      toast({
-        title: "ลบออกจากรายการโปรด",
-        description: "สินค้าถูกลบออกจากรายการโปรดแล้ว",
-      })
-    } catch (error) {
-      toast({
-        title: "เกิดข้อผิดพลาด",
-        description: "ไม่สามารถลบสินค้าออกจากรายการโปรดได้",
-        variant: "destructive",
-      })
-    }
-  }
-
-  const addToCart = (product: any) => {
-    dispatch({
-      type: "ADD_ITEM",
-      payload: {
-        id: product.id,
-        name: product.name,
-        price: product.price,
-        image: product.images[0],
-        quantity: 1,
-      },
-    })
-
-    toast({
-      title: "เพิ่มลงตะกร้าแล้ว",
-      description: `${product.name} ถูกเพิ่มลงตะกร้าเรียบร้อยแล้ว`,
-    })
-  }
-
-  const addAllToCart = () => {
-    wishlistItems.forEach((product) => {
-      dispatch({
-        type: "ADD_ITEM",
-        payload: {
-          id: product.id,
-          name: product.name,
-          price: product.price,
-          image: product.images[0],
-          quantity: 1,
-        },
-      })
-    })
-
-    toast({
-      title: "เพิ่มทั้งหมดลงตะกร้าแล้ว",
-      description: `เพิ่มสินค้า ${wishlistItems.length} รายการลงตะกร้าแล้ว`,
-    })
-  }
-
-  if (!isAuthenticated) {
-    return null
-  }
-
-  if (loading) {
-    return (
-      <div className="min-h-screen">
-        <Navbar />
-        <div className="container mx-auto px-4 py-16 text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
-          <p className="mt-4 text-gray-600">กำลังโหลดรายการโปรด...</p>
-        </div>
-        <Footer />
-      </div>
+  const items = wishlist
+    .map((slug) =>
+      mockFabrics.find((f) => f.slug === slug) ||
+      mockCollections.find((c) => c.slug === slug),
     )
-  }
+    .filter(Boolean) as (typeof mockFabrics[number] | typeof mockCollections[number])[]
 
   return (
     <div className="min-h-screen">
       <Navbar />
-
       <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-bold flex items-center">
-              <Heart className="mr-3 h-8 w-8 text-red-500" />
-              รายการโปรด
-            </h1>
-            <p className="text-gray-600 mt-2">สินค้าที่คุณสนใจและบันทึกไว้</p>
-          </div>
-
-          {wishlistItems.length > 0 && (
-            <Button onClick={addAllToCart} size="lg">
-              <ShoppingCart className="mr-2 h-4 w-4" />
-              เพิ่มทั้งหมดลงตะกร้า
-            </Button>
-          )}
-        </div>
-
-        {wishlistItems.length === 0 ? (
-          <div className="text-center py-16">
-            <Heart className="h-24 w-24 text-gray-300 mx-auto mb-6" />
-            <h2 className="text-2xl font-bold mb-4">รายการโปรดว่างเปล่า</h2>
-            <p className="text-gray-600 mb-8">เริ่มเพิ่มสินค้าที่คุณชื่นชอบลงในรายการโปรด</p>
-            <Link href="/products">
-              <Button size="lg">เริ่มช้อปปิ้ง</Button>
-            </Link>
-          </div>
+        <h1 className="text-3xl font-bold mb-6">รายการโปรด</h1>
+        {items.length === 0 ? (
+          <p className="text-center text-gray-600">ยังไม่มีรายการที่คุณสนใจ</p>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {wishlistItems.map((product) => (
-              <Card key={product.id} className="group hover:shadow-lg transition-shadow">
-                <CardContent className="p-0">
-                  <div className="relative overflow-hidden rounded-t-lg">
-                    <Link href={`/products/${product.slug}`}> 
-                      <Image
-                        src={product.images[0] || "/placeholder.svg"}
-                        alt={product.name}
-                        width={300}
-                        height={300}
-                        className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
-                      />
-                    </Link>
-
-                    {product.originalPrice && (
-                      <Badge className="absolute top-2 left-2 bg-red-500">
-                        ลด {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}%
-                      </Badge>
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="absolute top-2 right-2 bg-white/80 hover:bg-white text-red-500 hover:text-red-600"
-                      onClick={() => removeFromWishlist(product.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+            {items.map((item) => {
+              const isFabric = (item as any).color !== undefined
+              const slug = (item as any).slug
+              const href = isFabric ? `/fabrics/${slug}` : `/collections/${slug}`
+              const name = (item as any).name
+              const image = (item as any).images[0] || "/placeholder.svg"
+              return (
+                <Link key={slug} href={href} className="border rounded-lg overflow-hidden bg-white hover:shadow transition">
+                  <div className="relative aspect-square">
+                    <Image src={image} alt={name} fill className="object-cover" />
                   </div>
-
-                  <div className="p-4 space-y-3">
-                    <Link href={`/products/${product.slug}`}> 
-                      <h3 className="font-semibold text-lg line-clamp-2 hover:text-primary transition-colors">
-                        {product.name}
-                      </h3>
-                    </Link>
-
-                    <div className="flex items-center space-x-1">
-                      <div className="flex">
-                        {[...Array(5)].map((_, i) => (
-                          <Star
-                            key={i}
-                            className={`h-4 w-4 ${
-                              i < Math.floor(product.rating) ? "text-yellow-400 fill-current" : "text-gray-300"
-                            }`}
-                          />
-                        ))}
-                      </div>
-                      <span className="text-sm text-gray-600">({product.reviewCount})</span>
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      <span className="text-xl font-bold text-primary">฿{product.price.toLocaleString()}</span>
-                      {product.originalPrice && (
-                        <span className="text-sm text-gray-500 line-through">
-                          ฿{product.originalPrice.toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <Badge variant="outline">{product.category}</Badge>
-                      <Badge variant={product.inStock ? "default" : "destructive"}>
-                        {product.inStock ? "มีสินค้า" : "หมด"}
-                      </Badge>
-                    </div>
-
-                    <div className="flex space-x-2">
-                      <Link href={`/products/${product.slug}`} className="flex-1"> 
-                        <Button variant="outline" className="w-full bg-transparent">
-                          ดูรายละเอียด
-                        </Button>
-                      </Link>
-                      <Button onClick={() => addToCart(product)} disabled={!product.inStock} className="flex-1">
-                        <ShoppingCart className="mr-2 h-4 w-4" />
-                        เพิ่มลงตะกร้า
-                      </Button>
-                    </div>
+                  <div className="p-2 text-center">
+                    <p className="font-medium line-clamp-2">{name}</p>
                   </div>
-                </CardContent>
-              </Card>
-            ))}
+                </Link>
+              )
+            })}
           </div>
         )}
       </div>
-
       <Footer />
     </div>
   )

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Button } from "@/components/ui/button"
+import { useCompare } from "@/contexts/compare-context"
+
+interface Fabric {
+  id: string
+  slug: string | null
+  name: string
+  image_url?: string | null
+  image_urls?: string[] | null
+}
+
+export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
+  const { items, toggleCompare } = useCompare()
+  const router = useRouter()
+
+  const handleCompare = () => {
+    router.push(`/compare`)
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        {fabrics.map((fabric) => {
+          const slug = fabric.slug || fabric.id
+          const checked = items.includes(slug)
+          return (
+            <div
+              key={slug}
+              className="border rounded-lg overflow-hidden bg-white hover:shadow transition relative"
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={() => toggleCompare(slug)}
+                className="absolute top-2 left-2 z-10 bg-white/80"
+              />
+              <Link href={`/fabrics/${slug}`}>
+                <div className="relative aspect-square">
+                  <Image
+                    src={
+                      fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"
+                    }
+                    alt={fabric.name}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="p-2 text-center">
+                  <p className="font-medium line-clamp-2">{fabric.name}</p>
+                </div>
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+      {items.length > 1 && (
+        <div className="mt-4 text-center">
+          <Button onClick={handleCompare}>เปรียบเทียบตอนนี้</Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/WishlistButton.tsx
+++ b/components/WishlistButton.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { Heart } from "lucide-react"
+import { useWishlist } from "@/contexts/wishlist-context"
+
+export function WishlistButton({ slug }: { slug: string }) {
+  const { wishlist, toggleWishlist } = useWishlist()
+  const active = wishlist.includes(slug)
+
+  return (
+    <button onClick={() => toggleWishlist(slug)} aria-label="toggle wishlist">
+      <Heart
+        className={`h-6 w-6 ${active ? "text-red-500" : "text-gray-500"}`}
+        fill={active ? "currentColor" : "none"}
+      />
+    </button>
+  )
+}

--- a/contexts/compare-context.tsx
+++ b/contexts/compare-context.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+
+interface CompareContextValue {
+  items: string[]
+  toggleCompare: (slug: string) => void
+  clear: () => void
+}
+
+const CompareContext = createContext<CompareContextValue | null>(null)
+
+export function CompareProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useLocalStorage<string[]>("compare", [])
+
+  const toggleCompare = (slug: string) => {
+    setItems((prev) => {
+      if (prev.includes(slug)) return prev.filter((s) => s !== slug)
+      if (prev.length >= 3) return prev
+      return [...prev, slug]
+    })
+  }
+
+  const clear = () => setItems([])
+
+  return (
+    <CompareContext.Provider value={{ items, toggleCompare, clear }}>
+      {children}
+    </CompareContext.Provider>
+  )
+}
+
+export function useCompare() {
+  const ctx = useContext(CompareContext)
+  if (!ctx) throw new Error("useCompare must be used within CompareProvider")
+  return ctx
+}

--- a/contexts/wishlist-context.tsx
+++ b/contexts/wishlist-context.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+
+interface WishlistContextValue {
+  wishlist: string[]
+  toggleWishlist: (slug: string) => void
+}
+
+const WishlistContext = createContext<WishlistContextValue | null>(null)
+
+export function WishlistProvider({ children }: { children: ReactNode }) {
+  const [wishlist, setWishlist] = useLocalStorage<string[]>("wishlist", [])
+
+  const toggleWishlist = (slug: string) => {
+    setWishlist((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    )
+  }
+
+  return (
+    <WishlistContext.Provider value={{ wishlist, toggleWishlist }}>
+      {children}
+    </WishlistContext.Provider>
+  )
+}
+
+export function useWishlist() {
+  const ctx = useContext(WishlistContext)
+  if (!ctx) throw new Error("useWishlist must be used within WishlistProvider")
+  return ctx
+}

--- a/hooks/use-local-storage.ts
+++ b/hooks/use-local-storage.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { useState, useEffect } from "react"
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (v: T | ((prev: T) => T)) => void] {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? (JSON.parse(item) as T) : initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    } catch {}
+  }, [key, value])
+
+  return [value, setValue]
+}


### PR DESCRIPTION
## Summary
- add localStorage-based wishlist and compare contexts
- update layout to include new providers
- implement WishlistButton and FabricsList components
- integrate wishlist toggle on fabric and collection pages
- allow comparing fabrics and show results on /compare
- new wishlist page showing saved fabrics or collections
- add Messenger contact buttons across detail and order pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872928d8614832595e411e58a413b24