### PR TITLE
Add configurable Chatwoot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Real data is fetched from Supabase when the following variables are provided:
 
 - `NEXT_PUBLIC_SUPABASE_URL` – your Supabase project URL
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` – the project's anon key
+- `NEXT_PUBLIC_CHATWOOT_URL` – URL of your Chatwoot instance (defaults to `http://localhost:3000`)
 
 If these variables are absent, the app falls back to built-in mock data.
 

--- a/app/admin/chat/page.tsx
+++ b/app/admin/chat/page.tsx
@@ -3,9 +3,11 @@
 import { useEffect } from "react";
 
 export default function AdminChatPage() {
+  const chatwootUrl =
+    process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
   useEffect(() => {
-    window.open("http://localhost:3000", "_blank");
-  }, []);
+    window.open(chatwootUrl, "_blank");
+  }, [chatwootUrl]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function AdminIndex() {
+  const chatwootUrl =
+    process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
   return (
     <div className="flex flex-col gap-4 p-4">
       <Button
         variant="default"
-        onClick={() => window.open("http://localhost:3000", "_blank")}
+        onClick={() => window.open(chatwootUrl, "_blank")}
       >
         แชทลูกค้า (Chatwoot)
       </Button>

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -5,9 +5,12 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 
 export default function ChatPage() {
+  const chatwootUrl =
+    process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
+
   useEffect(() => {
-    window.open("http://localhost:3000", "_blank");
-  }, []);
+    window.open(chatwootUrl, "_blank");
+  }, [chatwootUrl]);
 
   return (
     <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_CHATWOOT_URL` variable
- use env var in Chat page and Admin pages
- document variable in README

## Testing
- `pnpm eslint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6872ac1aa92083258ef0f8cb003b6e7f