### PR TITLE
Implement admin order closing & printable summary

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -317,6 +317,21 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
             </Button>
           </CardContent>
         </Card>
+        <div className="flex justify-end">
+          <Button
+            onClick={async () => {
+              try {
+                setOrderStatus(order.id, "completed")
+                setStatus("completed")
+                toast.success("Order closed successfully")
+              } catch (err) {
+                toast.error("Failed to close order")
+              }
+            }}
+          >
+            Close Order
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/app/admin/orders/[id]/print/page.tsx
+++ b/app/admin/orders/[id]/print/page.tsx
@@ -4,8 +4,9 @@ import { useSearchParams } from "next/navigation"
 import { ArrowLeft, PrinterIcon as Print } from "lucide-react"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent } from "@/components/ui/cards/card"
-import BillPreview from "@/components/BillPreview"
+import { toast } from "sonner"
 import { mockOrders } from "@/lib/mock-orders"
+import { getPayment } from "@/lib/mock/payment"
 
 export default function AdminOrderPrintPage({ params }: { params: { id: string } }) {
   const { id } = params
@@ -13,23 +14,27 @@ export default function AdminOrderPrintPage({ params }: { params: { id: string }
   const fromChatName = searchParams.get("fromChat")
 
   const order = mockOrders.find((o) => o.id === id)
+  const payment = getPayment(id)
 
-  if (!order) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-4">ไม่พบบิล</h1>
-          <Link href="/admin/orders">
-            <Button>กลับไปหน้าคำสั่งซื้อ</Button>
-          </Link>
-        </div>
-      </div>
-    )
-  }
+  const paid = payment?.amount ?? 0
+  const remaining = order ? order.total - paid : 0
 
   const handlePrint = () => {
-    if (typeof window !== "undefined") {
-      window.print()
+    try {
+      if (typeof window !== "undefined") {
+        window.print()
+      }
+    } catch {
+      toast.error("Print failed")
+    }
+  }
+
+  const handleExport = () => {
+    try {
+      if (Math.random() < 0.05) throw new Error("fail")
+      toast.success("PDF exported (mock)")
+    } catch {
+      toast.error("Export failed")
     }
   }
 
@@ -38,33 +43,69 @@ export default function AdminOrderPrintPage({ params }: { params: { id: string }
       <div className="print:hidden bg-white border-b px-4 py-4">
         <div className="container mx-auto flex items-center justify-between">
           <div className="flex items-center space-x-4">
-            <Link href={`/admin/orders/${order.id}`}>
+            <Link href={`/admin/orders/${id}`}>
               <Button variant="outline" size="icon">
                 <ArrowLeft className="h-4 w-4" />
               </Button>
             </Link>
-            <h1 className="text-xl font-semibold">บิล {order.id}</h1>
+            <h1 className="text-xl font-semibold">Order {id}</h1>
           </div>
           <div className="flex space-x-2">
             <Button variant="outline" onClick={handlePrint}>
               <Print className="mr-2 h-4 w-4" />
-              พิมพ์
+              Print
+            </Button>
+            <Button variant="outline" onClick={handleExport}>
+              Export PDF (mock)
             </Button>
           </div>
         </div>
         {fromChatName && (
           <div className="container mx-auto mt-2">
-            <p className="text-sm text-gray-500">เปิดจากลูกค้า: {fromChatName}</p>
+            <p className="text-sm text-gray-500">Opened from: {fromChatName}</p>
           </div>
         )}
       </div>
 
       <div className="container mx-auto px-4 py-8 print:p-0">
-        <Card className="max-w-4xl mx-auto print:shadow-none print:border-none">
-          <CardContent className="p-8 print:p-6">
-            <BillPreview order={order} />
+        <Card className="max-w-3xl mx-auto print:shadow-none print:border-none">
+          <CardContent className="space-y-4 p-8 print:p-6">
+            {order ? (
+              <>
+                <div className="space-y-1">
+                  <p className="font-semibold">{order.customerName}</p>
+                  <p>{order.shippingAddress.phone}</p>
+                </div>
+                <div className="border-t pt-4 space-y-2">
+                  {order.items.map((it, i) => (
+                    <div key={i} className="flex justify-between">
+                      <span>{it.productName}</span>
+                      <span>
+                        {it.quantity} x ฿{it.price.toLocaleString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div className="border-t pt-4 space-y-1 text-right">
+                  <p>รวม: ฿{order.total.toLocaleString()}</p>
+                  <p>ชำระแล้ว: ฿{paid.toLocaleString()}</p>
+                  <p>คงเหลือ: ฿{remaining.toLocaleString()}</p>
+                </div>
+                {order.note && <p>หมายเหตุ: {order.note}</p>}
+                <p>สถานะ: {order.status}</p>
+              </>
+            ) : (
+              <p className="text-center">Order not found</p>
+            )}
           </CardContent>
         </Card>
+        {!order && (
+          <div className="mt-4 text-center">
+            <Link href="/admin/orders" className="text-blue-600 underline">
+              Back to orders
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow closing an order from order detail page
- redesign printable order view with summary
- support mock PDF export and print error handling

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68755a4c763c832597ad4ac93c9c73bf