### PR TITLE
Add packing status control

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -8,10 +8,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import OrderStatusDropdown from "@/components/admin/orders/OrderStatusDropdown"
 import { OrderTimeline, type TimelineEntry } from "@/components/order/OrderTimeline"
-import { mockOrders } from "@/lib/mock-orders"
+import { mockOrders, setPackingStatus } from "@/lib/mock-orders"
 import type { Order } from "@/types/order"
-import type { OrderStatus, ShippingStatus } from "@/types/order"
-import { shippingStatusOptions } from "@/types/order"
+import type { OrderStatus, ShippingStatus, PackingStatus } from "@/types/order"
+import { shippingStatusOptions, packingStatusOptions } from "@/types/order"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { toast } from "sonner"
@@ -23,6 +23,7 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
 
   const [status, setStatus] = useState<OrderStatus>(order?.status ?? "pendingPayment")
   const [shippingStatus, setShippingStatus] = useState<ShippingStatus>(order?.shipping_status ?? "pending")
+  const [packingStatus, setPackingStatusState] = useState<PackingStatus>(order?.packingStatus ?? "packing")
 
   if (!order) {
     return (
@@ -44,6 +45,12 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
     mockOrders[orderIndex].shipping_date = new Date().toISOString()
     setShippingStatus(value)
     toast.success("อัปเดตสถานะจัดส่งแล้ว")
+  }
+
+  const handlePackingChange = (value: PackingStatus) => {
+    setPackingStatus(order.id, value)
+    setPackingStatusState(value)
+    toast.success("อัปเดตสถานะแพ็กแล้ว")
   }
 
   return (
@@ -157,6 +164,21 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
                 </SelectTrigger>
                 <SelectContent>
                   {shippingStatusOptions.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center space-x-2">
+              <span>แพ็กสินค้า:</span>
+              <Select value={packingStatus} onValueChange={(v) => handlePackingChange(v as PackingStatus)}>
+                <SelectTrigger className="w-32">
+                  <Badge>{packingStatusOptions.find((o) => o.value === packingStatus)?.label}</Badge>
+                </SelectTrigger>
+                <SelectContent>
+                  {packingStatusOptions.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       {opt.label}
                     </SelectItem>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -11,11 +11,11 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Search, ArrowLeft, Eye, FileText, Edit, Copy, ExternalLink } from "lucide-react"
 import Link from "next/link"
 import { toast } from "sonner"
-import { mockOrders } from "@/lib/mock-orders"
+import { mockOrders, setPackingStatus } from "@/lib/mock-orders"
 import { mockCustomers } from "@/lib/mock-customers"
 import { createBill, confirmBill, mockBills } from "@/lib/mock-bills"
-import type { Order } from "@/types/order"
-import type { OrderStatus } from "@/types/order"
+import type { Order, OrderStatus, PackingStatus } from "@/types/order"
+import { packingStatusOptions } from "@/types/order"
 import {
   getOrderStatusBadgeVariant,
   getOrderStatusText,
@@ -52,6 +52,11 @@ export default function AdminOrdersPage() {
 
   const updateOrderStatus = (orderId: string, newStatus: OrderStatus) => {
     setOrders(orders.map((order) => (order.id === orderId ? { ...order, status: newStatus } : order)))
+  }
+
+  const updatePackingStatus = (orderId: string, status: PackingStatus) => {
+    setOrders(orders.map((o) => (o.id === orderId ? { ...o, packingStatus: status } : o)))
+    setPackingStatus(orderId, status)
   }
 
   const handleCreateBill = (orderId: string) => {
@@ -165,6 +170,7 @@ export default function AdminOrdersPage() {
                   <TableHead>วันที่สั่งซื้อ</TableHead>
                   <TableHead>ยอดรวม</TableHead>
                   <TableHead>สถานะ</TableHead>
+                  <TableHead>สถานะการแพ็ก</TableHead>
                   <TableHead>สถานะจัดส่ง</TableHead>
                   <TableHead className="text-right">การจัดการ</TableHead>
                 </TableRow>
@@ -197,6 +203,23 @@ export default function AdminOrdersPage() {
                       </SelectTrigger>
                       <SelectContent>
                         {orderStatusOptions.map((opt) => (
+                          <SelectItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      value={order.packingStatus}
+                      onValueChange={(v) => updatePackingStatus(order.id, v as PackingStatus)}
+                    >
+                      <SelectTrigger className="w-28">
+                        <Badge>{packingStatusOptions.find((o) => o.value === order.packingStatus)?.label}</Badge>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {packingStatusOptions.map((opt) => (
                           <SelectItem key={opt.value} value={opt.value}>
                             {opt.label}
                           </SelectItem>

--- a/app/invoice/[id]/page.tsx
+++ b/app/invoice/[id]/page.tsx
@@ -6,6 +6,8 @@ import { Separator } from "@/components/ui/separator"
 import { Download, PrinterIcon as Print, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { mockOrders } from "@/lib/mock-orders"
+import { Badge } from "@/components/ui/badge"
+import { packingStatusOptions } from "@/types/order"
 import { mockBills } from "@/lib/mock-bills"
 import { loadAutoReminder, autoReminder } from "@/lib/mock-settings"
 import { toast } from "sonner"
@@ -119,6 +121,12 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
                   </p>
                 </div>
               </div>
+            </div>
+
+            <div className="mb-6 text-right">
+              <Badge>
+                {packingStatusOptions.find((p) => p.value === order.packingStatus)?.label}
+              </Badge>
             </div>
 
             {/* Customer Info */}

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -1,4 +1,4 @@
-import type { OrderStatus, ShippingStatus, Order } from "@/types/order"
+import type { OrderStatus, ShippingStatus, Order, PackingStatus } from "@/types/order"
 
 import { supabase } from "./supabase"
 
@@ -34,6 +34,7 @@ const initialMockOrders: Order[] = [
     tracking_number: "TH1234567890",
     shipping_fee: 80,
     shipping_status: "pending",
+    packingStatus: "packing",
     shipping_date: "2024-01-16T10:30:00Z",
     delivery_note: "-",
     scheduledDeliveryDate: "2024-01-20",
@@ -84,6 +85,7 @@ const initialMockOrders: Order[] = [
     tracking_number: "TH0987654321",
     shipping_fee: 80,
     shipping_status: "shipped",
+    packingStatus: "packing",
     shipping_date: "2024-01-15T08:00:00Z",
     delivery_note: "ส่งตามเวลาทำการ",
     scheduledDeliveryDate: "2024-01-18",
@@ -109,8 +111,14 @@ export function regenerateMockOrders() {
   mockOrders = initialMockOrders.map((o) => ({
     ...o,
     items: o.items.map((i) => ({ ...i })),
+    packingStatus: o.packingStatus,
     timeline: o.timeline.map((t) => ({ ...t })),
   }))
+}
+
+export function setPackingStatus(orderId: string, status: PackingStatus) {
+  const order = mockOrders.find((o) => o.id === orderId)
+  if (order) order.packingStatus = status
 }
 
 export async function fetchOrders(): Promise<Order[]> {

--- a/types/order.ts
+++ b/types/order.ts
@@ -37,6 +37,14 @@ export const shippingStatusOptions: { value: ShippingStatus; label: string }[] =
   { value: "delivered", label: "ส่งมอบแล้ว" },
 ]
 
+export type PackingStatus = "packing" | "done" | "ready"
+
+export const packingStatusOptions: { value: PackingStatus; label: string }[] = [
+  { value: "packing", label: "กำลังแพ็ก" },
+  { value: "done", label: "แพ็กเสร็จ" },
+  { value: "ready", label: "พร้อมส่ง" },
+]
+
 export const orderStatusOptions: { value: OrderStatus; label: string }[] = [
   { value: "draft", label: "ร่าง" },
   { value: "pending", label: "รอยืนยัน" },
@@ -84,6 +92,8 @@ export interface Order {
   tracking_number: string
   shipping_fee: number
   shipping_status: ShippingStatus
+  /** Status of packing before shipment */
+  packingStatus: PackingStatus
   shipping_date: string
   delivery_note: string
   scheduledDeliveryDate?: string


### PR DESCRIPTION
## Summary
- track packing status on orders
- expose helper to update packing status
- add packing controls in admin order list and detail
- show packing step badge on invoice

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68737ce5c5a48325a58eb325b13d415b