### PR TITLE
Add toast notifications for chat activity

### DIFF
--- a/lib/mock-chat-activity.ts
+++ b/lib/mock-chat-activity.ts
@@ -20,6 +20,8 @@ export function saveChatActivity() {
   }
 }
 
+export const CHAT_ACTIVITY_EVENT = 'chatActivity'
+
 export function addChatActivity(customerId: string, action: string) {
   const entry: ChatActivity = {
     id: Date.now().toString(),
@@ -29,6 +31,9 @@ export function addChatActivity(customerId: string, action: string) {
   }
   chatActivity.push(entry)
   saveChatActivity()
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(CHAT_ACTIVITY_EVENT, { detail: entry }))
+  }
 }
 
 export function listChatActivity(customerId?: string) {


### PR DESCRIPTION
## Summary
- emit `chatActivity` events when activity is added
- show toast on the admin chat activity page when a customer with pending orders sends a message or reopens chat

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b2a372e88325b9ec1a144f277ff3