### PR TITLE
Implement mock chat invoice system

### DIFF
--- a/app/admin/chat-insight/page.tsx
+++ b/app/admin/chat-insight/page.tsx
@@ -1,0 +1,54 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { listChatBills, loadChatBills } from '@/lib/mock-chat-bills'
+import { format } from 'date-fns'
+
+export default function ChatInsightPage() {
+  const [bills, setBills] = useState(listChatBills())
+  useEffect(() => {
+    loadChatBills()
+    setBills(listChatBills())
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <h1 className="text-3xl font-bold mb-4">บิลที่สร้างจากแชท</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>วันที่</TableHead>
+            <TableHead>ลูกค้า</TableHead>
+            <TableHead>สินค้า</TableHead>
+            <TableHead>สถานะ</TableHead>
+            <TableHead className="w-24"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {bills.map((b) => (
+            <TableRow key={b.billId}>
+              <TableCell>{format(new Date(b.createdAt), 'yyyy-MM-dd')}</TableCell>
+              <TableCell>{b.fbName}</TableCell>
+              <TableCell>{b.items.map((i) => i.name).join(', ')}</TableCell>
+              <TableCell>{b.status}</TableCell>
+              <TableCell>
+                <Link href={`/chat-bill/${b.billId}`}>
+                  <Button variant="outline" size="sm">เปิดลิงก์</Button>
+                </Link>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/admin/chat/page.tsx
+++ b/app/admin/chat/page.tsx
@@ -1,17 +1,45 @@
 "use client"
 
-import { useEffect } from "react";
+import { useEffect, useState } from 'react'
+import CreateChatBillDialog from '@/components/admin/chat/CreateChatBillDialog'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 
 export default function AdminChatPage() {
-  const chatwootUrl =
-    process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
+  const chatwootUrl = process.env.NEXT_PUBLIC_CHATWOOT_URL || 'http://localhost:3000'
+  const [newBillId, setNewBillId] = useState<string | null>(null)
   useEffect(() => {
-    window.open(chatwootUrl, "_blank");
-  }, [chatwootUrl]);
+    window.open(chatwootUrl, '_blank')
+  }, [chatwootUrl])
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <p>กำลังเปิดหน้าต่างแชท...</p>
+      <CreateChatBillDialog onCreated={setNewBillId} />
+      {newBillId && (
+        <div className="space-y-2 text-center">
+          <p>บิลสร้างแล้ว:</p>
+          <Link href={`/chat-bill/${newBillId}`} className="text-blue-600 underline">
+            {`${origin}/chat-bill/${newBillId}`}
+          </Link>
+          <div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                navigator.clipboard.writeText(`${origin}/chat-bill/${newBillId}`)
+                alert('คัดลอกลิงก์แล้ว')
+              }}
+            >
+              คัดลอกลิงก์เพื่อส่งในแชท
+            </Button>
+          </div>
+          <p className="text-sm border rounded-md p-2 bg-gray-50">
+            {`สวัสดีค่ะ นี่คือบิลของคุณ ${origin}/chat-bill/${newBillId}`}
+          </p>
+        </div>
+      )}
     </div>
-  );
+  )
 }

