### PR TITLE
Configure Chatwoot port via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Real data is fetched from Supabase when the following variables are provided:
 - `NEXT_PUBLIC_SUPABASE_URL` – your Supabase project URL
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` – the project's anon key
 - `NEXT_PUBLIC_CHATWOOT_URL` – URL of your Chatwoot instance (defaults to `http://localhost:3000`)
+- `CHATWOOT_PORT` – port to expose the Chatwoot Rails server (defaults to `3000`)
 
 If these variables are absent, the app falls back to built-in mock data.
 
@@ -48,11 +49,12 @@ To run Chatwoot locally:
 ```bash
 cd chatwoot
 cp .env.example .env
+# Optionally change CHATWOOT_PORT in `.env` if 3000 is in use
 docker-compose build
 docker-compose up -d
 ```
 
-Chatwoot will be available at `http://localhost:3000`. The admin dashboard
+Chatwoot will be available at `http://localhost:${CHATWOOT_PORT}` (3000 by default). The admin dashboard
 includes a button to open Chatwoot in a new browser tab.
 
 ## Testing

--- a/chatwoot/.env.example
+++ b/chatwoot/.env.example
@@ -8,6 +8,10 @@ SECRET_KEY_BASE=replace_with_lengthy_secure_hex
 
 # Replace with the URL you are planning to use for your app
 FRONTEND_URL=http://0.0.0.0:3000
+# Default port for the Rails server. Change if port 3000 is busy
+CHATWOOT_PORT=3000
+# Port used for ActionCable (WebSocket) connections
+WEBSOCKET_PORT=3000
 # To use a dedicated URL for help center pages
 # HELPCENTER_URL=http://0.0.0.0:3000
 

--- a/chatwoot/docker-compose.yaml
+++ b/chatwoot/docker-compose.yaml
@@ -34,14 +34,14 @@ services:
       - mailhog
       - sidekiq
     ports:
-      - 3000:3000
+      - "${CHATWOOT_PORT:-3000}:3000"
     env_file: .env
     environment:
       - VITE_DEV_SERVER_HOST=vite
       - NODE_ENV=development
       - RAILS_ENV=development
     entrypoint: docker/entrypoints/rails.sh
-    command: ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
+    command: ["bundle", "exec", "rails", "s", "-p", "${CHATWOOT_PORT:-3000}", "-b", "0.0.0.0"]
 
   sidekiq:
     <<: *base

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+  // Run ESLint and TypeScript checks during `next build`
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- allow Chatwoot docker-compose port override via `CHATWOOT_PORT`
- document Chatwoot port usage in README
- note the port variables in `.env.example`
- run ESLint/TypeScript checks again during build

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6872a83802808325b43b873fef33ee15