### PR TITLE
Add mock debug logging tools

### DIFF
--- a/app/admin/logs/page.tsx
+++ b/app/admin/logs/page.tsx
@@ -1,0 +1,73 @@
+"use client"
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { logs, loadLogs, exportLogsTxt, exportLogsJson } from '@/lib/logs'
+
+export default function LogsPage() {
+  const { user, isAuthenticated } = useAuth()
+  const [entries, setEntries] = useState([...logs])
+
+  useEffect(() => {
+    loadLogs()
+    setEntries([...logs])
+  }, [])
+
+  if (!isAuthenticated || user?.role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Link href="/">
+          <Button>กลับหน้าแรก</Button>
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center mb-8 space-x-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">บันทึกระบบ</h1>
+          <div className="ml-auto flex gap-2">
+            <Button variant="outline" onClick={() => exportLogsTxt(entries, 'logs.txt')}>Export TXT</Button>
+            <Button variant="outline" onClick={() => exportLogsJson(entries, 'logs.json')}>Export JSON</Button>
+          </div>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Logs ({entries.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>เวลา</TableHead>
+                  <TableHead>การกระทำ</TableHead>
+                  <TableHead>ข้อมูล</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map((log) => (
+                  <TableRow key={log.id}>
+                    <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>{log.action}</TableCell>
+                    <TableCell>{JSON.stringify(log.payload)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -8,6 +8,8 @@ import { Badge } from "@/components/ui/badge";
 import { mockOrders, updateOrderStatus } from "@/lib/mock/orders";
 import { mockNotifications } from "@/lib/mock-notifications";
 import { chatNotifications } from "@/lib/mock/chat-notify";
+import DebugPanel from "@/components/admin/DebugPanel";
+import { logEvent } from "@/lib/logs";
 import type { Order } from "@/types/order";
 import { toast } from "sonner";
 
@@ -16,6 +18,7 @@ export default function AdminIndex() {
     process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
 
   const [orders, setOrders] = useState<Order[]>(mockOrders);
+  const [debugOpen, setDebugOpen] = useState(false);
 
   let todayCount = 0;
   let todayIncome = 0;
@@ -62,12 +65,14 @@ export default function AdminIndex() {
   const markReady = (id: string) => {
     updateOrderStatus(id, "packed");
     setOrders([...mockOrders]);
+    logEvent('order_ready', { id });
     toast.success("สถานะอัปเดตแล้ว");
   };
 
   const markCompleted = (id: string) => {
     updateOrderStatus(id, "completed");
     setOrders([...mockOrders]);
+    logEvent('order_completed', { id });
     toast.success("สถานะอัปเดตแล้ว");
   };
 
@@ -85,6 +90,18 @@ export default function AdminIndex() {
         <Link href="/admin/dashboard">
           <Button variant="outline" size="lg" className="h-12">เข้าสู่แดชบอร์ด</Button>
         </Link>
+        <Button
+          variant="outline"
+          size="lg"
+          className="h-12"
+          onClick={() => {
+            const next = !debugOpen
+            setDebugOpen(next)
+            logEvent('toggle_debug', { open: next })
+          }}
+        >
+          {debugOpen ? 'ปิด Debug' : 'เปิด Debug'}
+        </Button>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
@@ -191,11 +208,12 @@ export default function AdminIndex() {
                 </li>
               ))}
             </ul>
-          ) : (
-            <p>ไม่มีข้อมูลคำสั่งซื้อ</p>
-          )}
-        </CardContent>
+      ) : (
+        <p>ไม่มีข้อมูลคำสั่งซื้อ</p>
+      )}
+      </CardContent>
       </Card>
+      {debugOpen && <DebugPanel />}
     </div>
   );
 }

--- a/components/admin/DebugPanel.tsx
+++ b/components/admin/DebugPanel.tsx
@@ -1,0 +1,17 @@
+"use client"
+import { logs } from '@/lib/logs'
+
+export default function DebugPanel() {
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-80 max-h-60 overflow-y-auto rounded border bg-white p-4 text-xs shadow">
+      <p className="font-bold mb-2">Debug Panel</p>
+      {logs.length ? (
+        <pre className="whitespace-pre-wrap break-all">
+          {JSON.stringify(logs.slice(-5), null, 2)}
+        </pre>
+      ) : (
+        <p>No logs</p>
+      )}
+    </div>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -34,6 +34,7 @@ const navItems = [
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
   { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
   { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List },
+  { href: "/admin/logs", label: "Log", icon: FileText },
 ]
 
 export default function Sidebar({ className = "" }: { className?: string }) {

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -1,0 +1,55 @@
+export interface LogEntry {
+  id: string
+  action: string
+  payload?: any
+  timestamp: string
+}
+
+const STORAGE_KEY = 'appLogs'
+
+export let logs: LogEntry[] = []
+
+export function loadLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) logs = JSON.parse(stored)
+  }
+}
+
+export function logEvent(action: string, payload?: any) {
+  const entry: LogEntry = {
+    id: Date.now().toString(),
+    action,
+    payload,
+    timestamp: new Date().toISOString(),
+  }
+  logs.push(entry)
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(logs))
+  }
+}
+
+export function exportLogsTxt(entries: LogEntry[], filename: string) {
+  const text = entries
+    .map((e) => `[${e.timestamp}] ${e.action} ${JSON.stringify(e.payload)}`)
+    .join('\n')
+  const blob = new Blob([text], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function exportLogsJson(entries: LogEntry[], filename: string) {
+  const blob = new Blob([JSON.stringify(entries, null, 2)], {
+    type: 'application/json',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- implement local log utilities for mock mode
- show a debug panel on the admin landing page
- allow exporting logs and view them at `/admin/logs`
- link log viewer in the sidebar

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68756fd327ec832594ffe443b68e80cc