### PR TITLE
Add link to sofa covers page

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -50,6 +50,9 @@ export default function CollectionsPage() {
     <div className="min-h-screen flex flex-col">
       <Navbar />
       <div className="container mx-auto px-4 py-8 flex-1">
+        <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-900">
+          กำลังมองหาผ้าคลุมโซฟาเข้ารูปใช่ไหม? <Link href="/sofa-covers" className="underline text-blue-600">ดูลายผ้าสำหรับผ้าคลุมโซฟา</Link>
+        </div>
         <h1 className="text-3xl font-bold mb-6">คอลเลกชันลายผ้า</h1>
         {collections.length > 0 ? (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { FabricsList } from "@/components/FabricsList"
+import Link from "next/link"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
@@ -51,6 +52,9 @@ export default async function FabricsPage() {
     <div className="min-h-screen">
       <Navbar />
       <div className="container mx-auto px-4 py-8">
+        <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-900">
+          กำลังมองหาผ้าคลุมโซฟาเข้ารูปใช่ไหม? <Link href="/sofa-covers" className="underline text-blue-600">ดูลายผ้าสำหรับผ้าคลุมโซฟา</Link>
+        </div>
         <h1 className="text-3xl font-bold mb-6">แกลเลอรี่ลายผ้า</h1>
         <FabricsList fabrics={fabrics} />
       </div>


### PR DESCRIPTION
## Summary
- link from collections and fabrics pages to `/sofa-covers`

## Testing
- `npm test` *(fails: ERR_REQUIRE_ESM)*

------
https://chatgpt.com/codex/tasks/task_e_687524b430cc832592a1241d8ffe60b8