### PR TITLE
Implement mock bill pages

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -7,6 +7,9 @@ import { useAuth } from "@/contexts/auth-context"
 import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
 import {
   loadAutoMessage,
   autoMessage,
@@ -14,6 +17,9 @@ import {
   loadSocialLinks,
   socialLinks,
   setSocialLinks,
+  loadBillSecurity,
+  billSecurity,
+  setBillSecurity,
 } from "@/lib/mock-settings"
 
 export default function SettingsPage() {
@@ -21,12 +27,15 @@ export default function SettingsPage() {
   const router = useRouter()
   const [message, setMessage] = useState(autoMessage)
   const [links, setLinks] = useState(socialLinks)
+  const [security, setSecurity] = useState(billSecurity)
 
   useEffect(() => {
     loadAutoMessage()
     loadSocialLinks()
+    loadBillSecurity()
     setMessage(autoMessage)
     setLinks(socialLinks)
+    setSecurity(billSecurity)
     if (!isAuthenticated) {
       router.push("/login")
     } else if (user?.role !== "admin") {
@@ -39,6 +48,7 @@ export default function SettingsPage() {
   const handleSave = () => {
     setAutoMessage(message)
     setSocialLinks(links)
+    setBillSecurity(security)
     alert("บันทึกข้อความแล้ว")
   }
 
@@ -76,6 +86,31 @@ export default function SettingsPage() {
               value={links.line}
               onChange={(e) => setLinks({ ...links, line: e.target.value })}
               placeholder="Line URL"
+            />
+          </CardContent>
+        </Card>
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>ความปลอดภัยหน้าบิล</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="sec-enabled"
+                checked={security.enabled}
+                onCheckedChange={(v) => setSecurity({ ...security, enabled: Boolean(v) })}
+              />
+              <Label htmlFor="sec-enabled">ต้องยืนยันก่อนเข้าบิล</Label>
+            </div>
+            <Input
+              placeholder="เบอร์โทร"
+              value={security.phone}
+              onChange={(e) => setSecurity({ ...security, phone: e.target.value })}
+            />
+            <Input
+              placeholder="PIN"
+              value={security.pin}
+              onChange={(e) => setSecurity({ ...security, pin: e.target.value })}
             />
           </CardContent>
         </Card>

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -1,0 +1,24 @@
+import type { Bill, BillPayment } from "@/types/bill"
+
+export let mockBills: Bill[] = []
+
+export function createBill(orderId: string): Bill {
+  const id = `bill-${Math.random().toString(36).slice(2, 8)}`
+  const bill: Bill = { id, orderId, status: "unpaid", payments: [] }
+  mockBills.push(bill)
+  return bill
+}
+
+export function getBill(id: string): Bill | null {
+  return mockBills.find((b) => b.id === id) || null
+}
+
+export function confirmBill(id: string) {
+  const b = getBill(id)
+  if (b) b.status = "paid"
+}
+
+export function addBillPayment(id: string, payment: BillPayment) {
+  const b = getBill(id)
+  if (b) b.payments.push(payment)
+}

--- a/lib/mock-settings.ts
+++ b/lib/mock-settings.ts
@@ -28,3 +28,19 @@ export function setSocialLinks(links: { facebook: string; line: string }) {
     localStorage.setItem('socialLinks', JSON.stringify(links));
   }
 }
+
+export let billSecurity = { enabled: false, phone: "", pin: "" }
+
+export function loadBillSecurity() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('billSecurity')
+    if (stored) billSecurity = JSON.parse(stored)
+  }
+}
+
+export function setBillSecurity(sec: { enabled: boolean; phone: string; pin: string }) {
+  billSecurity = sec
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('billSecurity', JSON.stringify(sec))
+  }
+}

--- a/types/bill.ts
+++ b/types/bill.ts
@@ -1,0 +1,18 @@
+export type BillStatus = "unpaid" | "paid"
+
+export interface BillPayment {
+  id: string
+  date: string
+  amount: number
+  slip?: string
+  approved?: boolean
+}
+
+export interface Bill {
+  id: string
+  orderId: string
+  phone?: string
+  pin?: string
+  status: BillStatus
+  payments: BillPayment[]
+}


### PR DESCRIPTION
## Summary
- add bill type and mock bill database
- allow admin to create and confirm bills from order page
- extend admin settings with bill security options
- protect bill page with optional PIN/phone check and upload slip form
- update bill page to show QR and timeline

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68734abc6a38832585ebc3a3b0311c27