### PR TITLE
Add shipment workflow mocks

### DIFF
--- a/app/admin/alerts/pending-orders/page.tsx
+++ b/app/admin/alerts/pending-orders/page.tsx
@@ -1,0 +1,49 @@
+"use client"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ArrowLeft } from "lucide-react"
+import { mockOrders } from "@/lib/mock-orders"
+import { getMockNow } from "@/lib/mock-date"
+
+export default function PendingOrderAlerts() {
+  const now = getMockNow().getTime()
+  const overdue = mockOrders.filter(o => {
+    if (o.status !== "packed") return false
+    const entry = [...o.timeline].reverse().find(t => t.status === "packed")
+    if (!entry) return false
+    return now - new Date(entry.timestamp).getTime() > 3 * 24 * 60 * 60 * 1000
+  })
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">แจ้งเตือนออเดอร์ค้าง</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>ค้างเกิน 3 วัน ({overdue.length})</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {overdue.map(o => (
+              <div key={o.id} className="flex justify-between items-center border-b pb-2 last:border-b-0 text-red-600">
+                <span>{o.id} - {o.customerName}</span>
+                <Link href={`/admin/orders/${o.id}/delivery`}>
+                  <Button variant="destructive" size="sm">จัดการ</Button>
+                </Link>
+              </div>
+            ))}
+            {overdue.length === 0 && (
+              <p className="text-center text-sm text-gray-500">ไม่มีรายการ</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/feedback/page.tsx
+++ b/app/admin/feedback/page.tsx
@@ -11,7 +11,11 @@ export default function FeedbackListPage() {
   const [items, setItems] = useState(mockFeedbacks);
   useEffect(() => {
     loadFeedbacks();
-    setItems([...mockFeedbacks]);
+    const filtered = mockFeedbacks.filter((fb) => {
+      if (typeof window === "undefined") return true;
+      return !localStorage.getItem("fb-" + fb.orderId);
+    });
+    setItems(filtered);
   }, []);
 
   return (

--- a/app/admin/orders/[id]/confirm-pack/page.tsx
+++ b/app/admin/orders/[id]/confirm-pack/page.tsx
@@ -1,0 +1,91 @@
+"use client"
+import { useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { mockOrders, setOrderStatus } from "@/lib/mock-orders"
+import { toast } from "sonner"
+
+export default function ConfirmPackPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const idx = mockOrders.findIndex(o => o.id === id)
+  const order = mockOrders[idx]
+  const [checked, setChecked] = useState<Record<number, boolean>>({})
+  const [processing, setProcessing] = useState(false)
+
+  if (!order) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่พบออเดอร์</div>
+  }
+
+  const validAddress = Object.values(order.shippingAddress).every(v => v)
+  const allChecked = order.items.every((_, i) => checked[i])
+  const confirmed = order.status === "packed"
+
+  const handleConfirm = () => {
+    if (!allChecked || !validAddress || confirmed || processing) return
+    setProcessing(true)
+    setOrderStatus(order.id, "packed")
+    mockOrders[idx].packingStatus = "ready"
+    toast.success("ยืนยันแพ็กแล้ว")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href={`/admin/orders/${id}`}>\
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ยืนยันแพ็ค {order.id}</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการสินค้า</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {order.items.map((item, i) => (
+              <div key={i} className="flex justify-between items-center border-b pb-2 last:border-b-0">
+                <div>
+                  <p className="font-medium">{item.productName}</p>
+                  <p className="text-sm text-gray-600">
+                    {item.size && `ขนาด: ${item.size}`} {item.color && `| สี: ${item.color}`}
+                  </p>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <span>จำนวน: {item.quantity}</span>
+                  <input
+                    type="checkbox"
+                    checked={!!checked[i]}
+                    onChange={e => setChecked({ ...checked, [i]: e.target.checked })}
+                  />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>ที่อยู่จัดส่ง</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <p className="font-semibold">{order.shippingAddress.name}</p>
+            <p>{order.shippingAddress.address}</p>
+            <p>
+              {order.shippingAddress.city} {order.shippingAddress.postalCode}
+            </p>
+            <p>เบอร์โทร: {order.shippingAddress.phone}</p>
+          </CardContent>
+        </Card>
+
+        <Button onClick={handleConfirm} disabled={!allChecked || !validAddress || confirmed || processing}>
+          ยืนยันแพ็ค
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/orders/[id]/delivery/page.tsx
+++ b/app/admin/orders/[id]/delivery/page.tsx
@@ -1,0 +1,76 @@
+"use client"
+import { useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { mockOrders, setOrderStatus } from "@/lib/mock-orders"
+import { toast } from "sonner"
+
+export default function DeliveryPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const idx = mockOrders.findIndex(o => o.id === id)
+  const order = mockOrders[idx]
+  const [tracking, setTracking] = useState(order?.tracking_number || "")
+  const [provider, setProvider] = useState(order?.delivery_method || "")
+  const [img, setImg] = useState(order?.labelImage || "")
+  const [processing, setProcessing] = useState(false)
+
+  if (!order) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่พบออเดอร์</div>
+  }
+
+  const handleFile = (file: File) => {
+    if (file.size > 1024 * 1024) {
+      toast.error("รูปใหญ่เกิน 1MB")
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = e => setImg(e.target?.result as string)
+    reader.readAsDataURL(file)
+  }
+
+  const canSubmit = tracking.trim() !== "" && provider.trim() !== "" && img && order.shipping_status !== "shipped" && !processing
+
+  const submit = () => {
+    if (!canSubmit) return
+    setProcessing(true)
+    mockOrders[idx].tracking_number = tracking
+    mockOrders[idx].delivery_method = provider
+    mockOrders[idx].labelImage = img
+    mockOrders[idx].shipping_status = "shipped"
+    setOrderStatus(order.id, "shipped")
+    toast.success("บันทึกการจัดส่งแล้ว")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href={`/admin/orders/${id}`}>\
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">บันทึกการจัดส่ง {order.id}</h1>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>ข้อมูลจัดส่ง</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <input value={tracking} onChange={e => setTracking(e.target.value)} className="border rounded px-2 py-1 w-full" placeholder="เลข Tracking" />
+            <input value={provider} onChange={e => setProvider(e.target.value)} className="border rounded px-2 py-1 w-full" placeholder="ผู้ให้บริการ" />
+            <input type="file" accept="image/*" onChange={e => e.target.files && handleFile(e.target.files[0])} />
+            {img && <img src={img} alt="label" className="h-32" />}
+          </CardContent>
+        </Card>
+
+        <Button onClick={submit} disabled={!canSubmit}>
+          ส่งของแล้ว
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/orders/[id]/feedback/page.tsx
+++ b/app/admin/orders/[id]/feedback/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import FeedbackCard from "@/components/FeedbackCard"
+import { loadFeedbacks, mockFeedbacks, type Feedback } from "@/lib/mock-feedback"
+
+export default function OrderFeedbackPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [fb, setFb] = useState<Feedback | undefined>()
+  const [status, setStatus] = useState<string>("")
+
+  useEffect(() => {
+    loadFeedbacks()
+    setFb(mockFeedbacks.find(f => f.orderId === id))
+    if (typeof window !== "undefined") {
+      setStatus(localStorage.getItem("fb-" + id) || "")
+    }
+  }, [id])
+
+  const mark = (s: string) => {
+    setStatus(s)
+    if (typeof window !== "undefined") localStorage.setItem("fb-" + id, s)
+  }
+
+  if (!fb) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่มีความคิดเห็น</div>
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href={`/admin/orders/${id}`}>\
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">Feedback ออเดอร์ {id}</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>ความคิดเห็น</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FeedbackCard fb={fb} />
+            <div className="space-x-2">
+              <Button onClick={() => mark("read")} disabled={status === "read"}>อ่านแล้ว</Button>
+              <Button variant="outline" onClick={() => mark("followup")} disabled={status === "followup"}>ต้อง follow up</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/orders/pending-shipment/page.tsx
+++ b/app/admin/orders/pending-shipment/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ArrowLeft } from "lucide-react"
+import { mockOrders } from "@/lib/mock-orders"
+
+export default function PendingShipmentPage() {
+  const orders = mockOrders.filter(o => o.status === "packed")
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="flex items-center space-x-4 mb-4">
+          <Link href="/admin/orders">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ออเดอร์ที่รอจัดส่ง</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการ ({orders.length})</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {orders.map(o => (
+              <div key={o.id} className="flex justify-between items-center border-b pb-2 last:border-b-0">
+                <div>
+                  <p className="font-medium">{o.id}</p>
+                  <p className="text-sm text-gray-500">{o.customerName}</p>
+                </div>
+                <Link href={`/admin/orders/${o.id}/delivery`}>
+                  <Button variant="outline">จัดส่ง</Button>
+                </Link>
+              </div>
+            ))}
+            {orders.length === 0 && (
+              <p className="text-center text-sm text-gray-500">ไม่มีรายการ</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/types/order.ts
+++ b/types/order.ts
@@ -97,6 +97,8 @@ export interface Order {
   packingStatus: PackingStatus
   shipping_date: string
   delivery_note: string
+  /** Base64 label image */
+  labelImage?: string
   /** Scheduled date and time for delivery */
   scheduledDelivery?: string
   reorderedFromId?: string


### PR DESCRIPTION
## Summary
- add order confirmation step with checklist
- allow capturing delivery details with mock label
- filter feedback list by read status
- show pending shipment page for packed orders
- add alert page for overdue shipments
- expose label image on Order type

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874532410988325921ccdd220bdda5a