### PR TITLE
Add mock recommendation features

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/hooks/use-toast"
 import { mockOrders } from "@/lib/mock-orders"
 import type { OrderStatus, ShippingStatus } from "@/types/order"
 import { db } from "@/lib/database"
+import { SuggestedExtras } from "@/components/SuggestedExtras"
 
 export default function CheckoutPage() {
   const { state, dispatch } = useCart()
@@ -414,6 +415,7 @@ export default function CheckoutPage() {
                   </div>
 
                   <Separator />
+                  <SuggestedExtras />
 
                   {/* Price Breakdown */}
                   <div className="space-y-2">

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { notFound } from "next/navigation"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 import { MessageSquare, Share2, Receipt } from "lucide-react"
 import { CopyToClipboardButton } from "@/components/CopyToClipboardButton"
+import { FabricSuggestions } from "@/components/FabricSuggestions"
 
 interface Fabric {
   id: string
@@ -171,6 +172,7 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
           </div>
         </div>
       </div>
+      <FabricSuggestions slug={params.slug} />
       <Footer />
       <AnalyticsTracker event="ViewContent" />
     </div>

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useAuth } from "@/contexts/auth-context"
 import type { ShippingStatus } from "@/types/order"
 import { loadSocialLinks, socialLinks } from "@/lib/mock-settings"
+import { RecommendedAddons } from "@/components/RecommendedAddons"
 
 export default function ProductDetailPage({ params }: { params: { slug: string } }) {
   const { slug } = params
@@ -500,6 +501,8 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
             </TabsContent>
           </Tabs>
         </div>
+
+        <RecommendedAddons slug={product.slug} />
 
         {/* Related Products */}
         <div className="mt-16">

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -13,6 +13,7 @@ import { Star, Filter, Grid, List } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
 import { mockProducts } from "@/lib/mock-products"
+import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
 export default function ProductsPage() {
   const [searchTerm, setSearchTerm] = useState("")
@@ -181,6 +182,9 @@ export default function ProductsPage() {
                               ลด {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}%
                             </Badge>
                           )}
+                          {mockCoViewLog[product.slug] && (
+                            <Badge className="absolute top-2 right-2">ดูด้วยกันบ่อย</Badge>
+                          )}
                         </div>
 
                         <div className="p-4 space-y-2">
@@ -229,6 +233,9 @@ export default function ProductsPage() {
                             <Badge className="absolute top-1 left-1 bg-red-500 text-xs">
                               ลด {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}%
                             </Badge>
+                          )}
+                          {mockCoViewLog[product.slug] && (
+                            <Badge className="absolute top-1 right-1 text-xs">ดูด้วยกันบ่อย</Badge>
                           )}
                         </div>
 

--- a/components/FabricSuggestions.tsx
+++ b/components/FabricSuggestions.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { mockFabrics } from '@/lib/mock-fabrics'
+import { mockFabricSimilarity } from '@/lib/mock-fabric-similarity'
+import { recordFabricClick, getFabricPreference } from '@/lib/mock-user-preference'
+
+interface Props {
+  slug: string
+}
+
+export function FabricSuggestions({ slug }: Props) {
+  const [items, setItems] = useState<typeof mockFabrics>([])
+
+  useEffect(() => {
+    recordFabricClick(slug)
+    const prefs = getFabricPreference()
+    const similar = mockFabricSimilarity[slug] || []
+    const fabrics = mockFabrics.filter((f) => similar.includes(f.slug))
+    fabrics.sort((a, b) => (prefs[b.slug] || 0) - (prefs[a.slug] || 0))
+    setItems(fabrics.slice(0, 4))
+  }, [slug])
+
+  if (items.length === 0) return null
+
+  return (
+    <div className="mt-10">
+      <h2 className="text-2xl font-bold mb-4">คุณอาจชอบลายนี้</h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {items.map((f) => (
+          <Link key={f.slug} href={`/fabrics/${f.slug}`}>\
+            <div className="border rounded-lg overflow-hidden bg-white">
+              <div className="relative aspect-square">
+                <Image src={f.images[0]} alt={f.name} fill className="object-cover" />
+              </div>
+              <p className="p-2 text-center text-sm">{f.name}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/button"
 import { useCompare } from "@/contexts/compare-context"
+import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
 interface Fabric {
   id: string
@@ -30,11 +31,17 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
         {fabrics.map((fabric) => {
           const slug = fabric.slug || fabric.id
           const checked = items.includes(slug)
+          const coViewed = mockCoViewLog[slug]?.length
           return (
             <div
               key={slug}
               className="border rounded-lg overflow-hidden bg-white hover:shadow transition relative"
             >
+              {coViewed && (
+                <span className="absolute top-2 right-2 bg-primary text-white text-xs px-2 py-1 rounded">
+                  ดูด้วยกันบ่อย
+                </span>
+              )}
               <Checkbox
                 checked={checked}
                 onCheckedChange={() => toggleCompare(slug)}

--- a/components/RecommendedAddons.tsx
+++ b/components/RecommendedAddons.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { mockProducts } from '@/lib/mock-products'
+import { mockRelatedProducts } from '@/lib/mock-related-products'
+import { Card, CardContent } from '@/components/ui/card'
+
+export function RecommendedAddons({ slug }: { slug: string }) {
+  const related = mockRelatedProducts[slug] || []
+  const products = mockProducts.filter((p) => related.includes(p.slug))
+
+  if (products.length === 0) return null
+
+  return (
+    <div className="mt-16">
+      <h2 className="text-2xl font-bold mb-8">สินค้าเสริมที่แนะนำ</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {products.map((p) => (
+          <Card key={p.id} className="group hover:shadow-lg transition-shadow">
+            <CardContent className="p-0">
+              <Link href={`/products/${p.slug}`}>\
+                <div className="relative overflow-hidden rounded-t-lg">
+                  <Image
+                    src={p.images[0] || '/placeholder.svg'}
+                    alt={p.name}
+                    width={300}
+                    height={300}
+                    className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                  />
+                </div>
+                <div className="p-4">
+                  <h3 className="font-semibold line-clamp-2 mb-2">{p.name}</h3>
+                  <div className="flex items-center space-x-2">
+                    <span className="text-lg font-bold text-primary">฿{p.price.toLocaleString()}</span>
+                  </div>
+                </div>
+              </Link>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/SuggestedExtras.tsx
+++ b/components/SuggestedExtras.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useMemo, useState } from 'react'
+import Image from 'next/image'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
+import { mockOrders } from '@/lib/mock-orders'
+import { mockProducts } from '@/lib/mock-products'
+import { useCart } from '@/contexts/cart-context'
+
+export function SuggestedExtras() {
+  const { state, dispatch } = useCart()
+  const [selected, setSelected] = useState<string[]>([])
+
+  const suggestions = useMemo(() => {
+    const count: Record<string, number> = {}
+    for (const o of mockOrders) {
+      for (const item of o.items) {
+        count[item.productId] = (count[item.productId] || 0) + 1
+      }
+    }
+    const ids = Object.entries(count)
+      .sort((a, b) => b[1] - a[1])
+      .map(([id]) => id)
+    return ids
+      .filter((id) => !state.items.some((it) => it.id.startsWith(id)))
+      .slice(0, 3)
+  }, [state.items])
+
+  const products = mockProducts.filter((p) => suggestions.includes(p.id))
+
+  const toggle = (id: string) => {
+    setSelected((curr) =>
+      curr.includes(id) ? curr.filter((c) => c !== id) : [...curr, id],
+    )
+  }
+
+  const addToCart = () => {
+    products.forEach((p) => {
+      if (selected.includes(p.id)) {
+        dispatch({
+          type: 'ADD_ITEM',
+          payload: {
+            id: p.id,
+            name: p.name,
+            price: p.price,
+            image: p.images[0],
+            quantity: 1,
+          },
+        })
+      }
+    })
+    setSelected([])
+  }
+
+  if (products.length === 0) return null
+
+  return (
+    <div className="space-y-4 mb-8">
+      <h2 className="text-xl font-bold">ลูกค้ามักซื้อสิ่งนี้เพิ่ม</h2>
+      {products.map((p) => (
+        <div key={p.id} className="flex items-center space-x-3">
+          <Checkbox checked={selected.includes(p.id)} onCheckedChange={() => toggle(p.id)} />
+          <div className="relative w-12 h-12">
+            <Image src={p.images[0] || '/placeholder.svg'} alt={p.name} fill className="object-cover rounded" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium">{p.name}</p>
+            <p className="text-sm text-gray-600">฿{p.price.toLocaleString()}</p>
+          </div>
+        </div>
+      ))}
+      <Button onClick={addToCart} disabled={selected.length === 0}>เพิ่มสินค้า</Button>
+    </div>
+  )
+}

--- a/lib/mock-co-view-log.ts
+++ b/lib/mock-co-view-log.ts
@@ -1,0 +1,4 @@
+export const mockCoViewLog: Record<string, string[]> = {
+  'soft-linen': ['cozy-cotton'],
+  'premium-velvet': ['waterproof-pro'],
+}

--- a/lib/mock-fabric-similarity.ts
+++ b/lib/mock-fabric-similarity.ts
@@ -1,0 +1,7 @@
+export const mockFabricSimilarity: Record<string, string[]> = {
+  'soft-linen': ['cozy-cotton', 'floral-muse'],
+  'cozy-cotton': ['soft-linen', 'classic-stripe'],
+  'velvet-dream': ['classic-stripe', 'floral-muse'],
+  'classic-stripe': ['cozy-cotton', 'velvet-dream'],
+  'floral-muse': ['soft-linen', 'velvet-dream'],
+}

--- a/lib/mock-related-products.ts
+++ b/lib/mock-related-products.ts
@@ -1,0 +1,6 @@
+export const mockRelatedProducts: Record<string, string[]> = {
+  'premium-velvet': ['cotton-blend', 'waterproof-pro'],
+  'cotton-blend': ['premium-velvet'],
+  'waterproof-pro': ['premium-velvet', 'luxury-leather-look'],
+  'luxury-leather-look': ['waterproof-pro'],
+}

--- a/lib/mock-user-preference.ts
+++ b/lib/mock-user-preference.ts
@@ -1,0 +1,17 @@
+export type FabricPreference = Record<string, number>
+
+const STORAGE_KEY = 'fabric-preference'
+
+export function recordFabricClick(slug: string) {
+  if (typeof window === 'undefined') return
+  const raw = localStorage.getItem(STORAGE_KEY)
+  const data: FabricPreference = raw ? JSON.parse(raw) : {}
+  data[slug] = (data[slug] || 0) + 1
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+}
+
+export function getFabricPreference(): FabricPreference {
+  if (typeof window === 'undefined') return {}
+  const raw = localStorage.getItem(STORAGE_KEY)
+  return raw ? JSON.parse(raw) : {}
+}


### PR DESCRIPTION
## Summary
- suggest similar fabrics on fabric detail page
- show recommended add-on products
- display extra purchase suggestions during checkout
- track fabric click behavior in localStorage
- highlight items often viewed together

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873e590256483259e4f88d7d8b774f9