### PR TITLE
Improve bill handling mock tools

### DIFF
--- a/app/admin/bill/create/page.tsx
+++ b/app/admin/bill/create/page.tsx
@@ -50,7 +50,7 @@ export default function AdminBillCreatePage() {
     } catch (e) {
       toast.error("เกิดข้อผิดพลาด")
     } finally {
-      setLoading(false)
+      setTimeout(() => setLoading(false), 3000)
     }
   }
 

--- a/app/admin/chat/hotkey.tsx
+++ b/app/admin/chat/hotkey.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { useEffect, useState } from "react"
+import CreateChatBillDialog from "@/components/admin/chat/CreateChatBillDialog"
+
+export default function ChatHotkey() {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key.toLowerCase() === "b") {
+        e.preventDefault()
+        setOpen(true)
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [])
+
+  if (!open) return null
+  return <CreateChatBillDialog onCreated={() => setOpen(false)} />
+}

--- a/app/admin/chat/page.tsx
+++ b/app/admin/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import CreateChatBillDialog from '@/components/admin/chat/CreateChatBillDialog'
+import ChatHotkey from './hotkey'
 import Link from 'next/link'
 import { Button } from '@/components/ui/buttons/button'
 
@@ -18,6 +19,7 @@ export default function AdminChatPage() {
     <div className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <p>กำลังเปิดหน้าต่างแชท...</p>
       <CreateChatBillDialog onCreated={setNewBillId} />
+      <ChatHotkey />
       {newBillId && (
         <div className="space-y-2 text-center">
           <p>บิลสร้างแล้ว:</p>

--- a/app/admin/dev/bill-history/page.tsx
+++ b/app/admin/dev/bill-history/page.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { useState } from "react"
+import { isDevMock } from "@/lib/mock-settings"
+import { mockBills, confirmBill } from "@/lib/mock-bills"
+import { Button } from "@/components/ui/buttons/button"
+import EmptyState from "@/components/EmptyState"
+import { cancelBill } from "@/lib/mock-bills"
+
+export default function DevBillHistory() {
+  const [bills, setBills] = useState([...mockBills])
+
+  if (!isDevMock) return <EmptyState title="ไม่อนุญาต" />
+
+  const handleConfirm = (id: string) => {
+    confirmBill(id)
+    setBills([...mockBills])
+  }
+  const handleCancel = (id: string) => {
+    cancelBill(id)
+    setBills([...mockBills])
+  }
+
+  return (
+    <div className="space-y-4">
+      {bills.map((b) => (
+        <div key={b.id} className="flex items-center justify-between border p-2 rounded">
+          <span>{b.id}</span>
+          <span>{b.status}</span>
+          <div className="space-x-2">
+            <Button size="sm" onClick={() => handleConfirm(b.id)}>ชำระ</Button>
+            <Button variant="outline" size="sm" onClick={() => handleCancel(b.id)}>
+              ยกเลิก
+            </Button>
+          </div>
+        </div>
+      ))}
+      {bills.length === 0 && <EmptyState />}
+    </div>
+  )
+}

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useState } from "react"
 import Link from "next/link"
-import { ArrowLeft, Download, PrinterIcon as Print } from "lucide-react"
+import { ArrowLeft, Download, PrinterIcon as Print, Copy } from "lucide-react"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
@@ -12,6 +12,9 @@ import { mockOrders } from "@/lib/mock-orders"
 import { getBill, addBillPayment } from "@/lib/mock-bills"
 import { getQuickBill, getBillLink } from "@/lib/mock-quick-bills"
 import { billSecurity } from "@/lib/mock-settings"
+import ErrorBoundary from "@/components/ErrorBoundary"
+import EmptyState from "@/components/EmptyState"
+import { Badge } from "@/components/ui/badge"
 import { getMockNow } from "@/lib/mock-date"
 
 export default function BillPage({ params }: { params: { id: string } }) {
@@ -38,16 +41,7 @@ export default function BillPage({ params }: { params: { id: string } }) {
       }
       return null
     }
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-4">ไม่พบบิล</h1>
-          <Link href="/orders">
-            <Button>กลับไปหน้าคำสั่งซื้อ</Button>
-          </Link>
-        </div>
-      </div>
-    )
+    return <EmptyState title="ไม่พบบิล" subtitle="ตรวจสอบลิงก์อีกครั้ง" />
   }
 
   const handlePrint = () => {
@@ -58,6 +52,12 @@ export default function BillPage({ params }: { params: { id: string } }) {
 
   const handleDownload = () => {
     alert("ดาวน์โหลดบิล (ฟีเจอร์นี้จะพัฒนาในอนาคต)")
+  }
+
+  const handleCopy = () => {
+    if (typeof window !== "undefined") {
+      navigator.clipboard.writeText(window.location.href)
+    }
   }
 
   const handleVerify = () => {
@@ -110,6 +110,7 @@ export default function BillPage({ params }: { params: { id: string } }) {
   }
 
   return (
+    <ErrorBoundary>
     <div className="min-h-screen bg-gray-50">
       <div className="print:hidden bg-white border-b px-4 py-4">
         <div className="container mx-auto flex items-center justify-between">
@@ -120,16 +121,24 @@ export default function BillPage({ params }: { params: { id: string } }) {
               </Button>
             </Link>
             <h1 className="text-xl font-semibold">บิล {order.id}</h1>
+            <Badge variant="secondary">{bill.status}</Badge>
           </div>
           <div className="flex space-x-2">
             <Button variant="outline" onClick={handlePrint}>
               <Print className="mr-2 h-4 w-4" />
               พิมพ์
             </Button>
+            <Button variant="outline" onClick={handleCopy}>
+              <Copy className="mr-2 h-4 w-4" />
+              คัดลอกลิงก์
+            </Button>
             <Button onClick={handleDownload}>
               <Download className="mr-2 h-4 w-4" />
               ดาวน์โหลด PDF
             </Button>
+            <Link href="/admin/chat">
+              <Button variant="outline">เปิดแชท</Button>
+            </Link>
           </div>
         </div>
       </div>
@@ -167,6 +176,7 @@ export default function BillPage({ params }: { params: { id: string } }) {
         </Card>
       </div>
     </div>
+    </ErrorBoundary>
   )
 }
 

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react"
+import FallbackCenter from "./FallbackCenter"
+
+export default function EmptyState({
+  icon = "📭",
+  title = "ไม่พบข้อมูล",
+  subtitle = "",
+}: {
+  icon?: ReactNode
+  title?: string
+  subtitle?: string
+}) {
+  return <FallbackCenter icon={icon} title={title} subtitle={subtitle} />
+}

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -44,6 +44,14 @@ export function confirmBill(id: string) {
   }
 }
 
+export function cancelBill(id: string) {
+  const b = getBill(id)
+  if (b) {
+    b.status = "cancelled"
+    addAdminLog(`cancel bill ${id}`, 'mockAdminId')
+  }
+}
+
 export function addBillPayment(id: string, payment: BillPayment) {
   const b = getBill(id)
   if (b) b.payments.push(payment)


### PR DESCRIPTION
## Summary
- add generic `EmptyState` wrapper component
- enhance `/bill/[id]` with status badge, copy button, chat link and fallback error state
- throttle manual bill creation to avoid duplicate clicks
- add admin dev bill history list page with confirm/cancel actions
- add chat admin hotkey for quickly creating bills
- expose `cancelBill` helper for mocks

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68750bacd3048325bcf976de9d7cdeda