### PR TITLE
Add chat-customer linking admin page

### DIFF
--- a/app/admin/chat-customers/page.tsx
+++ b/app/admin/chat-customers/page.tsx
@@ -1,0 +1,74 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { mockConversations } from '@/lib/mock-chat'
+import { mockCustomers } from '@/lib/mock-customers'
+import { chatCustomerLinks, loadChatCustomerLinks, linkCustomer } from '@/lib/mock-chat-customer-links'
+
+export default function ChatCustomerLinksPage() {
+  const [links, setLinks] = useState(chatCustomerLinks)
+
+  useEffect(() => {
+    loadChatCustomerLinks()
+    setLinks([...chatCustomerLinks])
+  }, [])
+
+  const handleLink = (conversationId: string, customerId: string) => {
+    linkCustomer(conversationId, customerId)
+    setLinks([...chatCustomerLinks])
+  }
+
+  const getSelected = (conversationId: string) =>
+    links.find((l) => l.conversationId === conversationId)?.customerId || ''
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="container mx-auto space-y-4">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/chat">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ผูกลูกค้ากับแชท</h1>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ห้องแชท</TableHead>
+              <TableHead>ลูกค้า</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {mockConversations.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell>{c.name}</TableCell>
+                <TableCell>
+                  <Select
+                    value={getSelected(c.id)}
+                    onValueChange={(val) => handleLink(c.id, val)}
+                  >
+                    <SelectTrigger className="w-48">
+                      <SelectValue placeholder="เลือกลูกค้า" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {mockCustomers.map((cu) => (
+                        <SelectItem key={cu.id} value={cu.id}>
+                          {cu.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle, FileText } from "lucide-react"
+import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle, FileText, Link2 } from "lucide-react"
 import clsx from "clsx"
 
 const navItems = [
@@ -15,6 +15,7 @@ const navItems = [
   { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
   { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
+  { href: "/admin/chat-customers", label: "ผูกลูกค้ากับแชท", icon: Link2 },
 ]
 
 export default function Sidebar({ className = "" }: { className?: string }) {

--- a/lib/mock-chat-customer-links.ts
+++ b/lib/mock-chat-customer-links.ts
@@ -1,0 +1,37 @@
+export interface ChatCustomerLink {
+  conversationId: string
+  customerId: string
+}
+
+export let chatCustomerLinks: ChatCustomerLink[] = []
+
+export function loadChatCustomerLinks() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatCustomerLinks')
+    if (stored) chatCustomerLinks = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatCustomerLinks', JSON.stringify(chatCustomerLinks))
+  }
+}
+
+export function linkCustomer(conversationId: string, customerId: string) {
+  const existing = chatCustomerLinks.find((l) => l.conversationId === conversationId)
+  if (existing) {
+    existing.customerId = customerId
+  } else {
+    chatCustomerLinks.push({ conversationId, customerId })
+  }
+  save()
+}
+
+import { mockCustomers } from './mock-customers'
+
+export function getCustomerByConversation(conversationId: string) {
+  const link = chatCustomerLinks.find((l) => l.conversationId === conversationId)
+  if (!link) return undefined
+  return mockCustomers.find((c) => c.id === link.customerId)
+}

--- a/lib/mock-chat.ts
+++ b/lib/mock-chat.ts
@@ -1,5 +1,17 @@
 export let chatWelcome = 'สวัสดีค่ะ มีอะไรให้ช่วยไหม?'
 
+export interface ChatConversation {
+  id: string
+  name: string
+  lastMessage: string
+}
+
+export const mockConversations: ChatConversation[] = [
+  { id: 'conv-001', name: 'John Doe', lastMessage: 'สวัสดีครับ' },
+  { id: 'conv-002', name: 'Jane Smith', lastMessage: 'สนใจสินค้าค่ะ' },
+  { id: 'conv-003', name: 'Mike Johnson', lastMessage: 'ขอรายละเอียดเพิ่ม' },
+]
+
 export function loadChatWelcome() {
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('chatWelcome')


### PR DESCRIPTION
## Summary
- manage mapping between chat conversations and customers
- add minimal mock conversation data
- allow selecting customer for each conversation
- link to new screen from sidebar

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873a981b550832598f5a041a8534f00