### PR TITLE
Add .vercelignore for leaner builds

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,13 @@
+# Ignore Chatwoot Ruby backend
+chatwoot/
+
+# Documentation
+/docs/
+
+# Test directories and files
+**/__tests__/
+**/*.test.*
+**/*.spec.*
+
+# Local dependencies
+node_modules/


### PR DESCRIPTION
## Summary
- ignore Chatwoot and other nonessential folders in Vercel deploys

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68743180e4248325bab546387e7209de