### PR TITLE
Add team task pages

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -18,6 +18,7 @@ import {
   Warehouse,
   Receipt,
   Bug,
+  ClipboardList,
 } from "lucide-react"
 import Link from "next/link"
 import DashboardCard from "@/components/admin/dashboard/DashboardCard"
@@ -253,15 +254,44 @@ export default function AdminDashboard() {
                   แชทกับลูกค้า
                 </Button>
               </Link>
-              <Link href="/admin/dev">
-                <Button variant="outline" className="w-full justify-start bg-transparent">
-                  <Bug className="mr-2 h-4 w-4" />
-                  ข้อมูลระบบ
-                </Button>
-              </Link>
-            </CardContent>
-          </Card>
-        </div>
+          <Link href="/admin/dev">
+            <Button variant="outline" className="w-full justify-start bg-transparent">
+              <Bug className="mr-2 h-4 w-4" />
+              ข้อมูลระบบ
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <ClipboardList className="mr-2 h-5 w-5" />
+            งานทีม
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Link href="/team/production">
+            <Button variant="outline" className="w-full justify-start bg-transparent">
+              <ClipboardList className="mr-2 h-4 w-4" />
+              งานฝ่ายผลิต
+            </Button>
+          </Link>
+          <Link href="/team/shipping">
+            <Button variant="outline" className="w-full justify-start bg-transparent">
+              <ClipboardList className="mr-2 h-4 w-4" />
+              งานฝ่ายจัดส่ง
+            </Button>
+          </Link>
+          <Link href="/team/support">
+            <Button variant="outline" className="w-full justify-start bg-transparent">
+              <ClipboardList className="mr-2 h-4 w-4" />
+              งานฝ่ายบริการลูกค้า
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
 
         {/* Mock-up Notice */}
         <div className="mt-8 bg-blue-50 border border-blue-200 rounded-lg p-4">

--- a/app/team/[role]/page.tsx
+++ b/app/team/[role]/page.tsx
@@ -1,0 +1,42 @@
+import { mockTasks } from "@/lib/mock-tasks"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export default function TeamRolePage({ params }: { params: { role: string } }) {
+  const { role } = params
+  const tasks = mockTasks.filter((t) => t.role === role)
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-6">งานสำหรับทีม {role}</h1>
+        {tasks.length > 0 ? (
+          <div className="grid gap-4">
+            {tasks.map((task) => (
+              <Card key={task.id}>
+                <CardHeader>
+                  <CardTitle className="flex items-center">
+                    {task.title}
+                    {task.status !== "completed" && (
+                      <Badge variant="secondary" className="ml-2">
+                        {task.status === "inProgress" ? "กำลังทำ" : "รอดำเนินการ"}
+                      </Badge>
+                    )}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm text-gray-600 space-y-1">
+                  {task.orderId && <p>ออเดอร์: {task.orderId}</p>}
+                  {task.dueDate && (
+                    <p>กำหนดเสร็จ: {new Date(task.dueDate).toLocaleDateString("th-TH")}</p>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-600">ไม่มีงานสำหรับบทบาทนี้</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-tasks.ts
+++ b/lib/mock-tasks.ts
@@ -1,0 +1,35 @@
+import type { Task } from "@/types/task"
+
+export const mockTasks: Task[] = [
+  {
+    id: "TASK-001",
+    role: "production",
+    title: "ตัดผ้าสำหรับ ORD-001",
+    orderId: "ORD-001",
+    status: "pending",
+    dueDate: "2024-01-17",
+  },
+  {
+    id: "TASK-002",
+    role: "production",
+    title: "เย็บปลอก ORD-002",
+    orderId: "ORD-002",
+    status: "inProgress",
+    dueDate: "2024-01-18",
+  },
+  {
+    id: "TASK-003",
+    role: "shipping",
+    title: "แพ็กสินค้าส่ง ORD-001",
+    orderId: "ORD-001",
+    status: "pending",
+    dueDate: "2024-01-19",
+  },
+  {
+    id: "TASK-004",
+    role: "support",
+    title: "ตอบคำถามลูกค้า ORD-002",
+    orderId: "ORD-002",
+    status: "pending",
+  },
+]

--- a/types/task.ts
+++ b/types/task.ts
@@ -1,0 +1,10 @@
+export type TaskStatus = "pending" | "inProgress" | "completed"
+
+export interface Task {
+  id: string
+  role: string
+  title: string
+  orderId?: string
+  status: TaskStatus
+  dueDate?: string
+}


### PR DESCRIPTION
## Summary
- provide a `Task` type and mock task data
- create dynamic route to show tasks by role
- link team pages from admin dashboard

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68737c4ef26c8325a3f60dab86e125a9