--- a/app/chat-bill/[id]/page.tsx
+++ b/app/chat-bill/[id]/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { getChatBill, loadChatBills } from '@/lib/mock-chat-bills'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { useParams } from 'next/navigation'
+
+export default function ChatBillPage() {
+  const params = useParams<{ id: string }>()
+  const id = params.id
+  const [bill, setBill] = useState(() => getChatBill(id))
+  useEffect(() => {
+    loadChatBills()
+    setBill(getChatBill(id))
+  }, [id])
+
+  if (!bill) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>ไม่พบบิลนี้</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-6">
+        <h1 className="text-2xl font-bold text-center">
+          บิลสำหรับคุณ {bill.fbName} จากแชทเพจ
+        </h1>
+        <div className="border rounded-lg p-4 space-y-2 max-w-xl mx-auto">
+          {bill.items.map((it) => (
+            <div key={it.productId} className="flex justify-between">
+              <span>{it.name}</span>
+              <span>฿{it.price.toLocaleString()}</span>
+            </div>
+          ))}
+          <div className="flex justify-between border-t pt-2 font-semibold">
+            <span>ส่วนลด</span>
+            <span>-฿{bill.discount.toLocaleString()}</span>
+          </div>
+          <div className="flex justify-between font-bold">
+            <span>ยอดรวม</span>
+            <span>฿{bill.total.toLocaleString()}</span>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle } from "lucide-react"
+import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle, FileText } from "lucide-react"
 import clsx from "clsx"
 
 const navItems = [
@@ -14,6 +14,7 @@ const navItems = [
   { href: "/admin/coupons", label: "คูปอง", icon: Percent },
   { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
+  { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
 ]
 
 export default function Sidebar({ className = "" }: { className?: string }) {

--- a/components/admin/chat/CreateChatBillDialog.tsx
+++ b/components/admin/chat/CreateChatBillDialog.tsx
@@ -1,0 +1,111 @@
+"use client"
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { getProducts } from '@/lib/mock-products'
+import { createChatBill } from '@/lib/mock-chat-bills'
+
+export default function CreateChatBillDialog({
+  onCreated,
+}: {
+  onCreated: (id: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [products, setProducts] = useState<Array<{id:string,name:string,price:number}>>([])
+  const [selected, setSelected] = useState<Record<string, boolean>>({})
+  const [discount, setDiscount] = useState(0)
+  const [fbName, setFbName] = useState('')
+  const [fbLink, setFbLink] = useState('')
+  const [sessionId, setSessionId] = useState('')
+  const total = products.reduce((sum, p) => sum + (selected[p.id] ? p.price : 0), 0)
+
+  useEffect(() => {
+    getProducts().then((prods) =>
+      setProducts(prods.map((p) => ({ id: p.id, name: p.name, price: p.price })))
+    )
+  }, [])
+
+  const handleCreate = () => {
+    const items = products
+      .filter((p) => selected[p.id])
+      .map((p) => ({ productId: p.id, name: p.name, price: p.price, quantity: 1 }))
+    if (items.length === 0) {
+      alert('เลือกสินค้าอย่างน้อย 1 รายการ')
+      return
+    }
+    const bill = createChatBill({
+      fbName,
+      fbLink,
+      sessionId,
+      items,
+      discount,
+      total: items.reduce((s, i) => s + i.price, 0) - discount,
+    })
+    setOpen(false)
+    onCreated(bill.billId)
+    // reset
+    setSelected({})
+    setDiscount(0)
+    setFbName('')
+    setFbLink('')
+    setSessionId('')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">สร้างบิลใหม่</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>สร้างบิลจากแชท</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[70vh] overflow-y-auto">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <Label htmlFor="fbName">ชื่อในเฟสบุ๊ค</Label>
+              <Input id="fbName" value={fbName} onChange={(e)=>setFbName(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="fbLink">ลิงก์โปรไฟล์</Label>
+              <Input id="fbLink" value={fbLink} onChange={(e)=>setFbLink(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="session">Session ID</Label>
+              <Input id="session" value={sessionId} onChange={(e)=>setSessionId(e.target.value)} />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <p className="font-medium">เลือกสินค้า</p>
+            {products.map((p) => (
+              <label key={p.id} className="flex items-center space-x-2">
+                <Checkbox checked={!!selected[p.id]} onCheckedChange={(v)=>setSelected({ ...selected, [p.id]: Boolean(v) })} />
+                <span>{p.name} (฿{p.price.toLocaleString()})</span>
+              </label>
+            ))}
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="discount">ส่วนลด (บาท)</Label>
+              <Input id="discount" type="number" value={discount} onChange={(e)=>setDiscount(Number(e.target.value)||0)} />
+            </div>
+            <div className="flex items-end">ยอดรวม: ฿{(total - discount).toLocaleString()}</div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleCreate}>สร้างบิล</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/mock-chat-bills.ts
+++ b/lib/mock-chat-bills.ts
@@ -1,0 +1,46 @@
+import type { ChatBill } from '@/types/chat-bill'
+
+export let chatBills: ChatBill[] = []
+
+export function loadChatBills() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatBills')
+    if (stored) chatBills = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatBills', JSON.stringify(chatBills))
+  }
+}
+
+export function createChatBill(data: Omit<ChatBill, 'billId' | 'createdAt' | 'status'>) {
+  const bill: ChatBill = {
+    billId: `cb-${Math.random().toString(36).slice(2, 8)}`,
+    createdAt: new Date().toISOString(),
+    status: 'draft',
+    ...data,
+  }
+  chatBills = [bill, ...chatBills]
+  save()
+  return bill
+}
+
+export function markChatBillSent(id: string) {
+  chatBills = chatBills.map((b) => (b.billId === id ? { ...b, status: 'sent' } : b))
+  save()
+}
+
+export function markChatBillPaid(id: string) {
+  chatBills = chatBills.map((b) => (b.billId === id ? { ...b, status: 'paid' } : b))
+  save()
+}
+
+export function getChatBill(id: string) {
+  return chatBills.find((b) => b.billId === id)
+}
+
+export function listChatBills() {
+  return chatBills
+}

--- a/types/chat-bill.ts
+++ b/types/chat-bill.ts
@@ -1,0 +1,20 @@
+export interface ChatBillItem {
+  productId: string
+  name: string
+  price: number
+  quantity: number
+}
+
+export type ChatBillStatus = 'draft' | 'sent' | 'paid'
+
+export interface ChatBill {
+  billId: string
+  createdAt: string
+  fbName: string
+  fbLink: string
+  sessionId: string
+  items: ChatBillItem[]
+  discount: number
+  total: number
+  status: ChatBillStatus
+}


### PR DESCRIPTION
## Summary
- support chat-based bill creation
- show created bill links in admin chat view
- store chat bill info in local storage
- display chat bill invoice to customer
- list chat bills in a new chat-insight page
- add navigation item for the new page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68734fba86088325aeee0598ee477fce