### PR TITLE
Add admin supply tracking pages

### DIFF
--- a/app/admin/orders/[id]/supply/page.tsx
+++ b/app/admin/orders/[id]/supply/page.tsx
@@ -1,0 +1,107 @@
+"use client"
+import { useState } from "react"
+import Link from "next/link"
+import { ArrowLeft, Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { mockOrders } from "@/lib/mock-orders"
+import { addSupplyEntry, listSupplyForOrder, type SupplyItem } from "@/lib/mock-supply"
+import { getMockNow } from "@/lib/mock-date"
+
+export default function OrderSupplyPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const order = mockOrders.find((o) => o.id === id)
+  const [items, setItems] = useState<SupplyItem[]>(listSupplyForOrder(id))
+  const [item, setItem] = useState("")
+  const [qty, setQty] = useState("")
+  const [eta, setEta] = useState(
+    new Date(getMockNow().getTime() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 16),
+  )
+
+  if (!order) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่พบออเดอร์</div>
+  }
+
+  const addItem = () => {
+    if (!item || !qty) return
+    const entry = addSupplyEntry({ orderId: id, item, quantity: Number(qty), eta })
+    setItems([...items, entry])
+    setItem("")
+    setQty("")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href={`/admin/orders/${id}`}>\
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">วัตถุดิบออเดอร์ {id}</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>เพิ่มรายการวัตถุดิบ</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Input value={item} onChange={(e) => setItem(e.target.value)} placeholder="ชื่อวัตถุดิบ" />
+            <Input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              placeholder="จำนวน"
+              type="number"
+            />
+            <Input
+              type="datetime-local"
+              value={eta}
+              onChange={(e) => setEta(e.target.value)}
+            />
+            <Button onClick={addItem} disabled={!item || !qty}>
+              <Plus className="h-4 w-4 mr-2" /> เพิ่ม
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการวัตถุดิบ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ชื่อ</TableHead>
+                  <TableHead>จำนวน</TableHead>
+                  <TableHead>ETA</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((i) => (
+                  <TableRow key={i.id} className={new Date(i.eta) < getMockNow() ? "bg-red-100" : ""}>
+                    <TableCell>{i.item}</TableCell>
+                    <TableCell>{i.quantity}</TableCell>
+                    <TableCell>{new Date(i.eta).toLocaleString("th-TH")}</TableCell>
+                  </TableRow>
+                ))}
+                {items.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-center text-sm text-gray-500">
+                      ไม่มีข้อมูล
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/supply-tracker/page.tsx
+++ b/app/admin/supply-tracker/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { listAllSupply, type SupplyItem } from "@/lib/mock-supply"
+import { getMockNow } from "@/lib/mock-date"
+
+export default function SupplyTrackerPage() {
+  const items = listAllSupply()
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href="/admin/dashboard">\
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ติดตามวัตถุดิบ</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการวัตถุดิบ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Order</TableHead>
+                  <TableHead>ชื่อ</TableHead>
+                  <TableHead>จำนวน</TableHead>
+                  <TableHead>ETA</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((i: SupplyItem) => {
+                  const overdue = new Date(i.eta) < getMockNow()
+                  return (
+                    <TableRow key={i.id} className={overdue ? "bg-red-100" : ""}>
+                      <TableCell>{i.orderId}</TableCell>
+                      <TableCell>{i.item}</TableCell>
+                      <TableCell>{i.quantity}</TableCell>
+                      <TableCell>{new Date(i.eta).toLocaleString("th-TH")}</TableCell>
+                    </TableRow>
+                  )
+                })}
+                {items.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-sm text-gray-500">
+                      ไม่มีข้อมูล
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-supply.ts
+++ b/lib/mock-supply.ts
@@ -1,0 +1,52 @@
+export interface SupplyItem {
+  id: string
+  orderId: string
+  item: string
+  quantity: number
+  eta: string
+  received: boolean
+}
+
+import { getMockNow } from './mock-date'
+
+export let mockSupply: SupplyItem[] = [
+  {
+    id: 'SUP-001',
+    orderId: 'ORD-001',
+    item: 'ผ้า Cotton สีครีม',
+    quantity: 20,
+    eta: new Date(getMockNow().getTime() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+    received: false,
+  },
+  {
+    id: 'SUP-002',
+    orderId: 'ORD-002',
+    item: 'ซิป YKK',
+    quantity: 10,
+    eta: new Date(getMockNow().getTime() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    received: false,
+  },
+]
+
+export function addSupplyEntry(entry: Omit<SupplyItem, 'id' | 'received'>) {
+  const newEntry: SupplyItem = {
+    id: `SUP-${Math.random().toString(36).slice(2, 8)}`,
+    received: false,
+    ...entry,
+  }
+  mockSupply.push(newEntry)
+  return newEntry
+}
+
+export function markSupplyReceived(id: string) {
+  const s = mockSupply.find((m) => m.id === id)
+  if (s) s.received = true
+}
+
+export function listSupplyForOrder(orderId: string) {
+  return mockSupply.filter((s) => s.orderId === orderId)
+}
+
+export function listAllSupply() {
+  return mockSupply
+}


### PR DESCRIPTION
## Summary
- mock supply data module
- add order supply form page
- show supply tracker for all orders

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68742346ad4c8325a153bcf8fdc1ab88