### PR TITLE
Add sofa size settings

### DIFF
--- a/app/admin/sofa-sizes/page.tsx
+++ b/app/admin/sofa-sizes/page.tsx
@@ -1,0 +1,92 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAuth } from '@/contexts/auth-context'
+import { sofaSizes, loadSofaSizes, saveSofaSizes, type SofaSize } from '@/lib/mock-sofa-sizes'
+
+export default function AdminSofaSizesPage() {
+  const { user, isAuthenticated } = useAuth()
+  const router = useRouter()
+  const [sizes, setSizes] = useState<SofaSize[]>(sofaSizes)
+  const [value, setValue] = useState('')
+  const [label, setLabel] = useState('')
+
+  useEffect(() => {
+    loadSofaSizes()
+    setSizes([...sofaSizes])
+    if (!isAuthenticated) {
+      router.push('/login')
+    } else if (user?.role !== 'admin') {
+      router.push('/')
+    }
+  }, [isAuthenticated, user, router])
+
+  if (!isAuthenticated || user?.role !== 'admin') return null
+
+  const addSize = () => {
+    if (!value || !label) return
+    const newSize = { value, label }
+    const updated = [...sizes, newSize]
+    setSizes(updated)
+    saveSofaSizes(updated)
+    setValue('')
+    setLabel('')
+  }
+
+  const removeSize = (val: string) => {
+    const updated = sizes.filter((s) => s.value !== val)
+    setSizes(updated)
+    saveSofaSizes(updated)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ตั้งค่าขนาดโซฟา</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>เพิ่มขนาด</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input placeholder="Value" value={value} onChange={(e) => setValue(e.target.value)} />
+            <Input placeholder="Label" value={label} onChange={(e) => setLabel(e.target.value)} />
+            <Button onClick={addSize} disabled={!value || !label}>เพิ่ม</Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการขนาด</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {sizes.map((s) => (
+              <div key={s.value} className="flex items-center justify-between border-b py-2">
+                <div>
+                  <p className="font-medium">{s.label}</p>
+                  <p className="text-sm text-gray-600">{s.value}</p>
+                </div>
+                <Button size="icon" variant="outline" onClick={() => removeSize(s.value)}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            {sizes.length === 0 && (
+              <p className="text-center text-gray-500">ไม่มีข้อมูล</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -30,6 +30,7 @@ const navItems = [
   { href: "/admin/customers", label: "ลูกค้า", icon: Users },
   { href: "/admin/coupons", label: "คูปอง", icon: Percent },
   { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText },
+  { href: "/admin/sofa-sizes", label: "ขนาดโซฟา", icon: List },
   { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
   { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },

--- a/lib/mock-sofa-sizes.ts
+++ b/lib/mock-sofa-sizes.ts
@@ -1,0 +1,25 @@
+export interface SofaSize {
+  value: string
+  label: string
+}
+
+export let sofaSizes: SofaSize[] = [
+  { value: "S (90-140 cm)", label: "S (90-140 cm) - 1 ที่นั่ง" },
+  { value: "M (145-185 cm)", label: "M (145-185 cm) - 2 ที่นั่ง" },
+  { value: "L (190-230 cm)", label: "L (190-230 cm) - 3 ที่นั่ง" },
+  { value: "XL (235-300 cm)", label: "XL (235-300 cm) - 4+ ที่นั่ง" },
+]
+
+export function loadSofaSizes() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('sofaSizes')
+    if (stored) sofaSizes = JSON.parse(stored)
+  }
+}
+
+export function saveSofaSizes(items: SofaSize[]) {
+  sofaSizes = items
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('sofaSizes', JSON.stringify(items))
+  }
+}


### PR DESCRIPTION
## Summary
- create mock-sofa-sizes store with persistence
- add admin UI for managing sofa sizes
- link sofa size page from the sidebar

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68743230c7288325b21f1f71038373e4