### PR TITLE
Add scheduled delivery datetime field

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -24,6 +24,7 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
   const [status, setStatus] = useState<OrderStatus>(order?.status ?? "pendingPayment")
   const [shippingStatus, setShippingStatus] = useState<ShippingStatus>(order?.shipping_status ?? "pending")
   const [packingStatus, setPackingStatusState] = useState<PackingStatus>(order?.packingStatus ?? "packing")
+  const [scheduledDelivery, setScheduledDelivery] = useState(order?.scheduledDelivery || "")
 
   if (!order) {
     return (
@@ -186,12 +187,20 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
                 </SelectContent>
               </Select>
             </div>
-            <p>
-              วันนัดจัดส่ง:{" "}
-              {order.scheduledDeliveryDate
-                ? new Date(order.scheduledDeliveryDate).toLocaleDateString("th-TH")
-                : "-"}
-            </p>
+            <div className="space-y-1">
+              <label htmlFor="scheduledDelivery">วันนัดจัดส่ง:</label>
+              <input
+                id="scheduledDelivery"
+                type="datetime-local"
+                className="border rounded px-2 py-1"
+                value={scheduledDelivery}
+                onChange={(e) => {
+                  const val = e.target.value
+                  setScheduledDelivery(val)
+                  mockOrders[orderIndex].scheduledDelivery = val
+                }}
+              />
+            </div>
             <p>วันที่เปลี่ยน: {order.shipping_date ? new Date(order.shipping_date).toLocaleDateString("th-TH") : "-"}</p>
             <p>หมายเหตุ: {order.delivery_note || "-"}</p>
             <Button variant="outline" onClick={() => {

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -141,7 +141,7 @@ export default function CheckoutPage() {
         shipping_status: "pending" as ShippingStatus,
         shipping_date: "",
         delivery_note: "",
-        scheduledDeliveryDate: deliveryDate || undefined,
+        scheduledDelivery: deliveryDate || undefined,
         reorderedFromId: sessionStorage.getItem("reorderFromId") || undefined,
         checklist: {
           items: ["confirmSize", "confirmColor"],
@@ -300,7 +300,7 @@ export default function CheckoutPage() {
                   <Label htmlFor="deliveryDate">วันนัดจัดส่ง</Label>
                   <Input
                     id="deliveryDate"
-                    type="date"
+                    type="datetime-local"
                     value={deliveryDate}
                     onChange={(e) => setDeliveryDate(e.target.value)}
                   />

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -37,7 +37,7 @@ const initialMockOrders: Order[] = [
     packingStatus: "packing",
     shipping_date: "2024-01-16T10:30:00Z",
     delivery_note: "-",
-    scheduledDeliveryDate: "2024-01-20",
+    scheduledDelivery: "2024-01-20T10:00",
     timeline: [
       {
         timestamp: "2024-01-15T10:30:00Z",
@@ -88,7 +88,7 @@ const initialMockOrders: Order[] = [
     packingStatus: "packing",
     shipping_date: "2024-01-15T08:00:00Z",
     delivery_note: "ส่งตามเวลาทำการ",
-    scheduledDeliveryDate: "2024-01-18",
+    scheduledDelivery: "2024-01-18T10:00",
     timeline: [
       {
         timestamp: "2024-01-14T14:20:00Z",

--- a/types/order.ts
+++ b/types/order.ts
@@ -96,7 +96,8 @@ export interface Order {
   packingStatus: PackingStatus
   shipping_date: string
   delivery_note: string
-  scheduledDeliveryDate?: string
+  /** Scheduled date and time for delivery */
+  scheduledDelivery?: string
   reorderedFromId?: string
   validated?: boolean
   demo?: boolean


### PR DESCRIPTION
## Summary
- use datetime-local input at checkout to schedule delivery
- store scheduled delivery timestamp on Order objects
- allow admins to edit scheduled delivery in order details

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68737f5cbfe48325975f3986b370be07