### PR TITLE
Add notify team settings

### DIFF
--- a/app/admin/notifications/page.tsx
+++ b/app/admin/notifications/page.tsx
@@ -28,10 +28,13 @@ import {
   AlertTriangle,
   Trash2,
   RefreshCw,
+  Package,
+  BadgeDollarSign,
 } from "lucide-react"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import type { NotificationHistory, NotificationTemplate } from "@/lib/mock-notification-service"
+import { notifyTeams, loadNotifyTeams, setNotifyTeams } from "@/lib/mock-settings"
 
 export default function NotificationsPage() {
   const { toast } = useToast()
@@ -50,9 +53,12 @@ export default function NotificationsPage() {
     lineEnabled: true,
     testMode: true, // เปิดโหมดทดสอบเป็นค่าเริ่มต้น
   })
+  const [teams, setTeams] = useState(notifyTeams)
 
   useEffect(() => {
     loadData()
+    loadNotifyTeams()
+    setTeams(notifyTeams)
   }, [])
 
   const loadData = async () => {
@@ -149,6 +155,12 @@ export default function NotificationsPage() {
         variant: "destructive",
       })
     }
+  }
+
+  const updateTeam = (key: 'packing' | 'finance', value: boolean) => {
+    const updated = { ...teams, [key]: value }
+    setTeams(updated)
+    setNotifyTeams(updated)
   }
 
 
@@ -652,6 +664,41 @@ export default function NotificationsPage() {
                     <Switch
                       checked={settings.testMode}
                       onCheckedChange={(checked) => setSettings((prev) => ({ ...prev, testMode: checked }))}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>ทีมที่รับการแจ้งเตือน</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      <Package className="h-4 w-4" />
+                      <div>
+                        <Label>ทีมแพ็คสินค้า</Label>
+                        <p className="text-sm text-gray-500">แจ้งเตือนงานจัดส่ง</p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={teams.packing}
+                      onCheckedChange={(checked) => updateTeam('packing', checked)}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      <BadgeDollarSign className="h-4 w-4" />
+                      <div>
+                        <Label>ทีมการเงิน</Label>
+                        <p className="text-sm text-gray-500">แจ้งเตือนเรื่องชำระเงิน</p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={teams.finance}
+                      onCheckedChange={(checked) => updateTeam('finance', checked)}
                     />
                   </div>
                 </CardContent>

--- a/lib/mock-notification-service.ts
+++ b/lib/mock-notification-service.ts
@@ -1,4 +1,5 @@
 // Mock Notification Service สำหรับการทดสอบ
+import { notifyTeams, loadNotifyTeams } from './mock-settings'
 export interface NotificationTemplate {
   id: string
   name: string
@@ -305,6 +306,7 @@ export class MockNotificationService {
 
     // โหลดประวัติจาก localStorage
     this.loadHistory()
+    loadNotifyTeams()
   }
 
   private loadHistory(): void {
@@ -365,6 +367,18 @@ export class MockNotificationService {
 
   async sendNotification(notificationData: NotificationData): Promise<boolean> {
     const { type, recipient, data, priority } = notificationData
+    const teamMap: Record<NotificationData['type'], keyof typeof notifyTeams> = {
+      stock_low: 'packing',
+      stock_out: 'packing',
+      stock_critical: 'packing',
+      order_created: 'packing',
+      order_updated: 'packing',
+      system_alert: 'finance',
+    }
+    const team = teamMap[type]
+    if (team && !notifyTeams[team]) {
+      return true
+    }
     let success = false
 
     // เตรียมข้อมูลทั่วไป

--- a/lib/mock-settings.ts
+++ b/lib/mock-settings.ts
@@ -34,6 +34,8 @@ export let billSecurity = { enabled: false, phone: "", pin: "" }
 export let autoReminder = false
 export let reviewReminder = false
 
+export let notifyTeams = { packing: true, finance: true }
+
 export function loadBillSecurity() {
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('billSecurity')
@@ -73,5 +75,19 @@ export function setReviewReminder(val: boolean) {
   reviewReminder = val
   if (typeof window !== 'undefined') {
     localStorage.setItem('reviewReminder', JSON.stringify(val))
+  }
+}
+
+export function loadNotifyTeams() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('notifyTeams')
+    if (stored) notifyTeams = JSON.parse(stored)
+  }
+}
+
+export function setNotifyTeams(val: { packing: boolean; finance: boolean }) {
+  notifyTeams = val
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('notifyTeams', JSON.stringify(val))
   }
 }


### PR DESCRIPTION
## Summary
- persist notify teams in localStorage
- allow configuring team notifications from admin page
- respect notify team flags when saving notification history

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68737a6a3ec08325afcd6682911f832e