### PR TITLE
Add mock customer profile features

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import { useState } from "react"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -24,6 +25,8 @@ import {
   mockCustomers,
   getCustomerOrders,
   getCustomerStats,
+  updateCustomerPoints,
+  setCustomerTier,
 } from "@/lib/mock-customers"
 
 export default function CustomerDetailPage({
@@ -44,6 +47,8 @@ export default function CustomerDetailPage({
 
   const orders = getCustomerOrders(customer.id)
   const stats = getCustomerStats(customer.id)
+  const [pointDelta, setPointDelta] = useState(0)
+  const [tierValue, setTierValue] = useState<string>(customer.tier || "Silver")
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -61,6 +66,62 @@ export default function CustomerDetailPage({
         <div className="text-lg font-semibold">
           ยอดซื้อรวม: ฿{stats.totalSpent.toLocaleString()}
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>แต้มสะสม</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p>คะแนนปัจจุบัน: {customer.points ?? 0}</p>
+            <div className="flex space-x-2 items-center">
+              <input
+                type="number"
+                className="border px-2 py-1 rounded w-24"
+                value={pointDelta}
+                onChange={(e) => setPointDelta(Number(e.target.value))}
+              />
+              <Button
+                variant="outline"
+                onClick={() => {
+                  updateCustomerPoints(customer.id, pointDelta)
+                  setPointDelta(0)
+                }}
+              >
+                ปรับแต้ม
+              </Button>
+            </div>
+            {customer.pointHistory && customer.pointHistory.length > 0 && (
+              <div className="text-sm space-y-1">
+                {customer.pointHistory.map((h, i) => (
+                  <p key={i}>
+                    {new Date(h.timestamp).toLocaleDateString("th-TH")} :{' '}
+                    {h.change > 0 ? `+${h.change}` : h.change}
+                  </p>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Tier</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <select
+              className="border px-2 py-1 rounded"
+              value={tierValue}
+              onChange={(e) => {
+                setTierValue(e.target.value)
+                setCustomerTier(customer.id, e.target.value as any)
+              }}
+            >
+              <option value="Silver">Silver</option>
+              <option value="Gold">Gold</option>
+              <option value="VIP">VIP</option>
+            </select>
+          </CardContent>
+        </Card>
 
         <Tabs defaultValue="orders" className="space-y-4">
           <TabsList>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -12,6 +12,7 @@ import { Search, ArrowLeft, Eye, FileText, Edit, Copy, ExternalLink } from "luci
 import Link from "next/link"
 import { toast } from "sonner"
 import { mockOrders } from "@/lib/mock-orders"
+import { mockCustomers } from "@/lib/mock-customers"
 import type { Order } from "@/types/order"
 import type { OrderStatus } from "@/types/order"
 import {
@@ -31,6 +32,7 @@ export default function AdminOrdersPage() {
   const [orders, setOrders] = useState<Order[]>(mockOrders)
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState<string>("all")
+  const [customerFilter, setCustomerFilter] = useState<string>("all")
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
 
   const filteredOrders = orders.filter((order) => {
@@ -40,8 +42,10 @@ export default function AdminOrdersPage() {
       order.customerEmail.toLowerCase().includes(searchTerm.toLowerCase())
 
     const matchesStatus = statusFilter === "all" || order.status === statusFilter
+    const matchesCustomer =
+      customerFilter === "all" || order.customerId === customerFilter
 
-    return matchesSearch && matchesStatus
+    return matchesSearch && matchesStatus && matchesCustomer
   })
 
   const updateOrderStatus = (orderId: string, newStatus: OrderStatus) => {
@@ -89,6 +93,19 @@ export default function AdminOrdersPage() {
                     {statusOptions.map((opt) => (
                       <SelectItem key={opt.value} value={opt.value}>
                         {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value={customerFilter} onValueChange={setCustomerFilter}>
+                  <SelectTrigger className="w-40">
+                    <SelectValue placeholder="ลูกค้า" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">ทั้งหมด</SelectItem>
+                    {mockCustomers.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -181,8 +198,25 @@ export default function AdminOrdersPage() {
                                     <p>
                                       <strong>อีเมล:</strong> {selectedOrder.customerEmail}
                                     </p>
-                                    <p>
-                                      <strong>เบอร์โทร:</strong> {selectedOrder.shippingAddress.phone}
+                                    <p className="flex items-center space-x-2">
+                                      <strong>เบอร์โทร:</strong>
+                                      <a
+                                        href={`tel:${selectedOrder.shippingAddress.phone}`}
+                                        className="underline"
+                                      >
+                                        {selectedOrder.shippingAddress.phone}
+                                      </a>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() =>
+                                          navigator.clipboard.writeText(
+                                            selectedOrder.shippingAddress.phone,
+                                          )
+                                        }
+                                      >
+                                        <Copy className="h-4 w-4" />
+                                      </Button>
                                     </p>
                                   </div>
                                 </div>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../customers/page'

--- a/app/profile/orders/page.tsx
+++ b/app/profile/orders/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../orders/page'

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -14,6 +14,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { User, MapPin, Shield, Bell } from "lucide-react"
+import Link from "next/link"
+import { mockCustomers } from "@/lib/mock-customers"
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/hooks/use-toast"
 
@@ -21,6 +23,8 @@ export default function ProfilePage() {
   const { user, isAuthenticated } = useAuth()
   const router = useRouter()
   const { toast } = useToast()
+
+  const customer = mockCustomers.find((c) => c.id === user?.id)
 
   const [profileData, setProfileData] = useState({
     firstName: "John",
@@ -71,6 +75,22 @@ export default function ProfilePage() {
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl font-bold mb-8">โปรไฟล์ของฉัน</h1>
+
+          {customer && (
+            <Card className="mb-6">
+              <CardHeader>
+                <CardTitle>{customer.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-sm text-gray-600">{customer.email}</p>
+                <p>แต้มสะสม: {customer.points ?? 0}</p>
+                <p>Tier: {customer.tier || "-"}</p>
+                <Link href="/profile/orders">
+                  <Button className="mt-2">ดูคำสั่งซื้อ</Button>
+                </Link>
+              </CardContent>
+            </Card>
+          )}
 
           <Tabs defaultValue="profile" className="space-y-6">
             <TabsList className="grid w-full grid-cols-4">

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -9,7 +9,19 @@ export interface Customer {
   avatar?: string
   tags?: string[]
   note?: string
+  /** mock reward points */
+  points?: number
+  /** membership tier */
+  tier?: "Silver" | "Gold" | "VIP"
+  /** point change history */
+  pointHistory?: PointLog[]
   createdAt: string
+}
+
+export interface PointLog {
+  timestamp: string
+  change: number
+  reason?: string
 }
 
 import { mockOrders } from "./mock-orders"
@@ -26,6 +38,11 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     tags: ["ลูกค้าประจำ"],
     note: "ชอบผ้ากำมะหยี่",
+    points: 120,
+    tier: "Gold",
+    pointHistory: [
+      { timestamp: new Date().toISOString(), change: 120, reason: "สมัครสมาชิก" },
+    ],
     createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -39,6 +56,8 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     tags: ["COD"],
     note: "เก็บเงินปลายทาง",
+    points: 60,
+    tier: "Silver",
     createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -46,6 +65,8 @@ const initialMockCustomers: Customer[] = [
     name: "Mike Johnson",
     email: "mike@example.com",
     avatar: "/placeholder.svg?height=40&width=40",
+    points: 200,
+    tier: "VIP",
     createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -53,6 +74,8 @@ const initialMockCustomers: Customer[] = [
     name: "Sarah Wilson",
     email: "sarah@example.com",
     avatar: "/placeholder.svg?height=40&width=40",
+    points: 10,
+    tier: "Silver",
     createdAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -60,6 +83,8 @@ const initialMockCustomers: Customer[] = [
     name: "David Brown",
     email: "david@example.com",
     avatar: "/placeholder.svg?height=40&width=40",
+    points: 40,
+    tier: "Gold",
     createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -67,6 +92,8 @@ const initialMockCustomers: Customer[] = [
     name: "Lisa Anderson",
     email: "lisa@example.com",
     avatar: "/placeholder.svg?height=40&width=40",
+    points: 80,
+    tier: "Gold",
     createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ]
@@ -110,4 +137,26 @@ export async function fetchCustomers(): Promise<Customer[]> {
 
 export async function fetchCustomerById(id: string): Promise<Customer | undefined> {
   return Promise.resolve(mockCustomers.find((c) => c.id === id))
+}
+
+export function updateCustomerPoints(
+  id: string,
+  change: number,
+  reason?: string,
+) {
+  const customer = mockCustomers.find((c) => c.id === id)
+  if (!customer) return
+  customer.points = (customer.points || 0) + change
+  if (!customer.pointHistory) customer.pointHistory = []
+  customer.pointHistory.push({
+    timestamp: new Date().toISOString(),
+    change,
+    reason,
+  })
+}
+
+export function setCustomerTier(id: string, tier: "Silver" | "Gold" | "VIP") {
+  const customer = mockCustomers.find((c) => c.id === id)
+  if (!customer) return
+  customer.tier = tier
 }


### PR DESCRIPTION
## Summary
- show user info, points and tier on `/profile`
- expose mock order history at `/profile/orders`
- allow admin to edit customer points and tier with logs
- filter orders by customer and show phone copy link in admin
- re-export customers page as `/admin/users`
- extend mock customer data with points, tier and history

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68733354d1a483259413379b103a58af