### PR TITLE
Add admin fallback center

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,6 +1,11 @@
 import FallbackCenter from "@/components/FallbackCenter"
-import { BarChart3 } from "lucide-react"
 
 export default function AdminAnalyticsPage() {
-  return <FallbackCenter icon={BarChart3} subtitle="แดชบอร์ดสถิติ" />
+  return (
+    <FallbackCenter
+      icon="📊"
+      title="Analytics ยังไม่พร้อม"
+      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
+    />
+  )
 }

--- a/app/admin/campaigns/summary/page.tsx
+++ b/app/admin/campaigns/summary/page.tsx
@@ -1,6 +1,11 @@
 import FallbackCenter from "@/components/FallbackCenter"
-import { Megaphone } from "lucide-react"
 
 export default function CampaignSummaryPage() {
-  return <FallbackCenter icon={Megaphone} subtitle="สรุปแคมเปญ" />
+  return (
+    <FallbackCenter
+      icon="📣"
+      title="Campaign Summary ยังไม่พร้อม"
+      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
+    />
+  )
 }

--- a/app/admin/dev/log/page.tsx
+++ b/app/admin/dev/log/page.tsx
@@ -1,6 +1,11 @@
 import FallbackCenter from "@/components/FallbackCenter"
-import { List } from "lucide-react"
 
 export default function DevLogPage() {
-  return <FallbackCenter icon={List} subtitle="บันทึกสำหรับนักพัฒนา" />
+  return (
+    <FallbackCenter
+      icon="📝"
+      title="Dev Log ยังไม่พร้อม"
+      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
+    />
+  )
 }

--- a/app/admin/faq/page.tsx
+++ b/app/admin/faq/page.tsx
@@ -1,8 +1,11 @@
 import FallbackCenter from "@/components/FallbackCenter"
-import { BookOpen } from "lucide-react"
 
 export default function AdminFaqPage() {
   return (
-    <FallbackCenter icon={BookOpen} subtitle="ส่วนจัดการคำถามที่พบบ่อย" />
+    <FallbackCenter
+      icon="📘"
+      title="FAQ ยังไม่พร้อม"
+      subtitle="กำลังเตรียมระบบช่วยตอบคำถาม"
+    />
   )
 }

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,6 +1,11 @@
 import FallbackCenter from "@/components/FallbackCenter"
-import { FileChart } from "lucide-react"
 
 export default function AdminReportsPage() {
-  return <FallbackCenter icon={FileChart} subtitle="รายงานภาพรวม" />
+  return (
+    <FallbackCenter
+      icon="📑"
+      title="Reports ยังไม่พร้อม"
+      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
+    />
+  )
 }

--- a/components/FallbackCenter.tsx
+++ b/components/FallbackCenter.tsx
@@ -1,32 +1,21 @@
-import Link from "next/link"
-import { AlertCircle, type LucideIcon } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { type ReactNode } from "react"
 
 interface FallbackCenterProps {
-  icon?: LucideIcon
+  icon?: ReactNode
   title?: string
   subtitle?: string
-  href?: string
 }
 
 export default function FallbackCenter({
-  icon: Icon = AlertCircle,
-  title = "Coming soon",
-  subtitle,
-  href = "/",
+  icon = "🚧",
+  title = "หน้านี้ยังไม่พร้อมใช้งาน",
+  subtitle = "อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้",
 }: FallbackCenterProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="space-y-4 text-center">
-        <Icon className="mx-auto h-10 w-10 text-gray-400" />
-        <h1 className="text-2xl font-semibold">{title}</h1>
-        {subtitle && <p className="text-gray-500">{subtitle}</p>}
-        {href && (
-          <Link href={href}>
-            <Button>กลับหน้าแรก</Button>
-          </Link>
-        )}
-      </div>
+    <div className="flex flex-col items-center justify-center h-full text-center py-16 text-gray-500">
+      <div className="text-5xl mb-4">{icon}</div>
+      <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      <p className="text-sm">{subtitle}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a simple `FallbackCenter` component with default emoji display
- use the new fallback component in several admin pages

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_68744f9cfbbc8325b1531c8e3afb806d