### PR TITLE
Add admin customer notes

### DIFF
--- a/app/admin/chat-insight/page.tsx
+++ b/app/admin/chat-insight/page.tsx
@@ -11,12 +11,19 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { listChatBills, loadChatBills } from '@/lib/mock-chat-bills'
+import {
+  addCustomerNote,
+  listCustomerNotes,
+  loadCustomerNotes,
+} from '@/lib/mock-customer-notes'
 import { format } from 'date-fns'
 
 export default function ChatInsightPage() {
   const [bills, setBills] = useState(listChatBills())
+  const [, setRefresh] = useState(0)
   useEffect(() => {
     loadChatBills()
+    loadCustomerNotes()
     setBills(listChatBills())
   }, [])
 
@@ -30,6 +37,7 @@ export default function ChatInsightPage() {
             <TableHead>ลูกค้า</TableHead>
             <TableHead>สินค้า</TableHead>
             <TableHead>สถานะ</TableHead>
+            <TableHead>โน้ต</TableHead>
             <TableHead className="w-24"></TableHead>
           </TableRow>
         </TableHeader>
@@ -40,6 +48,26 @@ export default function ChatInsightPage() {
               <TableCell>{b.fbName}</TableCell>
               <TableCell>{b.items.map((i) => i.name).join(', ')}</TableCell>
               <TableCell>{b.status}</TableCell>
+              <TableCell className="space-y-1">
+                {listCustomerNotes(b.sessionId).map((n) => (
+                  <p key={n.id} className="text-xs text-gray-500">
+                    {n.note}
+                  </p>
+                ))}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const txt = window.prompt('เพิ่มโน้ต')
+                    if (txt) {
+                      addCustomerNote(b.sessionId, txt)
+                      setRefresh((v) => v + 1)
+                    }
+                  }}
+                >
+                  เพิ่มโน้ต
+                </Button>
+              </TableCell>
               <TableCell>
                 <Link href={`/chat-bill/${b.billId}`}>
                   <Button variant="outline" size="sm">เปิดลิงก์</Button>

--- a/lib/mock-customer-notes.ts
+++ b/lib/mock-customer-notes.ts
@@ -1,0 +1,37 @@
+export interface CustomerNote {
+  id: string
+  customerId: string
+  note: string
+  createdAt: string
+}
+
+export let customerNotes: CustomerNote[] = []
+
+export function loadCustomerNotes() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('customerNotes')
+    if (stored) customerNotes = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('customerNotes', JSON.stringify(customerNotes))
+  }
+}
+
+export function addCustomerNote(customerId: string, note: string): CustomerNote {
+  const entry: CustomerNote = {
+    id: Date.now().toString(),
+    customerId,
+    note,
+    createdAt: new Date().toISOString(),
+  }
+  customerNotes = [entry, ...customerNotes]
+  save()
+  return entry
+}
+
+export function listCustomerNotes(customerId: string): CustomerNote[] {
+  return customerNotes.filter((n) => n.customerId === customerId)
+}


### PR DESCRIPTION
## Summary
- implement `mock-customer-notes` with localStorage persistence
- allow admins to add notes per chat bill via Chat Insight page

## Testing
- `npx --yes pnpm eslint`
- `npx --yes pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6873b0c8a7ac83259d122d8efdc0d611