### PR TITLE
Add speed namer for collection creation

### DIFF
--- a/app/admin/collections/create/page.tsx
+++ b/app/admin/collections/create/page.tsx
@@ -8,7 +8,8 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { addCollection } from "@/lib/mock-collections"
+import { addCollection, mockCollections } from "@/lib/mock-collections"
+import { uniqueCollectionName } from "@/lib/speed-namer"
 
 function slugify(str: string) {
   return str
@@ -50,6 +51,13 @@ export default function CreateCollectionPage() {
     } catch {}
   }, [])
 
+  const handleRandomName = () => {
+    const slugs = mockCollections.map((c) => c.slug)
+    const newName = uniqueCollectionName(slugs)
+    setName(newName)
+    setSlug(slugify(newName))
+  }
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     addCollection({
@@ -84,7 +92,10 @@ export default function CreateCollectionPage() {
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="name">ชื่อคอลเลกชัน</Label>
-                <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+                <div className="flex space-x-2">
+                  <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+                  <Button type="button" onClick={handleRandomName}>สุ่มชื่อ</Button>
+                </div>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="slug">Slug</Label>

--- a/lib/speed-namer.ts
+++ b/lib/speed-namer.ts
@@ -1,0 +1,139 @@
+export const adjectives = [
+  "Brilliant",
+  "Cozy",
+  "Dreamy",
+  "Elegant",
+  "Fancy",
+  "Gentle",
+  "Happy",
+  "Icy",
+  "Jolly",
+  "Kind",
+  "Lush",
+  "Mellow",
+  "Noble",
+  "Oasis",
+  "Peaceful",
+  "Quiet",
+  "Radiant",
+  "Sunny",
+  "Tranquil",
+  "Vibrant",
+  "Whimsical",
+  "Youthful",
+  "Zesty",
+  "Amber",
+  "Blissful",
+  "Charming",
+  "Delightful",
+  "Enchanted",
+  "Floral",
+  "Golden",
+  "Humble",
+  "Ivory",
+  "Jade",
+  "Lavish",
+  "Magical",
+  "Nostalgic",
+  "Opulent",
+  "Playful",
+  "Quirky",
+  "Rustic",
+  "Serene",
+  "Timeless",
+  "Unique",
+  "Velvet",
+  "Warm",
+  "Xtraordinary",
+  "Yearning",
+  "Zealous",
+  "Artful",
+  "Bold",
+]
+
+export const themes = [
+  "Aurora",
+  "Breeze",
+  "Cascade",
+  "Dawn",
+  "Eclipse",
+  "Forest",
+  "Glow",
+  "Harbor",
+  "Island",
+  "Jungle",
+  "Kingdom",
+  "Lagoon",
+  "Meadow",
+  "Nirvana",
+  "Oasis",
+  "Prairie",
+  "Quest",
+  "Ridge",
+  "Sanctuary",
+  "Terrace",
+  "Utopia",
+  "Valley",
+  "Wonder",
+  "Xanadu",
+  "Yard",
+  "Zen",
+  "Alpine",
+  "Bay",
+  "Canyon",
+  "Desert",
+  "Estate",
+  "Fjord",
+  "Grove",
+  "Harbor",
+  "Inlet",
+  "Junction",
+  "Knoll",
+  "Lair",
+  "Mesa",
+  "Nook",
+  "Orbit",
+  "Peak",
+  "Quarry",
+  "Refuge",
+  "Springs",
+  "Trail",
+  "Union",
+  "Vista",
+  "Wilds",
+  "Xylophone",
+  "Yonder",
+  "Zephyr",
+]
+
+export const presetNames = adjectives.flatMap((a) =>
+  themes.map((t) => `${a} ${t}`),
+)
+
+function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/--+/g, "-")
+    .replace(/^-|-$/g, "")
+}
+
+export function randomCollectionName() {
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)]
+  const theme = themes[Math.floor(Math.random() * themes.length)]
+  return `${adj} ${theme}`
+}
+
+export function uniqueCollectionName(existingSlugs: string[]) {
+  const tried = new Set<string>()
+  while (tried.size < presetNames.length) {
+    const name = presetNames[Math.floor(Math.random() * presetNames.length)]
+    if (tried.has(name)) continue
+    tried.add(name)
+    const slug = slugify(name)
+    if (!existingSlugs.includes(slug)) return name
+  }
+  return `Collection-${Date.now()}`
+}


### PR DESCRIPTION
## Summary
- provide a `speed-namer` helper with 50 adjectives and 50 themes (2500+ combos)
- expose `uniqueCollectionName` to generate unused names
- add "สุ่มชื่อ" button on collection create page using the new helper

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687421325c34832593e71b9cfc7db1ed