### PR TITLE
Add mobile admin UX improvements

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -10,6 +10,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { AdminProductsProvider } from "@/contexts/admin-products-context"
 import { AdminCollectionsProvider } from "@/contexts/admin-collections-context"
 import { AdminToast } from "@/components/admin/AdminToast"
+import QuickActionBar from "@/components/admin/QuickActionBar"
 import ErrorBoundary from "@/components/ErrorBoundary"
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
@@ -47,8 +48,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             )}
             <div className="flex flex-1 flex-col">
               <Topbar onMenuClick={() => setSidebarOpen(true)} />
-              <main className="flex-1 p-4">{children}</main>
+              <main className="flex-1 p-4 pb-20 md:pb-4">{children}</main>
               <AdminToast />
+              <QuickActionBar />
             </div>
           </div>
         </AdminProductsProvider>

--- a/app/admin/openbill/quick/page.tsx
+++ b/app/admin/openbill/quick/page.tsx
@@ -32,25 +32,25 @@ export default function AdminOpenBillQuick() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 pb-20">
       <div className="container mx-auto px-4 py-8 space-y-6">
         <h1 className="text-3xl font-bold">เปิดบิลแบบรวดเร็ว</h1>
-        <Card>
+        <Card className="p-4 border">
           <CardHeader>
             <CardTitle>ข้อมูลลูกค้า</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            <Input placeholder="ชื่อลูกค้า" value={customerName} onChange={(e) => setCustomerName(e.target.value)} />
-            <Input placeholder="เบอร์ติดต่อ" value={phone} onChange={(e) => setPhone(e.target.value)} />
-            <Input placeholder="หมายเหตุ" value={note} onChange={(e) => setNote(e.target.value)} />
+            <Input className="w-full" placeholder="ชื่อลูกค้า" value={customerName} onChange={(e) => setCustomerName(e.target.value)} />
+            <Input className="w-full" placeholder="เบอร์ติดต่อ" value={phone} onChange={(e) => setPhone(e.target.value)} />
+            <Input className="w-full" placeholder="หมายเหตุ" value={note} onChange={(e) => setNote(e.target.value)} />
           </CardContent>
         </Card>
-        <Card>
+        <Card className="p-4 border">
           <CardHeader>
             <CardTitle>รายการสินค้า</CardTitle>
           </CardHeader>
-          <CardContent>
-            <Table>
+          <CardContent className="overflow-x-auto">
+            <Table className="min-w-full">
               <TableHeader>
                 <TableRow>
                   <TableHead>ชื่อสินค้า</TableHead>
