### PR TITLE
Implement chat templates and messaging hooks

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import OrderStatusDropdown from "@/components/admin/orders/OrderStatusDropdown"
 import { OrderTimeline, type TimelineEntry } from "@/components/order/OrderTimeline"
-import { mockOrders, setPackingStatus } from "@/lib/mock-orders"
+import { mockOrders, setPackingStatus, setOrderStatus } from "@/lib/mock-orders"
 import type { Order } from "@/types/order"
 import type { OrderStatus, ShippingStatus, PackingStatus } from "@/types/order"
 import { shippingStatusOptions, packingStatusOptions } from "@/types/order"
@@ -37,7 +37,7 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
 
   const handleAddEntry = (entry: TimelineEntry) => {
     mockOrders[orderIndex].timeline.push(entry)
-    mockOrders[orderIndex].status = entry.status
+    setOrderStatus(order.id, entry.status)
     setStatus(entry.status)
     toast.success("บันทึกสถานะแล้ว")
   }

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -11,7 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Search, ArrowLeft, Eye, FileText, Edit, Copy, ExternalLink } from "lucide-react"
 import Link from "next/link"
 import { toast } from "sonner"
-import { mockOrders, setPackingStatus } from "@/lib/mock-orders"
+import { mockOrders, setPackingStatus, setOrderStatus } from "@/lib/mock-orders"
 import { mockCustomers } from "@/lib/mock-customers"
 import { createBill, confirmBill, mockBills } from "@/lib/mock-bills"
 import { exportCSV } from "@/lib/mock-export"
@@ -53,6 +53,7 @@ export default function AdminOrdersPage() {
 
   const updateOrderStatus = (orderId: string, newStatus: OrderStatus) => {
     setOrders(orders.map((order) => (order.id === orderId ? { ...order, status: newStatus } : order)))
+    setOrderStatus(orderId, newStatus)
   }
 
   const updatePackingStatus = (orderId: string, status: PackingStatus) => {
@@ -78,14 +79,6 @@ export default function AdminOrdersPage() {
     confirmBill(billId)
     setBills([...mockBills])
     updateOrderStatus(orderId, "paid")
-    const idx = mockOrders.findIndex((o) => o.id === orderId)
-    if (idx !== -1) {
-      mockOrders[idx].timeline.push({
-        timestamp: new Date().toISOString(),
-        status: "paid",
-        updatedBy: "admin@nutlove.co",
-      })
-    }
     toast.success("ยืนยันยอดแล้ว")
   }
 

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -2,6 +2,7 @@ import type { Bill, BillPayment, BillStatus } from "@/types/bill"
 import { mockOrders } from "./mock-orders"
 import { mockCustomers } from "./mock-customers"
 import { addAdminLog } from "./mock-admin-logs"
+import { addChatMessage } from "./mock-chat-messages"
 
 export let mockBills: Bill[] = []
 
@@ -26,6 +27,7 @@ export function createBill(
   }
   mockBills.push(bill)
   addAdminLog(`create bill ${bill.id}`, 'mockAdminId')
+  addChatMessage(orderId, 'bill_created')
   return bill
 }
 

--- a/lib/mock-chat-messages.ts
+++ b/lib/mock-chat-messages.ts
@@ -1,0 +1,31 @@
+import { getChatTemplate } from './mock-chat-templates'
+
+export interface ChatMessageEntry {
+  id: string
+  conversationId: string
+  templateId: string
+  text: string
+  createdAt: string
+}
+
+export const chatMessages: Record<string, ChatMessageEntry[]> = {}
+
+export function addChatMessage(conversationId: string, templateId: string): ChatMessageEntry | null {
+  const template = getChatTemplate(templateId)
+  if (!template) return null
+  const msg: ChatMessageEntry = {
+    id: Date.now().toString(),
+    conversationId,
+    templateId,
+    text: template.text,
+    createdAt: new Date().toISOString(),
+  }
+  if (!chatMessages[conversationId]) chatMessages[conversationId] = []
+  chatMessages[conversationId].push(msg)
+  return msg
+}
+
+export function listChatMessages(conversationId: string): ChatMessageEntry[] {
+  return chatMessages[conversationId] || []
+}
+

--- a/lib/mock-chat-templates.ts
+++ b/lib/mock-chat-templates.ts
@@ -1,0 +1,29 @@
+export interface ChatTemplate {
+  id: string
+  name: string
+  text: string
+}
+
+export let chatTemplates: ChatTemplate[] = [
+  { id: 'bill_created', name: 'สร้างบิล', text: 'เราได้ออกบิลใหม่ให้คุณแล้วค่ะ' },
+  { id: 'status_paid', name: 'ยืนยันการชำระ', text: 'ออเดอร์ของคุณชำระเรียบร้อยแล้วค่ะ' },
+]
+
+export function loadChatTemplates() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatTemplates')
+    if (stored) chatTemplates = JSON.parse(stored)
+  }
+}
+
+export function setChatTemplates(templates: ChatTemplate[]) {
+  chatTemplates = templates
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatTemplates', JSON.stringify(templates))
+  }
+}
+
+export function getChatTemplate(id: string): ChatTemplate | undefined {
+  return chatTemplates.find((t) => t.id === id)
+}
+

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -1,6 +1,7 @@
 import type { OrderStatus, ShippingStatus, Order, PackingStatus } from "@/types/order"
 
 import { supabase } from "./supabase"
+import { addChatMessage } from "./mock-chat-messages"
 
 const initialMockOrders: Order[] = [
   {
@@ -121,6 +122,20 @@ export function regenerateMockOrders() {
 export function setPackingStatus(orderId: string, status: PackingStatus) {
   const order = mockOrders.find((o) => o.id === orderId)
   if (order) order.packingStatus = status
+}
+
+export function setOrderStatus(orderId: string, status: OrderStatus) {
+  const order = mockOrders.find((o) => o.id === orderId)
+  if (!order) return
+  if (order.status !== status) {
+    order.status = status
+    order.timeline.push({
+      timestamp: new Date().toISOString(),
+      status,
+      updatedBy: "admin@nutlove.co",
+    })
+    addChatMessage(orderId, 'status_' + status)
+  }
 }
 
 export async function fetchOrders(): Promise<Order[]> {

--- a/lib/order-database.ts
+++ b/lib/order-database.ts
@@ -1,4 +1,5 @@
 import type { ManualOrder } from "@/types/order"
+import { addChatMessage } from "./mock-chat-messages"
 
 // Mock database for manual orders
 const manualOrders: ManualOrder[] = [
@@ -209,6 +210,7 @@ export const orderDb = {
             status: updates.status,
             updatedBy: "admin@nutlove.co",
           })
+          addChatMessage(id, 'status_' + updates.status)
         }
 
         manualOrders[index] = {


### PR DESCRIPTION
## Summary
- add editable chat templates and in-memory chat message store
- generate a message when bills are created or orders change status
- keep admin pages using new order status helper

## Testing
- `pnpm test`
- `pnpm eslint`

------
https://chatgpt.com/codex/tasks/task_e_6873ab3366748325b78d7d8de7481a23