### PR TITLE
Add local duplicate ref check on bill payments

### DIFF
--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -10,6 +10,7 @@ import BillPreview from "@/components/BillPreview"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
 import { mockOrders } from "@/lib/mock-orders"
 import { getBill, addBillPayment } from "@/lib/mock-bills"
+import { addRef, isDuplicateRef } from "@/lib/mock-ref-check"
 import { getQuickBill, getBillLink } from "@/lib/mock-quick-bills"
 import { billSecurity } from "@/lib/mock-settings"
 import ErrorBoundary from "@/components/ErrorBoundary"
@@ -69,12 +70,18 @@ export default function BillPage({ params }: { params: { id: string } }) {
   }
 
   const handleSendSlip = () => {
+    const ref = slip?.name || `pay-${Date.now()}`
+    if (isDuplicateRef(ref)) {
+      alert("เราได้รับข้อมูลแล้ว ไม่ต้องกดซ้ำครับพี่")
+      return
+    }
     addBillPayment(bill.id, {
-      id: `pay-${Date.now()}`,
+      id: ref,
       date: new Date().toISOString(),
       amount: parseFloat(amount) || 0,
       slip: slip?.name,
     })
+    addRef(ref)
     setAmount("")
     setSlip(null)
     alert("ส่งข้อมูลแล้ว")

--- a/lib/mock-ref-check.ts
+++ b/lib/mock-ref-check.ts
@@ -1,0 +1,26 @@
+const STORAGE_KEY = 'submittedRefs'
+let refs: string[] = []
+
+if (typeof window !== 'undefined') {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    refs = stored ? JSON.parse(stored) : []
+  } catch {}
+}
+
+export function addRef(ref: string) {
+  refs.push(ref)
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(refs))
+    } catch {}
+  }
+}
+
+export function isDuplicateRef(ref: string): boolean {
+  const duplicate = refs.includes(ref)
+  if (duplicate) {
+    console.warn('duplicate ref', ref)
+  }
+  return duplicate
+}


### PR DESCRIPTION
## Summary
- track bill payment references in `localStorage`
- warn user if they try to submit the same reference twice

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68753c2fb11483258d142b78b455c842