### PR TITLE
Fix 404 build by moving search params logic to client

### DIFF
--- a/app/404.tsx
+++ b/app/404.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { Suspense } from 'react'
+import NotFoundClient from './NotFoundClient'
+
+export default function NotFoundPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <NotFoundClient />
+    </Suspense>
+  )
+}

--- a/app/NotFoundClient.tsx
+++ b/app/NotFoundClient.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export default function NotFoundClient() {
+  const searchParams = useSearchParams()
+  const code = searchParams.get('code') ?? '404'
+  return <div>ไม่พบหน้านี้ (code: {code})</div>
+}


### PR DESCRIPTION
## Summary
- add a new 404 page that wraps a client component with `Suspense`
- implement `NotFoundClient` to read `code` from `useSearchParams`

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_687343afcce88325a2fcdb0a197cd196