### PR TITLE
Add mock claim system and admin logs

### DIFF
--- a/app/admin/claims/page.tsx
+++ b/app/admin/claims/page.tsx
@@ -1,0 +1,93 @@
+"use client"
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useAuth } from '@/contexts/auth-context'
+import { mockClaims, updateClaim } from '@/lib/mock-claims'
+import { exportCSV } from '@/lib/mock-export'
+
+export default function AdminClaimsPage() {
+  const { user, isAuthenticated } = useAuth()
+  const [claims, setClaims] = useState([...mockClaims])
+
+  if (!isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">ไม่มีสิทธิ์เข้าถึง</h1>
+          <Link href="/">
+            <Button>กลับหน้าแรก</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const handleApprove = (id: string) => {
+    updateClaim(id, { status: 'approved' })
+    setClaims([...mockClaims])
+  }
+
+  const handleReject = (id: string) => {
+    const reason = window.prompt('เหตุผลการปฏิเสธ') || ''
+    updateClaim(id, { status: 'rejected', reason })
+    setClaims([...mockClaims])
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-8">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">เคลมสินค้า</h1>
+          <Button onClick={() => { const csv = exportCSV(claims); const preview = csv.split('\n').slice(0,4).join('\n'); alert(preview); }}>Export CSV</Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการเคลม ({claims.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ออเดอร์</TableHead>
+                  <TableHead>รูป</TableHead>
+                  <TableHead>เหตุผล</TableHead>
+                  <TableHead>สถานะ</TableHead>
+                  <TableHead className="text-right">การจัดการ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {claims.map((c) => (
+                  <TableRow key={c.id}>
+                    <TableCell>{c.orderId}</TableCell>
+                    <TableCell>
+                      <img src={c.image} alt="img" className="h-12 w-12" />
+                    </TableCell>
+                    <TableCell>{c.reason}</TableCell>
+                    <TableCell>{c.status}</TableCell>
+                    <TableCell className="text-right space-x-2">
+                      <Button size="sm" onClick={() => handleApprove(c.id)}>
+                        อนุมัติ
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => handleReject(c.id)}>
+                        ปฏิเสธ
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -14,6 +14,7 @@ import {
   getCustomerOrders,
   type Customer,
 } from "@/lib/mock-customers"
+import { exportCSV } from "@/lib/mock-export"
 
 
 export default function AdminCustomersPage() {
@@ -189,6 +190,13 @@ export default function AdminCustomersPage() {
                   <option value="frequent">ซื้อบ่อย</option>
                   <option value="unpaid">ค้างจ่าย</option>
                 </select>
+                <Button onClick={() => {
+                  const csv = exportCSV(customers)
+                  const preview = csv.split('\n').slice(0,4).join('\n')
+                  alert(preview)
+                }}>
+                  Export CSV
+                </Button>
               </div>
             </div>
           </CardHeader>

--- a/app/admin/dev/page.tsx
+++ b/app/admin/dev/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useAuth } from "@/contexts/auth-context"
+import { isDevMock } from "@/lib/mock-settings"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import {
@@ -16,6 +17,20 @@ import {
 
 export default function AdminDevPage() {
   const { user, isAuthenticated } = useAuth()
+  if (!isDevMock) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>ไม่อนุญาต</p>
+      </div>
+    )
+  }
+  if (!isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>ไม่มีสิทธิ์เข้าถึง</p>
+      </div>
+    )
+  }
   const handleClear = () => {
     resetMockOrders()
     resetMockCustomers()

--- a/app/admin/logs/page.tsx
+++ b/app/admin/logs/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { mockAdminLogs } from '@/lib/mock-admin-logs'
+
+export default function AdminLogsPage() {
+  const { user, isAuthenticated } = useAuth()
+
+  if (!isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">ไม่มีสิทธิ์เข้าถึง</h1>
+          <Link href="/">
+            <Button>กลับหน้าแรก</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-8">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">บันทึกการทำงาน</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Admin Logs ({mockAdminLogs.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>เวลา</TableHead>
+                  <TableHead>ผู้ดำเนินการ</TableHead>
+                  <TableHead>การกระทำ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {mockAdminLogs.map((log) => (
+                  <TableRow key={log.id}>
+                    <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>{log.admin}</TableCell>
+                    <TableCell>{log.action}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/media/page.tsx
+++ b/app/admin/media/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+import Link from 'next/link'
+import { useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/contexts/auth-context'
+import { getMedia } from '@/lib/mock-media'
+
+export default function AdminMediaPage() {
+  const { user, isAuthenticated } = useAuth()
+  const [search, setSearch] = useState('')
+  const media = getMedia().filter(m => m.url.includes(search))
+
+  if (!isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">ไม่มีสิทธิ์เข้าถึง</h1>
+          <Link href="/">
+            <Button>กลับหน้าแรก</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-8">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">คลังรูปภาพ</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <div className="flex justify-between items-center">
+              <CardTitle>รูปภาพ ({media.length})</CardTitle>
+              <Input placeholder="ค้นหา..." value={search} onChange={e => setSearch(e.target.value)} className="w-64" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {media.map(m => (
+                <div key={m.id} className="border rounded-lg p-2 text-center">
+                  <img src={m.url} alt="img" className="h-32 w-full object-cover rounded" />
+                  <p className="text-sm mt-2 text-gray-500">{m.source}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner"
 import { mockOrders, setPackingStatus } from "@/lib/mock-orders"
 import { mockCustomers } from "@/lib/mock-customers"
 import { createBill, confirmBill, mockBills } from "@/lib/mock-bills"
+import { exportCSV } from "@/lib/mock-export"
 import type { Order, OrderStatus, PackingStatus } from "@/types/order"
 import { packingStatusOptions } from "@/types/order"
 import {
@@ -157,6 +158,13 @@ export default function AdminOrdersPage() {
                   }
                 }}>
                   สแกน QR
+                </Button>
+                <Button onClick={() => {
+                  const csv = exportCSV(mockOrders)
+                  const preview = csv.split('\n').slice(0,4).join('\n')
+                  alert(preview)
+                }}>
+                  Export CSV
                 </Button>
               </div>
             </div>

--- a/app/invoice/[id]/page.tsx
+++ b/app/invoice/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { packingStatusOptions } from "@/types/order"
 import { mockBills } from "@/lib/mock-bills"
 import { loadAutoReminder, autoReminder } from "@/lib/mock-settings"
+import { createClaim } from "@/lib/mock-claims"
 import { toast } from "sonner"
 
 export default function InvoicePage({ params }: { params: { id: string } }) {
@@ -38,6 +39,14 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
   const handleDownload = () => {
     // In a real app, this would generate and download a PDF
     alert("ดาวน์โหลดใบเสร็จ (ฟีเจอร์นี้จะพัฒนาในอนาคต)")
+  }
+
+  const handleClaim = () => {
+    const reason = window.prompt('แจ้งปัญหา') || ''
+    if (!reason) return
+    const image = '/mock/img' + Date.now() + '.jpg'
+    createClaim({ orderId: order.id, image, reason })
+    alert('ส่งคำขอเคลมแล้ว')
   }
 
   useEffect(() => {
@@ -79,6 +88,9 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
             <Button onClick={handleDownload}>
               <Download className="mr-2 h-4 w-4" />
               ดาวน์โหลด PDF
+            </Button>
+            <Button variant="destructive" onClick={handleClaim}>
+              แจ้งเคลม
             </Button>
           </div>
         </div>

--- a/contexts/admin-products-context.tsx
+++ b/contexts/admin-products-context.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, type ReactNode } from "react"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 import { mockProducts } from "@/lib/mock-products"
 import type { Product } from "@/types/product"
+import { addAdminLog } from "@/lib/mock-admin-logs"
 
 interface AdminProductsContextValue {
   products: Product[]
@@ -24,14 +25,17 @@ export function AdminProductsProvider({ children }: { children: ReactNode }) {
       ...data,
     }
     setProducts((prev) => [...prev, newProduct])
+    addAdminLog(`add product ${newProduct.id}`, 'mockAdminId')
   }
 
   const updateProduct = (id: string, data: Partial<Product>) => {
     setProducts((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)))
+    addAdminLog(`update product ${id}`, 'mockAdminId')
   }
 
   const deleteProduct = (id: string) => {
     setProducts((prev) => prev.filter((p) => p.id !== id))
+    addAdminLog(`delete product ${id}`, 'mockAdminId')
   }
 
   return (

--- a/lib/mock-admin-logs.ts
+++ b/lib/mock-admin-logs.ts
@@ -1,0 +1,17 @@
+export interface AdminLog {
+  id: string
+  action: string
+  timestamp: string
+  admin: string
+}
+
+export let mockAdminLogs: AdminLog[] = []
+
+export function addAdminLog(action: string, admin: string) {
+  mockAdminLogs.push({
+    id: Date.now().toString(),
+    action,
+    admin,
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -1,6 +1,7 @@
 import type { Bill, BillPayment, BillStatus } from "@/types/bill"
 import { mockOrders } from "./mock-orders"
 import { mockCustomers } from "./mock-customers"
+import { addAdminLog } from "./mock-admin-logs"
 
 export let mockBills: Bill[] = []
 
@@ -24,6 +25,7 @@ export function createBill(
     bill.hidden = true
   }
   mockBills.push(bill)
+  addAdminLog(`create bill ${bill.id}`, 'mockAdminId')
   return bill
 }
 
@@ -33,7 +35,10 @@ export function getBill(id: string): Bill | null {
 
 export function confirmBill(id: string) {
   const b = getBill(id)
-  if (b) b.status = "paid"
+  if (b) {
+    b.status = "paid"
+    addAdminLog(`confirm bill ${id}`, 'mockAdminId')
+  }
 }
 
 export function addBillPayment(id: string, payment: BillPayment) {

--- a/lib/mock-claims.ts
+++ b/lib/mock-claims.ts
@@ -1,0 +1,27 @@
+export interface Claim {
+  id: string
+  orderId: string
+  image: string
+  reason: string
+  status: 'pending' | 'approved' | 'rejected'
+}
+
+let initialClaims: Claim[] = []
+export let mockClaims: Claim[] = [...initialClaims]
+
+export function createClaim(data: Omit<Claim, 'id' | 'status'>) {
+  const newClaim: Claim = {
+    id: Date.now().toString(),
+    status: 'pending',
+    ...data,
+  }
+  mockClaims.push(newClaim)
+  return newClaim
+}
+
+export function updateClaim(id: string, data: Partial<Claim>) {
+  const idx = mockClaims.findIndex(c => c.id === id)
+  if (idx !== -1) {
+    mockClaims[idx] = { ...mockClaims[idx], ...data }
+  }
+}

--- a/lib/mock-export.ts
+++ b/lib/mock-export.ts
@@ -1,0 +1,6 @@
+export function exportCSV<T extends object>(rows: T[]): string {
+  const keys = Object.keys(rows[0] || {})
+  const header = keys.join(',')
+  const data = rows.map(r => keys.map(k => (r as any)[k]).join(',')).join('\n')
+  return [header, data].join('\n')
+}

--- a/lib/mock-media.ts
+++ b/lib/mock-media.ts
@@ -1,0 +1,16 @@
+import { mockReviewImages } from './mock-review-images'
+import { mockProducts } from './mock-products'
+import { mockClaims } from './mock-claims'
+
+export interface MediaItem {
+  id: string
+  url: string
+  source: string
+}
+
+export function getMedia(): MediaItem[] {
+  const claimImages = mockClaims.map(c => ({ id: c.id, url: c.image, source: 'claim' }))
+  const reviewImages = mockReviewImages.map((r, idx) => ({ id: 'review-' + idx, url: r.url, source: 'review' }))
+  const productImages = mockProducts.flatMap(p => p.images.map((url, idx) => ({ id: `${p.id}-${idx}`, url, source: 'product' })))
+  return [...claimImages, ...reviewImages, ...productImages]
+}

--- a/lib/mock-settings.ts
+++ b/lib/mock-settings.ts
@@ -1,3 +1,4 @@
+export const isDevMock = true;
 export let autoMessage = "ขอบคุณที่สั่งซื้อกับเรา";
 export let socialLinks = { facebook: "", line: "" };
 


### PR DESCRIPTION
## Summary
- add claim management page
- implement admin log tracking
- add media gallery and CSV export helpers
- guard dev page with `isDevMock`
- allow customers to file claims from invoices

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68738b2290288325a84308fbd01e3ead