### PR TITLE
Implement quote request mock flow

### DIFF
--- a/app/admin/quotes/[id]/page.tsx
+++ b/app/admin/quotes/[id]/page.tsx
@@ -1,0 +1,70 @@
+"use client"
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { getQuote, updateQuote } from '@/lib/mock-quotes'
+import type { QuoteStatus } from '@/types/quote'
+
+export default function AdminQuoteDetail({ params }: { params: { id: string } }) {
+  const { id } = params
+  const quote = getQuote(id)
+  const router = useRouter()
+  const [price, setPrice] = useState(quote?.estimatedTotal || '')
+  const [note, setNote] = useState(quote?.note || '')
+
+  if (!quote) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่พบใบเสนอราคา</div>
+  }
+
+  const save = () => {
+    updateQuote(id, { estimatedTotal: Number(price), note, status: 'quoted' as QuoteStatus })
+    router.push('/admin/quotes')
+  }
+
+  const reject = () => {
+    updateQuote(id, { status: 'rejected' as QuoteStatus })
+    router.push('/admin/quotes')
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-2">
+          <Link href="/admin/quotes">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ใบเสนอราคา {quote.id}</h1>
+        </div>
+        <Card className="max-w-xl">
+          <CardHeader>
+            <CardTitle>ประเมินราคา</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              type="number"
+              placeholder="ราคาโดยประมาณ"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+            />
+            <Textarea
+              placeholder="หมายเหตุ"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+            />
+            <div className="flex space-x-2">
+              <Button onClick={save}>บันทึก</Button>
+              <Button variant="outline" onClick={reject}>ปฏิเสธ</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/quotes/page.tsx
+++ b/app/admin/quotes/page.tsx
@@ -1,0 +1,90 @@
+"use client"
+import { useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, FileText } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { exportQuotesCSV, mockQuotes } from '@/lib/mock-quotes'
+
+export default function AdminQuotesPage() {
+  const [csvPreview, setCsvPreview] = useState('')
+  const [status, setStatus] = useState('all')
+
+  const filtered = mockQuotes.filter(q => status === 'all' || q.status === status)
+
+  const prepareExport = () => {
+    setCsvPreview(exportQuotesCSV())
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-2">
+          <Link href="/admin">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ใบเสนอราคา</h1>
+          <div className="ml-auto">
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button size="sm" variant="outline" onClick={prepareExport}>
+                  <FileText className="mr-2 h-4 w-4" />Export CSV
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>CSV Preview</DialogTitle>
+                </DialogHeader>
+                <pre className="whitespace-pre-wrap text-xs max-h-60 overflow-auto">
+                  {csvPreview}
+                </pre>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>ลูกค้า</TableHead>
+                  <TableHead>สถานะ</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((q) => (
+                  <TableRow key={q.id}>
+                    <TableCell>{q.id}</TableCell>
+                    <TableCell>{q.customerId}</TableCell>
+                    <TableCell>{q.status}</TableCell>
+                    <TableCell>
+                      <Link href={`/admin/quotes/${q.id}`}>
+                        <Button size="sm" variant="outline">เปิด</Button>
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {filtered.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center">
+                      ไม่มีข้อมูล
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -21,6 +21,7 @@ import { useCart } from "@/contexts/cart-context"
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/hooks/use-toast"
 import { mockOrders } from "@/lib/mock-orders"
+import { createQuote } from "@/lib/mock-quotes"
 import type { OrderStatus, ShippingStatus } from "@/types/order"
 import { db } from "@/lib/database"
 import { SuggestedExtras } from "@/components/SuggestedExtras"
@@ -171,6 +172,11 @@ export default function CheckoutPage() {
       dispatch({ type: "CLEAR_CART" })
       router.push(`/success/${orderId}`)
     }, 3000)
+  }
+
+  const handleRequestQuote = () => {
+    const quote = createQuote(user?.id || guestId || 'guest', state.items)
+    router.push(`/quote-request/${quote.id}`)
   }
 
   if (state.items.length === 0) {
@@ -508,6 +514,15 @@ export default function CheckoutPage() {
                     }
                   >
                     {isProcessing ? "กำลังดำเนินการ..." : `ชำระเงิน ฿${finalTotal.toLocaleString()}`}
+                  </Button>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full mt-2"
+                    onClick={handleRequestQuote}
+                  >
+                    ขอใบเสนอราคาแทนการสั่งซื้อ
                   </Button>
 
                   <div className="text-center">

--- a/app/quote-request/[id]/page.tsx
+++ b/app/quote-request/[id]/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useRouter } from 'next/navigation'
+import { getQuote } from '@/lib/mock-quotes'
+import { useCart } from '@/contexts/cart-context'
+
+export default function QuoteRequestPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const quote = getQuote(id)
+  const { dispatch } = useCart()
+  const router = useRouter()
+
+  const confirm = () => {
+    if (!quote) return
+    quote.items.forEach((item) => {
+      dispatch({ type: 'ADD_ITEM', payload: item })
+    })
+    router.push('/cart')
+  }
+
+  if (!quote) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        ไม่พบใบเสนอราคา
+      </div>
+    )
+  }
+
+  const statusText =
+    quote.status === 'pending'
+      ? 'รอประเมิน'
+      : quote.status === 'quoted'
+        ? 'เสนอราคาแล้ว'
+        : 'ปฏิเสธ'
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>ใบเสนอราคา {quote.id}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p>สถานะ: {statusText}</p>
+            {quote.estimatedTotal && (
+              <p>ราคาโดยประมาณ: ฿{quote.estimatedTotal.toLocaleString()}</p>
+            )}
+            {quote.note && <p>หมายเหตุ: {quote.note}</p>}
+            {quote.status === 'quoted' && (
+              <Button onClick={confirm} className="w-full">
+                ยืนยันสั่งซื้อ
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/quote-request/page.tsx
+++ b/app/quote-request/page.tsx
@@ -1,0 +1,3 @@
+export default function QuoteRequestIndex() {
+  return <div className="min-h-screen flex items-center justify-center">กรุณาระบุไอดีใบเสนอราคา</div>
+}

--- a/lib/mock-quotes.ts
+++ b/lib/mock-quotes.ts
@@ -1,0 +1,35 @@
+import type { Quote, QuoteItem, QuoteStatus } from '@/types/quote'
+import { exportCSV } from './mock-export'
+
+export let mockQuotes: Quote[] = []
+
+export function createQuote(customerId: string, items: QuoteItem[]): Quote {
+  const quote: Quote = {
+    id: `Q-${Date.now()}`,
+    customerId,
+    items: items.map((i) => ({ ...i })),
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  }
+  mockQuotes.push(quote)
+  return quote
+}
+
+export function getQuote(id: string): Quote | undefined {
+  return mockQuotes.find((q) => q.id === id)
+}
+
+export function updateQuote(
+  id: string,
+  data: { status?: QuoteStatus; estimatedTotal?: number; note?: string },
+) {
+  const q = getQuote(id)
+  if (!q) return
+  if (data.status) q.status = data.status
+  if (typeof data.estimatedTotal !== 'undefined') q.estimatedTotal = data.estimatedTotal
+  if (typeof data.note !== 'undefined') q.note = data.note
+}
+
+export function exportQuotesCSV(): string {
+  return exportCSV(mockQuotes)
+}

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -1,0 +1,21 @@
+export type QuoteStatus = 'pending' | 'quoted' | 'rejected'
+
+export interface QuoteItem {
+  id: string
+  name: string
+  price: number
+  image: string
+  quantity: number
+  size?: string
+  color?: string
+}
+
+export interface Quote {
+  id: string
+  customerId: string
+  items: QuoteItem[]
+  status: QuoteStatus
+  estimatedTotal?: number
+  note?: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- allow requesting a quote from checkout
- show quote status at `/quote-request/[id]`
- admin can manage quotes in `/admin/quotes`
- mock data stored in `mock-quotes.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6873f406932883258ce54c229c6cf13e