### PR TITLE
Add mock promo expiry and packing list features

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -25,6 +25,7 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
   const [shippingStatus, setShippingStatus] = useState<ShippingStatus>(order?.shipping_status ?? "pending")
   const [packingStatus, setPackingStatusState] = useState<PackingStatus>(order?.packingStatus ?? "packing")
   const [scheduledDelivery, setScheduledDelivery] = useState(order?.scheduledDelivery || "")
+  const [chatNote, setChatNote] = useState(order?.chatNote || "")
 
   if (!order) {
     return (
@@ -211,6 +212,28 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
               }
             }}>
               เพิ่มบันทึกการโทร/ส่ง
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>โน้ตจากแชท</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <textarea
+              className="border rounded w-full p-2"
+              value={chatNote}
+              onChange={(e) => setChatNote(e.target.value)}
+            />
+            <Button
+              variant="outline"
+              onClick={() => {
+                mockOrders[orderIndex].chatNote = chatNote
+                toast.success("บันทึกแล้ว")
+              }}
+            >
+              บันทึก
             </Button>
           </CardContent>
         </Card>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -172,6 +172,7 @@ export default function AdminOrdersPage() {
                   <TableHead>สถานะ</TableHead>
                   <TableHead>สถานะการแพ็ก</TableHead>
                   <TableHead>สถานะจัดส่ง</TableHead>
+                  <TableHead>เหตุผลทิ้งบิล</TableHead>
                   <TableHead className="text-right">การจัดการ</TableHead>
                 </TableRow>
               </TableHeader>
@@ -228,6 +229,7 @@ export default function AdminOrdersPage() {
                     </Select>
                   </TableCell>
                   <TableCell>{order.shipping_status}</TableCell>
+                  <TableCell>{bills.find((b) => b.orderId === order.id)?.abandonReason || "-"}</TableCell>
                   <TableCell className="text-right">
                       <div className="flex items-center justify-end space-x-2">
                         <Dialog>

--- a/app/admin/promo/page.tsx
+++ b/app/admin/promo/page.tsx
@@ -13,10 +13,12 @@ export default function AdminPromoPage() {
   const [promos, setPromos] = useState<Promo[]>(listPromos())
   const [code, setCode] = useState("")
   const [customerId, setCustomerId] = useState("2")
+  const [startDate, setStartDate] = useState("2024-01-21")
+  const [endDate, setEndDate] = useState("2024-01-31")
 
   const handleCreate = () => {
     if (!code) return
-    createPromo(code, customerId)
+    createPromo(code, customerId, startDate, endDate)
     setPromos(listPromos())
     setCode("")
   }
@@ -58,6 +60,8 @@ export default function AdminPromoPage() {
                 </option>
               ))}
             </select>
+            <Input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+            <Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
             <Button onClick={handleCreate}>สร้าง</Button>
           </CardContent>
         </Card>
@@ -71,6 +75,8 @@ export default function AdminPromoPage() {
                 <TableRow>
                   <TableHead>โค้ด</TableHead>
                   <TableHead>ลูกค้า</TableHead>
+                  <TableHead>เริ่ม</TableHead>
+                  <TableHead>สิ้นสุด</TableHead>
                   <TableHead>ลิงก์</TableHead>
                   <TableHead></TableHead>
                 </TableRow>
@@ -80,6 +86,8 @@ export default function AdminPromoPage() {
                   <TableRow key={p.id}>
                     <TableCell>{p.code}</TableCell>
                     <TableCell>{mockCustomers.find((c) => c.id === p.customerId)?.name}</TableCell>
+                    <TableCell>{p.startDate}</TableCell>
+                    <TableCell>{p.endDate}</TableCell>
                     <TableCell>
                       <Link href={`/promo/${p.code}`}>{`/promo/${p.code}`}</Link>
                     </TableCell>

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -11,6 +11,7 @@ import { OrderTimeline } from "@/components/order/OrderTimeline"
 import { mockOrders } from "@/lib/mock-orders"
 import { getBill, addBillPayment } from "@/lib/mock-bills"
 import { billSecurity } from "@/lib/mock-settings"
+import { getMockNow } from "@/lib/mock-date"
 
 export default function BillPage({ params }: { params: { id: string } }) {
   const { id } = params
@@ -20,6 +21,12 @@ export default function BillPage({ params }: { params: { id: string } }) {
   const [code, setCode] = useState("")
   const [amount, setAmount] = useState("")
   const [slip, setSlip] = useState<File | null>(null)
+  const [reason, setReason] = useState(bill?.abandonReason || "")
+
+  const baseDate = new Date(bill?.dueDate || bill.createdAt)
+  const expired =
+    bill.status !== "paid" &&
+    getMockNow().getTime() > baseDate.getTime() + 3 * 24 * 60 * 60 * 1000
 
   if (!bill || !order) {
     return (
@@ -116,6 +123,21 @@ export default function BillPage({ params }: { params: { id: string } }) {
               <Input id="amt" value={amount} onChange={(e) => setAmount(e.target.value)} />
               <Input type="file" onChange={(e) => setSlip(e.target.files?.[0] ?? null)} />
               <Button onClick={handleSendSlip}>ส่งหลักฐานโอน</Button>
+              {expired && !reason && (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    const r = window.prompt("บอกเหตุผลการไม่ชำระ")
+                    if (r) {
+                      setReason(r)
+                      bill.abandonReason = r
+                    }
+                  }}
+                >
+                  บอกเหตุผล
+                </Button>
+              )}
+              {reason && <p className="text-sm text-gray-600">เหตุผล: {reason}</p>}
             </div>
           </CardContent>
         </Card>

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { mockCustomers } from "@/lib/mock-customers"
+
+export default function CustomersPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">ลูกค้าของเรา</h1>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {mockCustomers.map((c) => (
+            <div key={c.id} className="border p-4 rounded">
+              <p className="font-medium">{c.name}</p>
+              <p className="text-sm text-gray-500">{c.email}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/promo/[code]/page.tsx
+++ b/app/promo/[code]/page.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { getPromoByCode } from "@/lib/mock-promos"
+import { getMockNow } from "@/lib/mock-date"
 import { mockCustomers } from "@/lib/mock-customers"
 
 export default function PromoPage({ params }: { params: { code: string } }) {
@@ -14,14 +15,27 @@ export default function PromoPage({ params }: { params: { code: string } }) {
     )
   }
   const customer = mockCustomers.find((c) => c.id === promo.customerId)
+  const expired =
+    new Date(promo.endDate).getTime() < getMockNow().getTime()
   return (
     <div className="min-h-screen flex items-center justify-center">
       <div className="space-y-4 text-center">
-        <h1 className="text-3xl font-bold">โปรโมชันพิเศษสำหรับ {customer?.name}</h1>
-        <p>โค้ดของคุณคือ {promo.code}</p>
-        <Link href="/">
-          <Button>กลับสู่หน้าหลัก</Button>
-        </Link>
+        {expired ? (
+          <>
+            <h1 className="text-3xl font-bold">หมดเวลา</h1>
+            <Link href="/">
+              <Button>กลับสู่หน้าหลัก</Button>
+            </Link>
+          </>
+        ) : (
+          <>
+            <h1 className="text-3xl font-bold">โปรโมชันพิเศษสำหรับ {customer?.name}</h1>
+            <p>โค้ดของคุณคือ {promo.code}</p>
+            <Link href="/">
+              <Button>กลับสู่หน้าหลัก</Button>
+            </Link>
+          </>
+        )}
       </div>
     </div>
   )

--- a/app/team/packing/page.tsx
+++ b/app/team/packing/page.tsx
@@ -1,0 +1,66 @@
+"use client"
+import { useState } from "react"
+import { mockOrders } from "@/lib/mock-orders"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface PickItem {
+  key: string
+  name: string
+  quantity: number
+}
+
+export default function PackingPage() {
+  const [items, setItems] = useState<PickItem[]>([])
+
+  const generate = () => {
+    const orders = mockOrders.filter(
+      (o) => o.status === "paid" && o.shipping_status === "pending",
+    )
+    const map = new Map<string, PickItem>()
+    orders.forEach((o) => {
+      o.items.forEach((it) => {
+        const key = `${it.productId}-${it.size}-${it.color}`
+        const existing = map.get(key)
+        if (existing) {
+          existing.quantity += it.quantity
+        } else {
+          map.set(key, {
+            key,
+            name: it.productName,
+            quantity: it.quantity,
+          })
+        }
+      })
+    })
+    setItems(Array.from(map.values()))
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">รายการแพ็กวันนี้</h1>
+        <Button onClick={generate}>รวมสินค้าที่ต้องแพ็กวันนี้</Button>
+        {items.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Pick List</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {items.map((it) => (
+                <div key={it.key} className="flex justify-between border-b py-1">
+                  <span>{it.name}</span>
+                  <span>{it.quantity}</span>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/lib/mock-date.ts
+++ b/lib/mock-date.ts
@@ -1,0 +1,4 @@
+export const MOCK_NOW = new Date('2024-01-21T00:00:00Z');
+export function getMockNow() {
+  return MOCK_NOW;
+}

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -22,6 +22,7 @@ const initialMockOrders: Order[] = [
     status: "depositPaid",
     depositPercent: 50,
     note: "Deposit received",
+    chatNote: "",
     createdAt: "2024-01-15T10:30:00Z",
     shippingAddress: {
       name: "John Doe",
@@ -73,6 +74,7 @@ const initialMockOrders: Order[] = [
     total: 3980,
     status: "paid",
     depositPercent: 100,
+    chatNote: "",
     createdAt: "2024-01-14T14:20:00Z",
     shippingAddress: {
       name: "Jane Smith",

--- a/lib/mock-promos.ts
+++ b/lib/mock-promos.ts
@@ -2,15 +2,24 @@ export interface Promo {
   id: string
   code: string
   customerId: string
+  startDate: string
+  endDate: string
 }
 
 export let mockPromos: Promo[] = []
 
-export function createPromo(code: string, customerId: string): Promo {
+export function createPromo(
+  code: string,
+  customerId: string,
+  startDate: string,
+  endDate: string,
+): Promo {
   const promo: Promo = {
     id: `promo-${Math.random().toString(36).slice(2, 8)}`,
     code,
     customerId,
+    startDate,
+    endDate,
   }
   mockPromos.push(promo)
   return promo

--- a/types/bill.ts
+++ b/types/bill.ts
@@ -18,4 +18,5 @@ export interface Bill {
   createdAt: string
   dueDate?: string
   hidden?: boolean
+  abandonReason?: string
 }

--- a/types/order.ts
+++ b/types/order.ts
@@ -80,6 +80,7 @@ export interface Order {
   status: OrderStatus
   depositPercent?: number
   note?: string
+  chatNote?: string
   createdAt: string
   shippingAddress: {
     name: string


### PR DESCRIPTION
## Summary
- add mock date helper
- support promo start and end dates
- handle expired promo links
- extend admin promo management for date fields
- show abandonment reason in orders
- add chat note field on order detail page
- allow customers list & packing list pages
- record late payment reason on bill

## Testing
- `pnpm test`
- `pnpm eslint`

------
https://chatgpt.com/codex/tasks/task_e_687386fc9fa083258285e0947e02a590