### PR TITLE
Add SKU support and copy button

### DIFF
--- a/app/admin/fabrics/[id]/page.tsx
+++ b/app/admin/fabrics/[id]/page.tsx
@@ -17,6 +17,7 @@ interface FabricDetailPageProps {
 interface Fabric {
   id: string
   name: string
+  sku: string
   collection_id: string
   image_urls: string[]
   price_min: number
@@ -50,7 +51,7 @@ export default function FabricDetailPage({ params }: FabricDetailPageProps) {
       }
       const { data, error } = await supabase
         .from("fabrics")
-        .select("id, name, collection_id, image_urls, price_min, price_max")
+        .select("id, name, sku, collection_id, image_urls, price_min, price_max")
         .eq("id", params.id)
         .single()
       if (error || !data) {
@@ -119,6 +120,7 @@ export default function FabricDetailPage({ params }: FabricDetailPageProps) {
                   <p>คอลเลกชัน: {collectionName}</p>
                 )}
                 <p>รหัสคอลเลกชัน: {fabric.collection_id}</p>
+                <p>SKU: {fabric.sku}</p>
                 <p>
                   ราคา: ฿{fabric.price_min.toLocaleString()} - ฿{fabric.price_max.toLocaleString()}
                 </p>

--- a/app/admin/fabrics/create/page.tsx
+++ b/app/admin/fabrics/create/page.tsx
@@ -69,8 +69,18 @@ export default function CreateFabricPage() {
       setImageUrl(uploadedUrl)
     }
 
+    const { data: last } = await supabase
+      .from("fabrics")
+      .select("sku")
+      .order("sku", { ascending: false })
+      .limit(1)
+      .single()
+    const lastNum = last?.sku ? parseInt(last.sku.split("-")[1]) : 0
+    const sku = `FBC-${String(lastNum + 1).padStart(3, "0")}`
+
     const { error } = await supabase.from("fabrics").insert({
       name,
+      sku,
       image_url: uploadedUrl,
       collection_id: collectionId,
     })

--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -24,6 +24,7 @@ import { useToast } from "@/hooks/use-toast"
 interface Fabric {
   id: string
   name: string
+  sku: string
   collection_id: string
   image_url: string | null
   price_min: number
@@ -82,7 +83,7 @@ export default function AdminFabricsPage() {
       if (!supabase) return
       const { data: fabricsData, error } = await supabase
         .from("fabrics")
-        .select("id, name, collection_id, image_url, price_min, price_max")
+        .select("id, name, sku, collection_id, image_url, price_min, price_max")
       if (error || !fabricsData) {
         console.error("Failed to fetch fabrics", error)
         return

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -14,6 +14,7 @@ interface Fabric {
   id: string
   slug: string
   name: string
+  sku: string
   color: string
   price: number
   images: string[]
@@ -24,7 +25,11 @@ export default function ComparePage() {
   const [fabrics, setFabrics] = useState<Fabric[]>([])
 
   useEffect(() => {
-    setFabrics(mockFabrics.filter((f) => items.includes(f.slug)))
+    setFabrics(
+      mockFabrics
+        .filter((f) => items.includes(f.slug))
+        .map((f) => ({ ...f }))
+    )
   }, [items])
 
   if (fabrics.length === 0) {

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -11,11 +11,13 @@ import { mockFabrics } from "@/lib/mock-fabrics"
 import { notFound } from "next/navigation"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 import { MessageSquare, Share2, Receipt } from "lucide-react"
+import { CopyToClipboardButton } from "@/components/CopyToClipboardButton"
 
 interface Fabric {
   id: string
   slug: string | null
   name: string
+  sku?: string | null
   description?: string | null
   size?: string | null
   collection_id?: string | null
@@ -40,7 +42,7 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   }
   const { data } = await supabase
     .from("fabrics")
-    .select("name, description, image_url, image_urls")
+    .select("name, description, sku, image_url, image_urls")
     .eq("slug", params.slug)
     .single()
   if (!data) return {}
@@ -71,6 +73,7 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
       id: f!.id,
       slug: f!.slug,
       name: f!.name,
+      sku: f!.sku,
       description: '',
       image_urls: f!.images,
       price_min: f!.price,
@@ -79,7 +82,7 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
   } else {
     const { data, error } = await supabase
       .from("fabrics")
-      .select("id, slug, name, description, size, collection_id, image_url, image_urls, price_min, price_max")
+      .select("id, slug, name, sku, description, size, collection_id, image_url, image_urls, price_min, price_max")
       .eq("slug", params.slug)
       .single()
 
@@ -132,6 +135,9 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
             {fabric.size && (
               <p className="text-gray-600">ขนาด: {fabric.size}</p>
             )}
+            {fabric.sku && (
+              <p className="text-gray-600">SKU: {fabric.sku}</p>
+            )}
             {collection && (
               <p className="text-gray-600">
                 คอลเลกชัน:{" "}
@@ -157,6 +163,7 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
               <Button variant="outline" size="lg">
                 <Receipt className="h-5 w-5 mr-2" />เปิดบิล
               </Button>
+              <CopyToClipboardButton text={fabric.slug || fabric.sku || fabric.id} />
               <Button variant="outline" size="lg">
                 <Share2 className="h-5 w-5" />
               </Button>

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -15,6 +15,7 @@ interface Fabric {
   id: string
   slug: string | null
   name: string
+  sku?: string | null
   image_url?: string | null
   image_urls?: string[] | null
 }
@@ -26,12 +27,13 @@ export default async function FabricsPage() {
       id: f.id,
       slug: f.slug,
       name: f.name,
+      sku: f.sku,
       image_urls: f.images,
     }))
   } else {
     const { data, error } = await supabase
       .from("fabrics")
-      .select("id, slug, name, image_url, image_urls")
+      .select("id, slug, name, sku, image_url, image_urls")
 
     if (error || !data) {
       return (

--- a/components/CopyToClipboardButton.tsx
+++ b/components/CopyToClipboardButton.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { Copy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function CopyToClipboardButton({ text }: { text: string }) {
+  const handleClick = () => {
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.error("Failed to copy", err)
+    })
+  }
+
+  return (
+    <Button variant="outline" size="lg" onClick={handleClick} aria-label="copy">
+      <Copy className="h-5 w-5" />
+    </Button>
+  )
+}

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -11,6 +11,7 @@ interface Fabric {
   id: string
   slug: string | null
   name: string
+  sku?: string | null
   image_url?: string | null
   image_urls?: string[] | null
 }

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -4,6 +4,7 @@ export interface Fabric {
   id: string
   name: string
   slug: string
+  sku: string
   color: string
   price: number
   images: string[]
@@ -14,6 +15,7 @@ export const mockFabrics: Fabric[] = [
     id: 'f01',
     name: 'Soft Linen',
     slug: 'soft-linen',
+    sku: 'FBC-001',
     color: 'ครีม',
     price: 990,
     images: ['/images/039.jpg', '/images/040.jpg'],
@@ -22,6 +24,7 @@ export const mockFabrics: Fabric[] = [
     id: 'f02',
     name: 'Cozy Cotton',
     slug: 'cozy-cotton',
+    sku: 'FBC-002',
     color: 'เทา',
     price: 1090,
     images: ['/images/041.jpg', '/images/042.jpg'],
@@ -30,6 +33,7 @@ export const mockFabrics: Fabric[] = [
     id: 'f03',
     name: 'Velvet Dream',
     slug: 'velvet-dream',
+    sku: 'FBC-003',
     color: 'น้ำเงิน',
     price: 1290,
     images: ['/images/043.jpg', '/images/044.jpg'],
@@ -38,6 +42,7 @@ export const mockFabrics: Fabric[] = [
     id: 'f04',
     name: 'Classic Stripe',
     slug: 'classic-stripe',
+    sku: 'FBC-004',
     color: 'กรม',
     price: 1190,
     images: ['/images/045.jpg', '/images/046.jpg'],
@@ -46,6 +51,7 @@ export const mockFabrics: Fabric[] = [
     id: 'f05',
     name: 'Floral Muse',
     slug: 'floral-muse',
+    sku: 'FBC-005',
     color: 'ชมพู',
     price: 1090,
     images: ['/images/047.jpg', '/images/035.jpg'],


### PR DESCRIPTION
## Summary
- add `sku` to fabric mock data
- extend Fabric types with a new `sku` field
- generate unique SKUs when creating fabrics
- show SKU data in admin and fabric detail pages
- allow copying the slug/SKU from fabric detail page

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68739e70983883258ba824ce73c13cce