### PR TITLE
Add customer mute controls

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Switch } from "@/components/ui/switch"
 import CustomerCard from "@/components/admin/customers/CustomerCard"
 import {
   Tabs,
@@ -27,6 +28,7 @@ import {
   getCustomerStats,
   updateCustomerPoints,
   setCustomerTier,
+  setCustomerMuted,
 } from "@/lib/mock-customers"
 
 export default function CustomerDetailPage({
@@ -49,6 +51,7 @@ export default function CustomerDetailPage({
   const stats = getCustomerStats(customer.id)
   const [pointDelta, setPointDelta] = useState(0)
   const [tierValue, setTierValue] = useState<string>(customer.tier || "Silver")
+  const [muted, setMuted] = useState<boolean>(customer.muted ?? false)
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -120,6 +123,21 @@ export default function CustomerDetailPage({
               <option value="Gold">Gold</option>
               <option value="VIP">VIP</option>
             </select>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Mute notifications</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Switch
+              checked={muted}
+              onCheckedChange={(v) => {
+                setMuted(v)
+                setCustomerMuted(customer.id, v)
+              }}
+            />
           </CardContent>
         </Card>
 

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -1,4 +1,6 @@
 import type { Bill, BillPayment, BillStatus } from "@/types/bill"
+import { mockOrders } from "./mock-orders"
+import { mockCustomers } from "./mock-customers"
 
 export let mockBills: Bill[] = []
 
@@ -7,6 +9,8 @@ export function createBill(
   status: BillStatus = "unpaid",
   dueDate?: string,
 ): Bill {
+  const order = mockOrders.find((o) => o.id === orderId)
+  const customer = order && mockCustomers.find((c) => c.id === order.customerId)
   const id = `bill-${Math.random().toString(36).slice(2, 8)}`
   const bill: Bill = {
     id,
@@ -15,6 +19,9 @@ export function createBill(
     payments: [],
     createdAt: new Date().toISOString(),
     dueDate,
+  }
+  if (customer?.muted) {
+    bill.hidden = true
   }
   mockBills.push(bill)
   return bill

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -13,6 +13,8 @@ export interface Customer {
   points?: number
   /** membership tier */
   tier?: "Silver" | "Gold" | "VIP"
+  /** mute notifications */
+  muted?: boolean
   /** point change history */
   pointHistory?: PointLog[]
   createdAt: string
@@ -159,4 +161,10 @@ export function setCustomerTier(id: string, tier: "Silver" | "Gold" | "VIP") {
   const customer = mockCustomers.find((c) => c.id === id)
   if (!customer) return
   customer.tier = tier
+}
+
+export function setCustomerMuted(id: string, muted: boolean) {
+  const customer = mockCustomers.find((c) => c.id === id)
+  if (!customer) return
+  customer.muted = muted
 }

--- a/lib/mock-notification-service.ts
+++ b/lib/mock-notification-service.ts
@@ -1,5 +1,8 @@
 // Mock Notification Service สำหรับการทดสอบ
 import { notifyTeams, loadNotifyTeams } from './mock-settings'
+import { mockCustomers } from './mock-customers'
+import { mockOrders } from './mock-orders'
+import type { Customer } from './mock-customers'
 export interface NotificationTemplate {
   id: string
   name: string
@@ -367,6 +370,22 @@ export class MockNotificationService {
 
   async sendNotification(notificationData: NotificationData): Promise<boolean> {
     const { type, recipient, data, priority } = notificationData
+    let customer: Customer | undefined
+    if ((data as any).orderId) {
+      const order = mockOrders.find((o) => o.id === (data as any).orderId)
+      if (order) {
+        customer = mockCustomers.find((c) => c.id === order.customerId)
+      }
+    }
+    if (!customer && recipient.email) {
+      customer = mockCustomers.find((c) => c.email === recipient.email)
+    }
+    if (!customer && recipient.phone) {
+      customer = mockCustomers.find((c) => c.phone === recipient.phone)
+    }
+    if (customer?.muted) {
+      return false
+    }
     const teamMap: Record<NotificationData['type'], keyof typeof notifyTeams> = {
       stock_low: 'packing',
       stock_out: 'packing',

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -1,4 +1,7 @@
 import nodemailer from "nodemailer"
+import { mockCustomers } from "./mock-customers"
+import { mockOrders } from "./mock-orders"
+import type { Customer } from "./mock-customers"
 
 // Types
 export interface NotificationTemplate {
@@ -378,6 +381,22 @@ export class NotificationService {
 
   async sendNotification(notificationData: NotificationData): Promise<boolean> {
     const { type, recipient, data, priority } = notificationData
+    let customer: Customer | undefined
+    if ((data as any).orderId) {
+      const order = mockOrders.find((o) => o.id === (data as any).orderId)
+      if (order) {
+        customer = mockCustomers.find((c) => c.id === order.customerId)
+      }
+    }
+    if (!customer && recipient.email) {
+      customer = mockCustomers.find((c) => c.email === recipient.email)
+    }
+    if (!customer && recipient.phone) {
+      customer = mockCustomers.find((c) => c.phone === recipient.phone)
+    }
+    if (customer?.muted) {
+      return false
+    }
     let success = false
 
     // Prepare common data


### PR DESCRIPTION
## Summary
- allow `Customer` records to be muted
- expose `setCustomerMuted` helper
- mark bills as hidden when their customer is muted
- ignore muted customers in notification services
- toggle mute state in admin customer page

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6873816434e48325aab89432b127b390