### PR TITLE
Add dynamic image format support

### DIFF
--- a/app/admin/fabrics/[id]/edit/page.tsx
+++ b/app/admin/fabrics/[id]/edit/page.tsx
@@ -87,7 +87,7 @@ export default function EditFabricPage({ params }: EditFabricPageProps) {
           .single()
         if (data?.slug) slug = data.slug
       }
-      const processedFile = await prepareFabricImage(imageFile, slug, 1)
+      const processedFile = await prepareFabricImage(imageFile, slug, 1, 'image/webp')
       const fileName = processedFile.name
       const { error: uploadError } = await supabase.storage
         .from("fabric-images")
@@ -152,7 +152,7 @@ export default function EditFabricPage({ params }: EditFabricPageProps) {
                 <Input
                   id="image"
                   type="file"
-                  accept="image/png, image/jpeg"
+                  accept="image/png, image/jpeg, image/webp"
                   onChange={(e) => {
                     const file = e.target.files?.[0]
                     if (file) {

--- a/app/admin/fabrics/create/page.tsx
+++ b/app/admin/fabrics/create/page.tsx
@@ -53,7 +53,7 @@ export default function CreateFabricPage() {
           .single()
         if (data?.slug) slug = data.slug
       }
-      const processedFile = await prepareFabricImage(imageFile, slug, 1)
+      const processedFile = await prepareFabricImage(imageFile, slug, 1, 'image/webp')
       const fileName = processedFile.name
       const { error: uploadError } = await supabase.storage
         .from("fabric-images")
@@ -115,7 +115,7 @@ export default function CreateFabricPage() {
                 <Input
                   id="image"
                   type="file"
-                  accept="image/png, image/jpeg"
+                  accept="image/png, image/jpeg, image/webp"
                   onChange={(e) => {
                     const file = e.target.files?.[0]
                     if (file) {


### PR DESCRIPTION
## Summary
- allow picking `image/webp` or `image/png` output
- tweak compression until file is under 300KB
- export processed fabrics as WebP
- update fabric upload forms to accept WebP

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_68739d015488832591ca67533aae6435