### PR TITLE
Add chat shortcut and admin product preview

### DIFF
--- a/app/admin/products/create/page.tsx
+++ b/app/admin/products/create/page.tsx
@@ -23,6 +23,10 @@ export default function CreateProductPage() {
   const [category, setCategory] = useState("")
   const [collectionId, setCollectionId] = useState("")
   const [images, setImages] = useState("")
+  const [features, setFeatures] = useState("")
+  const [sizes, setSizes] = useState("")
+  const [colors, setColors] = useState("")
+  const [showPreview, setShowPreview] = useState(false)
   const { addProduct } = useAdminProducts()
   const { collections } = useAdminCollections()
 
@@ -60,9 +64,9 @@ export default function CreateProductPage() {
       inStock: true,
       rating: 0,
       reviews: 0,
-      sizes: [],
-      colors: [],
-      features: [],
+      sizes: sizes.split(',').map((s) => s.trim()).filter(Boolean),
+      colors: colors.split(',').map((s) => s.trim()).filter(Boolean),
+      features: features.split(',').map((s) => s.trim()).filter(Boolean),
       material: "",
       care: [],
     })
@@ -123,12 +127,44 @@ export default function CreateProductPage() {
                 <Label htmlFor="images">รูปภาพ (คั่นด้วย comma)</Label>
                 <Input id="images" value={images} onChange={(e) => setImages(e.target.value)} />
               </div>
+              <div className="space-y-2">
+                <Label htmlFor="features">คุณสมบัติผ้า (คั่นด้วย comma)</Label>
+                <Input id="features" value={features} onChange={(e) => setFeatures(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sizes">ขนาดที่มี (คั่นด้วย comma)</Label>
+                <Input id="sizes" value={sizes} onChange={(e) => setSizes(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="colors">สีที่มี (คั่นด้วย comma)</Label>
+                <Input id="colors" value={colors} onChange={(e) => setColors(e.target.value)} />
+              </div>
               <div className="pt-4 flex justify-end">
+                <Button type="button" variant="outline" onClick={() => setShowPreview(!showPreview)} className="mr-2">
+                  Preview
+                </Button>
                 <Button type="submit">บันทึก</Button>
               </div>
             </form>
           </CardContent>
         </Card>
+        {showPreview && (
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>ตัวอย่างสินค้า</CardTitle>
+            </CardHeader>
+            <CardContent className="flex space-x-4">
+              <div className="relative w-32 h-32 flex-shrink-0">
+                <img src={images.split(',')[0] || '/placeholder.svg'} alt={name} className="w-full h-full object-cover rounded-lg" />
+              </div>
+              <div className="space-y-1">
+                <p className="font-semibold">{name || 'ชื่อสินค้า'}</p>
+                <p className="text-sm text-gray-600">฿{price || 0}</p>
+                <p className="text-sm text-gray-600">{features}</p>
+              </div>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   )

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Star, Heart, Share2, ShoppingCart, Truck, Shield, RotateCcw, Minus, Plus } from "lucide-react"
+import { Star, Heart, Share2, ShoppingCart, Truck, Shield, RotateCcw, Minus, Plus, MessageCircle } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { mockProducts } from "@/lib/mock-products"
@@ -223,6 +223,12 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
               <Link href={`/order/new?product=${product.slug}`} className="flex-1">
                 <Button className="w-full" size="lg">สั่งซื้อ</Button>
               </Link>
+              <Link href="/chat" className="flex-1">
+                <Button variant="outline" className="w-full" size="lg">
+                  <MessageCircle className="mr-2 h-5 w-5" />
+                  แชทสอบถาม
+                </Button>
+              </Link>
               <Button
                 variant="outline"
                 size="lg"
@@ -299,7 +305,7 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
             <TabsContent value="features" className="mt-6">
               <Card>
                 <CardContent className="p-6">
-                  <h3 className="font-semibold text-lg mb-4">คุณสมบัติพิเศษ</h3>
+                  <h3 className="font-semibold text-lg mb-4">คุณสมบัติผ้า</h3>
                   <div className="grid grid-cols-2 gap-4">
                     {product.features.map((feature, index) => (
                       <div key={index} className="flex items-center space-x-2">
@@ -391,7 +397,7 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
           <h2 className="text-2xl font-bold mb-8">สินค้าที่เกี่ยวข้อง</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {mockProducts
-              .filter((p) => p.id !== product.id && p.category === product.category)
+              .filter((p) => p.id !== product.id && p.collectionId === product.collectionId)
               .slice(0, 4)
               .map((relatedProduct) => (
                 <Card key={relatedProduct.id} className="group hover:shadow-lg transition-shadow">


### PR DESCRIPTION
## Summary
- add chat button on product page
- rename features heading to fabric properties
- filter related products by collection
- expand admin product form with fabric features and preview

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e72275b48325af06edb41841b7dd