@@ -62,13 +62,13 @@ export default function AdminOpenBillQuick() {
                 {items.map((item, idx) => (
                   <TableRow key={idx}>
                     <TableCell>
-                      <Input value={item.name} onChange={(e) => updateItem(idx, "name", e.target.value)} />
+                      <Input className="w-full" value={item.name} onChange={(e) => updateItem(idx, "name", e.target.value)} />
                     </TableCell>
                     <TableCell>
-                      <Input type="number" value={item.qty} onChange={(e) => updateItem(idx, "qty", e.target.value)} />
+                      <Input className="w-full" type="number" value={item.qty} onChange={(e) => updateItem(idx, "qty", e.target.value)} />
                     </TableCell>
                     <TableCell>
-                      <Input type="number" value={item.price} onChange={(e) => updateItem(idx, "price", e.target.value)} />
+                      <Input className="w-full" type="number" value={item.price} onChange={(e) => updateItem(idx, "price", e.target.value)} />
                     </TableCell>
                   </TableRow>
                 ))}
@@ -77,7 +77,7 @@ export default function AdminOpenBillQuick() {
             <Button variant="outline" className="mt-2" onClick={addItem}>เพิ่มสินค้าใหม่</Button>
           </CardContent>
         </Card>
-        <Button onClick={save}>บันทึกบิล</Button>
+        <Button className="fixed bottom-4 left-4 right-4" onClick={save}>บันทึกบิล</Button>
       </div>
     </div>
   )

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -174,7 +174,39 @@ export default function AdminOrdersPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <Table>
+            <div className="md:hidden space-y-4 mb-4">
+              {filteredOrders.map((order) => (
+                <details key={order.id} className="rounded-lg border p-4">
+                  <summary className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium">{order.customerName}</p>
+                      <p className="text-sm text-gray-500">
+                        {new Date(order.createdAt).toLocaleDateString("th-TH")}
+                      </p>
+                    </div>
+                    {statusTag(order)}
+                  </summary>
+                  <div className="mt-2 space-y-1 text-sm">
+                    <p>รหัส: {order.id}</p>
+                    <p>ยอดรวม: ฿{order.total.toLocaleString()}</p>
+                  </div>
+                  <div className="mt-2 flex gap-2">
+                    <Link href={`/admin/orders/${order.id}`}>
+                      <Button size="sm">ดู</Button>
+                    </Link>
+                    <Button
+                      size="sm"
+                      onClick={() => updateOrderStatus(order.id, "completed")}
+                    >
+                      ปิดยอด
+                    </Button>
+                  </div>
+                </details>
+              ))}
+            </div>
+
+            <div className="hidden md:block overflow-x-auto">
+            <Table className="min-w-full">
               <TableHeader>
                 <TableRow>
                   <TableHead>รหัสคำสั่งซื้อ</TableHead>
@@ -415,6 +447,7 @@ export default function AdminOrdersPage() {
                 ))}
               </TableBody>
             </Table>
+            </div>
 
             {filteredOrders.length === 0 && (
               <div className="text-center py-8">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -75,16 +75,18 @@ export default function AdminIndex() {
       <div className="flex flex-col gap-4 mb-4">
         <Button
           variant="default"
+          size="lg"
+          className="h-12"
           onClick={() => window.open(chatwootUrl, "_blank")}
         >
           แชทลูกค้า (Chatwoot)
         </Button>
         <Link href="/admin/dashboard">
-          <Button variant="outline">เข้าสู่แดชบอร์ด</Button>
+          <Button variant="outline" size="lg" className="h-12">เข้าสู่แดชบอร์ด</Button>
         </Link>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         <Card>
           <CardContent className="p-4 text-center">
             <p className="text-sm text-gray-600">ออเดอร์วันนี้</p>

--- a/components/admin/QuickActionBar.tsx
+++ b/components/admin/QuickActionBar.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import Link from "next/link"
+import { Plus, ClipboardList, MessageCircle, Settings } from "lucide-react"
+
+export default function QuickActionBar() {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-20 flex justify-around border-t bg-background py-2 md:hidden">
+      <Link href="/admin/openbill/quick" className="flex flex-col items-center text-xs">
+        <Plus className="h-5 w-5" />
+        <span>เปิดบิล</span>
+      </Link>
+      <Link href="/admin/orders" className="flex flex-col items-center text-xs">
+        <ClipboardList className="h-5 w-5" />
+        <span>ออเดอร์</span>
+      </Link>
+      <Link href="/admin/chat" className="flex flex-col items-center text-xs">
+        <MessageCircle className="h-5 w-5" />
+        <span>แชท</span>
+      </Link>
+      <Link href="/admin/settings" className="flex flex-col items-center text-xs">
+        <Settings className="h-5 w-5" />
+        <span>ตั้งค่า</span>
+      </Link>
+    </nav>
+  )
+}

--- a/components/admin/Topbar.tsx
+++ b/components/admin/Topbar.tsx
@@ -19,7 +19,7 @@ export default function Topbar({ onMenuClick }: { onMenuClick?: () => void }) {
   }, [])
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-background px-4">
+    <header className="sticky top-0 z-10 flex h-14 items-center justify-between border-b bg-background px-4">
       <div className="flex items-center gap-2">
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary
- make top bar sticky
- add mobile quick action bar
- tweak admin dashboard button and grid spacing
- optimize quick bill page layout for mobile
- render mobile card list for order admin page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875613734e88325a9eabb07962b3ce9