### PR TITLE
Add admin customer management features

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -30,6 +30,21 @@ import {
   setCustomerTier,
   setCustomerMuted,
 } from "@/lib/mock-customers"
+import {
+  loadCustomerNotes,
+  listCustomerNotes,
+  addCustomerNote,
+} from "@/lib/mock-customer-notes"
+import {
+  loadCustomerTags,
+  listCustomerTags,
+  addCustomerTag,
+} from "@/lib/mock-customer-tags"
+import {
+  loadFlaggedUsers,
+  getFlagStatus,
+} from "@/lib/mock-flagged-users"
+import { getLatestChatMessage } from "@/lib/mock-chat-messages"
 
 export default function CustomerDetailPage({
   params,
@@ -38,6 +53,12 @@ export default function CustomerDetailPage({
 }) {
   const { id } = params
   const customer = mockCustomers.find((c) => c.id === id)
+
+  useEffect(() => {
+    loadCustomerNotes()
+    loadCustomerTags()
+    loadFlaggedUsers()
+  }, [])
 
   if (!customer) {
     return (
@@ -52,6 +73,9 @@ export default function CustomerDetailPage({
   const [pointDelta, setPointDelta] = useState(0)
   const [tierValue, setTierValue] = useState<string>(customer.tier || "Silver")
   const [muted, setMuted] = useState<boolean>(customer.muted ?? false)
+  const [noteInput, setNoteInput] = useState("")
+  const [tagInput, setTagInput] = useState("")
+  const latestMessage = getLatestChatMessage(customer.id)
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -66,9 +90,76 @@ export default function CustomerDetailPage({
         </div>
 
         <CustomerCard customer={customer} />
+        {getFlagStatus(customer.id) && (
+          <Badge variant="destructive">ต้องตรวจสอบก่อนตอบ</Badge>
+        )}
+        <div className="space-y-2">
+          <div>
+            <p className="font-semibold">แท็ก</p>
+            <div className="flex flex-wrap gap-1 py-1">
+              {listCustomerTags(customer.id).map((t) => (
+                <Badge key={t.id} variant="secondary">
+                  {t.tag}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex space-x-2 pt-1">
+              <input
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                className="border px-2 py-1 rounded"
+              />
+              <Button
+                variant="outline"
+                onClick={() => {
+                  if (tagInput) {
+                    addCustomerTag(customer.id, tagInput)
+                    setTagInput("")
+                  }
+                }}
+              >
+                เพิ่มแท็ก
+              </Button>
+            </div>
+          </div>
+          <div>
+            <p className="font-semibold">โน้ต</p>
+            <div className="space-y-1 py-1">
+              {listCustomerNotes(customer.id).map((n) => (
+                <p key={n.id} className="text-sm text-gray-500">
+                  {n.note}
+                </p>
+              ))}
+            </div>
+            <div className="flex space-x-2 pt-1">
+              <input
+                value={noteInput}
+                onChange={(e) => setNoteInput(e.target.value)}
+                className="border px-2 py-1 rounded"
+              />
+              <Button
+                variant="outline"
+                onClick={() => {
+                  if (noteInput) {
+                    addCustomerNote(customer.id, noteInput)
+                    setNoteInput("")
+                  }
+                }}
+              >
+                เพิ่มโน้ต
+              </Button>
+            </div>
+          </div>
+        </div>
         <div className="text-lg font-semibold">
           ยอดซื้อรวม: ฿{stats.totalSpent.toLocaleString()}
         </div>
+        {latestMessage && (
+          <div className="text-sm text-gray-600">แชทล่าสุด: {latestMessage.text}</div>
+        )}
+        <Link href="/chat">
+          <Button variant="outline">เปิดใน Chatwoot</Button>
+        </Link>
 
         <Card>
           <CardHeader>

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -14,6 +14,12 @@ import {
   getCustomerOrders,
   type Customer,
 } from "@/lib/mock-customers"
+import {
+  loadCustomerNotes,
+  listCustomerNotes,
+} from "@/lib/mock-customer-notes"
+import { loadCustomerTags, listCustomerTags } from "@/lib/mock-customer-tags"
+import { loadFlaggedUsers, getFlagStatus } from "@/lib/mock-flagged-users"
 import { exportCSV } from "@/lib/mock-export"
 
 
@@ -24,6 +30,9 @@ export default function AdminCustomersPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    loadCustomerNotes()
+    loadCustomerTags()
+    loadFlaggedUsers()
     loadData()
   }, [])
 
@@ -40,6 +49,10 @@ export default function AdminCustomersPage() {
           lastOrderDate: stats.lastOrderDate,
         }
       })
+
+      customersData.sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )
 
       setCustomers(customersData)
     } catch (error) {
@@ -244,13 +257,18 @@ export default function AdminCustomersPage() {
                     </TableCell>
                     <TableCell>
                       <div className="space-y-1">
-                        {customer.tags?.map((tag) => (
-                          <Badge key={tag} variant="secondary" className="mr-1">
-                            {tag}
+                        {listCustomerTags(customer.id).map((t) => (
+                          <Badge key={t.id} variant="secondary" className="mr-1">
+                            {t.tag}
                           </Badge>
                         ))}
-                        {customer.note && (
-                          <p className="text-xs text-gray-500">{customer.note}</p>
+                        {listCustomerNotes(customer.id)[0] && (
+                          <p className="text-xs text-gray-500">
+                            {listCustomerNotes(customer.id)[0].note}
+                          </p>
+                        )}
+                        {getFlagStatus(customer.id) && (
+                          <Badge variant="destructive">ต้องตรวจสอบก่อนตอบ</Badge>
                         )}
                       </div>
                     </TableCell>

--- a/lib/mock-chat-messages.ts
+++ b/lib/mock-chat-messages.ts
@@ -29,3 +29,9 @@ export function listChatMessages(conversationId: string): ChatMessageEntry[] {
   return chatMessages[conversationId] || []
 }
 
+export function getLatestChatMessage(conversationId: string): ChatMessageEntry | undefined {
+  const msgs = chatMessages[conversationId]
+  if (!msgs || msgs.length === 0) return undefined
+  return msgs[msgs.length - 1]
+}
+

--- a/lib/mock-customer-tags.ts
+++ b/lib/mock-customer-tags.ts
@@ -1,0 +1,42 @@
+export interface CustomerTag {
+  id: string
+  customerId: string
+  tag: string
+  createdAt: string
+}
+
+export let customerTags: CustomerTag[] = []
+
+export function loadCustomerTags() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('customerTags')
+    if (stored) customerTags = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('customerTags', JSON.stringify(customerTags))
+  }
+}
+
+export function addCustomerTag(customerId: string, tag: string): CustomerTag {
+  const entry: CustomerTag = {
+    id: Date.now().toString(),
+    customerId,
+    tag,
+    createdAt: new Date().toISOString(),
+  }
+  customerTags = [entry, ...customerTags]
+  save()
+  return entry
+}
+
+export function listCustomerTags(customerId: string): CustomerTag[] {
+  return customerTags.filter((t) => t.customerId === customerId)
+}
+
+export function removeCustomerTag(id: string) {
+  customerTags = customerTags.filter((t) => t.id !== id)
+  save()
+}

--- a/lib/mock-flagged-users.ts
+++ b/lib/mock-flagged-users.ts
@@ -1,0 +1,30 @@
+export type FlagStatus = 'flagged' | 'blacklist'
+
+export let flaggedUsers: Record<string, FlagStatus> = {}
+
+export function loadFlaggedUsers() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('flaggedUsers')
+    if (stored) flaggedUsers = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('flaggedUsers', JSON.stringify(flaggedUsers))
+  }
+}
+
+export function setFlagStatus(id: string, status: FlagStatus) {
+  flaggedUsers[id] = status
+  save()
+}
+
+export function clearFlag(id: string) {
+  delete flaggedUsers[id]
+  save()
+}
+
+export function getFlagStatus(id: string): FlagStatus | undefined {
+  return flaggedUsers[id]
+}


### PR DESCRIPTION
## Summary
- manage admin-only customer tags and flagged users via new mock modules
- show tags, notes, and flagged status on customer list
- allow editing tags and notes on customer detail page
- highlight flagged customers with a warning badge
- link detail page to chat and display last mock message

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873f1447c6c8325a81b720a4ffae9c2