### PR TITLE
Implement mock sales report exports

### DIFF
--- a/app/admin/reports/sales/page.tsx
+++ b/app/admin/reports/sales/page.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import Link from "next/link"
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { ArrowLeft, Download } from "lucide-react"
+import { Button } from "@/components/ui/buttons/button"
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/cards/card"
+import { Input } from "@/components/ui/inputs/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { toast } from "sonner"
+import {
+  getOrdersInRange,
+  getDailySales,
+  getTopSellingItems,
+} from "@/lib/mock/orders"
+import { downloadExcel } from "@/lib/mock-export"
+import { formatCurrency } from "@/lib/utils"
+
+export default function AdminSalesReport() {
+  const today = new Date()
+  const past = new Date()
+  past.setDate(today.getDate() - 6)
+  const [start, setStart] = useState(past.toISOString().slice(0, 10))
+  const [end, setEnd] = useState(today.toISOString().slice(0, 10))
+
+  const startDate = useMemo(() => new Date(start), [start])
+  const endDate = useMemo(() => new Date(end + "T23:59:59"), [end])
+
+  const orders = useMemo(() => getOrdersInRange(startDate, endDate), [startDate, endDate])
+  const daily = useMemo(() => getDailySales(startDate, endDate), [startDate, endDate])
+  const total = useMemo(() => orders.reduce((s, o) => s + o.total, 0), [orders])
+  const topItems = useMemo(() => getTopSellingItems(startDate, endDate), [startDate, endDate])
+
+  const exportSummary = () => {
+    const lines = ["date,total", ...daily.map((d) => `${d.date},${d.total}`), "", "item,quantity", ...topItems.map((i) => `${i.name},${i.count}`)]
+    const blob = new Blob([lines.join("\n")], { type: "text/csv" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = "sales-summary.csv"
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const exportOrders = async () => {
+    await downloadExcel(
+      orders.map((o) => ({
+        id: o.id,
+        customer: o.customerName,
+        date: o.createdAt.slice(0, 10),
+        total: o.total,
+        status: o.status,
+      })),
+      "orders.xlsx",
+    )
+    toast.success("Export completed (mock)")
+  }
+
+  const exportAll = async () => {
+    exportSummary()
+    await exportOrders()
+    toast.success("ดาวน์โหลดไฟล์ทั้งหมดแล้ว (mock)")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/reports">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold">รายงานยอดขาย (mock)</h1>
+            <p className="text-gray-600">ดูยอดขายและสินค้าขายดี</p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+          <Input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+          <Button onClick={exportSummary} variant="outline">
+            <Download className="h-4 w-4" /> Export Summary (.csv)
+          </Button>
+          <Button onClick={exportOrders} variant="outline">
+            <Download className="h-4 w-4" /> Export Orders (.xlsx)
+          </Button>
+          <Button onClick={exportAll} variant="outline">
+            <Download className="h-4 w-4" /> ดาวน์โหลดทั้งหมด (CSV + Excel)
+          </Button>
+        </div>
+        {orders.length === 0 ? (
+          <Card>
+            <CardContent className="text-center py-8">
+              <p className="mb-2">ไม่มีข้อมูลในช่วงเวลานี้</p>
+              <p className="text-sm text-gray-500">ลองปรับช่วงวันที่ใหม่</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>ยอดขายรวม {formatCurrency(total)}</CardTitle>
+              </CardHeader>
+              <CardContent className="h-60">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={daily}>
+                    <XAxis dataKey="date" />
+                    <YAxis />
+                    <Tooltip />
+                    <Bar dataKey="total" fill="#8884d8" name="ยอดขาย" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>สินค้า Top 5</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>สินค้า</TableHead>
+                      <TableHead className="text-right">จำนวน</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {topItems.map((item) => (
+                      <TableRow key={item.name}>
+                        <TableCell>{item.name}</TableCell>
+                        <TableCell className="text-right">{item.count}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-export.ts
+++ b/lib/mock-export.ts
@@ -27,3 +27,24 @@ export function downloadPDF(content: string, filename: string) {
   a.click()
   URL.revokeObjectURL(url)
 }
+
+export async function downloadExcel<T extends object>(
+  rows: T[],
+  filename: string,
+) {
+  if (rows.length === 0) return
+  const XLSX = await import('xlsx')
+  const ws = XLSX.utils.json_to_sheet(rows)
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
+  const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+  const blob = new Blob([buf], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -157,3 +157,40 @@ export async function fetchOrders(): Promise<Order[]> {
 
   return data as Order[]
 }
+
+export function getOrdersInRange(start: Date, end: Date): Order[] {
+  return mockOrders.filter((o) => {
+    const d = new Date(o.createdAt)
+    return d >= start && d <= end
+  })
+}
+
+export function getDailySales(start: Date, end: Date) {
+  const days: Array<{ date: string; total: number }> = []
+  const cur = new Date(start)
+  while (cur <= end) {
+    const dateStr = cur.toISOString().slice(0, 10)
+    const total = mockOrders
+      .filter((o) => o.createdAt.slice(0, 10) === dateStr)
+      .reduce((s, o) => s + o.total, 0)
+    days.push({ date: dateStr, total })
+    cur.setDate(cur.getDate() + 1)
+  }
+  return days
+}
+
+export function getTopSellingItems(start: Date, end: Date, top = 5) {
+  const counts: Record<string, number> = {}
+  mockOrders.forEach((o) => {
+    const d = new Date(o.createdAt)
+    if (d >= start && d <= end) {
+      o.items.forEach((i) => {
+        counts[i.productName] = (counts[i.productName] || 0) + i.quantity
+      })
+    }
+  })
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top)
+    .map(([name, count]) => ({ name, count }))
+}

--- a/lib/mock/orders.ts
+++ b/lib/mock/orders.ts
@@ -1,8 +1,16 @@
 import type { Order, OrderStatus } from "@/types/order"
-import { mockOrders as baseOrders, setOrderStatus } from "../mock-orders"
+import {
+  mockOrders as baseOrders,
+  setOrderStatus,
+  getOrdersInRange,
+  getDailySales,
+  getTopSellingItems,
+} from "../mock-orders"
 
 export const mockOrders: Order[] = baseOrders
 
 export function updateOrderStatus(id: string, status: OrderStatus) {
   setOrderStatus(id, status)
 }
+
+export { getOrdersInRange, getDailySales, getTopSellingItems }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "latest",
+    "xlsx": "^0.18.5",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       vaul:
         specifier: latest
         version: 1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -1785,6 +1788,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1954,6 +1961,10 @@ packages:
   caniuse-lite@1.0.30001727:
     resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
@@ -1990,6 +2001,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2013,6 +2028,11 @@ packages:
 
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2449,6 +2469,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3327,6 +3351,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -3721,9 +3749,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3744,6 +3780,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -5237,6 +5278,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@7.1.4: {}
 
   ajv@6.12.6:
@@ -5425,6 +5468,11 @@ snapshots:
 
   caniuse-lite@1.0.30001727: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.2.1:
     dependencies:
       assertion-error: 2.0.1
@@ -5477,6 +5525,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5500,6 +5550,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confusing-browser-globals@1.0.11: {}
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6083,6 +6135,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -7028,6 +7082,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -7531,7 +7589,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -7546,6 +7608,16 @@ snapshots:
       strip-ansi: 7.1.0
 
   ws@8.18.3: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- add mock sales report page
- support Excel export
- expose mock order reporting helpers

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687562bf8d648325a6e4900a1388e6f8