### PR TITLE
Add chat activity tracking

### DIFF
--- a/app/admin/chat-activity/page.tsx
+++ b/app/admin/chat-activity/page.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { chatActivity, loadChatActivity, type ChatActivity } from "@/lib/mock-chat-activity"
+import { mockCustomers } from "@/lib/mock-customers"
+
+export default function AdminChatActivityPage() {
+  const [customerId, setCustomerId] = useState("all")
+  const [activity, setActivity] = useState<ChatActivity[]>([])
+
+  useEffect(() => {
+    loadChatActivity()
+    setActivity([...chatActivity])
+  }, [])
+
+  const filtered =
+    customerId === "all"
+      ? activity
+      : activity.filter((a) => a.customerId === customerId)
+
+  const getName = (id: string) =>
+    mockCustomers.find((c) => c.id === id)?.name || id
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-8">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">กิจกรรมแชท</h1>
+        </div>
+        <div className="mb-4 flex items-center space-x-2">
+          <span className="text-sm">ลูกค้า</span>
+          <Select value={customerId} onValueChange={setCustomerId}>
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">ทั้งหมด</SelectItem>
+              {mockCustomers.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>บันทึก ({filtered.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>เวลา</TableHead>
+                  <TableHead>ลูกค้า</TableHead>
+                  <TableHead>การกระทำ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell>{new Date(a.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>{getName(a.customerId)}</TableCell>
+                    <TableCell>{a.action}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -4,8 +4,14 @@ import { useEffect, useState } from "react";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { chatWelcome, loadChatWelcome } from "@/lib/mock-chat";
+import {
+  addChatActivity,
+  loadChatActivity,
+} from "@/lib/mock-chat-activity";
+import { useAuth } from "@/contexts/auth-context";
 
 export default function ChatPage() {
+  const { user, guestId } = useAuth();
   const chatwootUrl =
     process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
   const [message, setMessage] = useState(chatWelcome);
@@ -14,6 +20,8 @@ export default function ChatPage() {
     loadChatWelcome();
     setMessage(chatWelcome);
     window.open(chatwootUrl, "_blank");
+    loadChatActivity();
+    addChatActivity(user?.id || guestId!, "open_chat");
   }, [chatwootUrl]);
 
   return (

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,8 +3,11 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Home, Search, ArrowLeft } from "lucide-react"
+import { addChatActivity, loadChatActivity } from "@/lib/mock-chat-activity"
+import { useAuth } from "@/contexts/auth-context"
 
 export default function NotFound() {
+  const { user, guestId } = useAuth()
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50">
       <div className="text-center space-y-8 px-4">
@@ -66,10 +69,14 @@ export default function NotFound() {
                 ติดต่อเรา
               </Button>
             </Link>
-            <Link href="/chat">
-              <Button variant="ghost" size="sm">
-                แชทสด
-              </Button>
+            <Link
+              href="/chat"
+              onClick={() => {
+                loadChatActivity()
+                addChatActivity(user?.id || guestId!, "open_chat")
+              }}
+            >
+              <Button variant="ghost" size="sm">แชทสด</Button>
             </Link>
           </div>
         </div>

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle, FileText } from "lucide-react"
+import { Home, ShoppingCart, Package, Layers, Users, Percent, Bell, MessageCircle, FileText, List } from "lucide-react"
 import clsx from "clsx"
 
 const navItems = [
@@ -15,6 +15,7 @@ const navItems = [
   { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
   { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
+  { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List },
 ]
 
 export default function Sidebar({ className = "" }: { className?: string }) {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -33,12 +33,13 @@ import {
 import { useCart } from "@/contexts/cart-context"
 import { useAuth } from "@/contexts/auth-context"
 import { useDevelopmentNotice } from "@/hooks/use-development-notice"
+import { addChatActivity, loadChatActivity } from "@/lib/mock-chat-activity"
 
 export function Navbar() {
   const [searchQuery, setSearchQuery] = useState("")
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const { state } = useCart()
-  const { user, isAuthenticated, logout } = useAuth()
+  const { user, guestId, isAuthenticated, logout } = useAuth()
   const router = useRouter()
   const { showDevelopmentNotice } = useDevelopmentNotice()
 
@@ -168,7 +169,16 @@ export function Navbar() {
 
                   {userMenuItems.map((item) => (
                     <DropdownMenuItem key={item.name} asChild>
-                      <Link href={item.href} className="flex items-center">
+                      <Link
+                        href={item.href}
+                        onClick={() => {
+                          if (item.href === "/chat") {
+                            loadChatActivity()
+                            addChatActivity(user?.id || guestId!, "open_chat")
+                          }
+                        }}
+                        className="flex items-center"
+                      >
                         <item.icon className="mr-2 h-4 w-4" />
                         {item.name}
                       </Link>
@@ -247,6 +257,12 @@ export function Navbar() {
                           <Link
                             key={item.name}
                             href={item.href}
+                            onClick={() => {
+                              if (item.href === "/chat") {
+                                loadChatActivity()
+                                addChatActivity(user?.id || guestId!, "open_chat")
+                              }
+                            }}
                             className="flex items-center px-3 py-2 text-sm font-medium rounded-md hover:bg-accent"
                           >
                             <item.icon className="mr-2 h-4 w-4" />

--- a/lib/mock-chat-activity.ts
+++ b/lib/mock-chat-activity.ts
@@ -1,0 +1,38 @@
+export interface ChatActivity {
+  id: string
+  customerId: string
+  action: string
+  timestamp: string
+}
+
+export let chatActivity: ChatActivity[] = []
+
+export function loadChatActivity() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatActivity')
+    if (stored) chatActivity = JSON.parse(stored)
+  }
+}
+
+export function saveChatActivity() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatActivity', JSON.stringify(chatActivity))
+  }
+}
+
+export function addChatActivity(customerId: string, action: string) {
+  const entry: ChatActivity = {
+    id: Date.now().toString(),
+    customerId,
+    action,
+    timestamp: new Date().toISOString(),
+  }
+  chatActivity.push(entry)
+  saveChatActivity()
+}
+
+export function listChatActivity(customerId?: string) {
+  return customerId
+    ? chatActivity.filter((a) => a.customerId === customerId)
+    : chatActivity
+}


### PR DESCRIPTION
## Summary
- record chat usage in `mock-chat-activity`
- log customer visits to chat
- display activity timeline in admin area
- expose new admin sidebar link

## Testing
- `npm test`
- `npm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_6873aecf7e8c83259c527336ba3d7d7c