### PR TITLE
Add breadcrumbs and sticky bar to collection page

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -1,11 +1,21 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/buttons/button"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
 import { supabase } from "@/lib/supabase"
 import { getCollections } from "@/lib/mock-collections"
 import { WishlistButton } from "@/components/WishlistButton"
 import { mockFabrics } from "@/lib/mock-fabrics"
 import { FabricsList } from "@/components/FabricsList"
+import { CopyPageLinkButton } from "@/components/CopyPageLinkButton"
+import { CollectionStickyBar } from "@/components/CollectionStickyBar"
 
 export default async function CollectionDetailPage({ params }: { params: { slug: string } }) {
   let data: any
@@ -14,7 +24,9 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
     const collections = await getCollections()
     data = collections.find((c) => c.slug === params.slug)
     if (!data) {
-      return <div className="p-4 text-red-500">ไม่พบคอลเลกชันนี้</div>
+      return (
+        <div className="text-center text-destructive">ไม่พบคอลเลกชันนี้ในระบบ</div>
+      )
     }
   } else {
     const { data: dbData, error } = await supabase
@@ -24,7 +36,9 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
       .single()
 
     if (error || !dbData) {
-      return <div className="p-4 text-red-500">ไม่พบคอลเลกชันนี้</div>
+      return (
+        <div className="text-center text-destructive">ไม่พบคอลเลกชันนี้ในระบบ</div>
+      )
     }
 
     data = {
@@ -38,22 +52,36 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
   }
 
   const fabrics = mockFabrics.filter((f) => f.collectionSlug === data.slug)
+  const subtitle = `มีทั้งหมด ${fabrics.length} ลายผ้าในกลุ่มนี้`
 
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
-      <div className="container mx-auto px-4 py-8 flex-1">
-        <div className="flex items-center mb-2 space-x-2">
+      <div className="container mx-auto px-4 py-8 flex-1 space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">หน้าแรก</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/collections">คอลเลกชัน</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{data.name}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <div className="flex items-center space-x-2">
           <h1 className="text-3xl font-bold">{data.name}</h1>
           <WishlistButton slug={data.slug} />
         </div>
-        {data.priceRange && (
-          <p className="text-gray-700 mb-2">{data.priceRange}</p>
-        )}
+        <p className="text-gray-700">{subtitle}</p>
         {data.description && (
-          <p className="text-gray-600 mb-4 whitespace-pre-line">{data.description}</p>
+          <p className="text-gray-600 whitespace-pre-line">{data.description}</p>
         )}
-        <div className="mb-6">
+        <div className="flex items-center gap-2">
           <a
             href={`https://m.me/elfsofacover?text=${encodeURIComponent(
               `สนใจลายผ้า ${data.slug} ครับ`,
@@ -63,10 +91,12 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
           >
             <Button size="sm">💬 สอบถามผ่าน Facebook</Button>
           </a>
+          <CopyPageLinkButton />
         </div>
         <FabricsList fabrics={fabrics} />
       </div>
       <Footer />
+      <CollectionStickyBar name={data.name} />
     </div>
   )
 }

--- a/components/CollectionStickyBar.tsx
+++ b/components/CollectionStickyBar.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+
+export function CollectionStickyBar({ name }: { name: string }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 100)
+    }
+    window.addEventListener("scroll", onScroll)
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+
+  return (
+    <div
+      className={`fixed left-0 right-0 z-40 bottom-0 md:top-0 md:bottom-auto border bg-background transition-transform ${visible ? "translate-y-0" : "translate-y-full md:-translate-y-full"}`}
+    >
+      <div className="container mx-auto px-4 py-2 flex items-center justify-between text-sm">
+        <span className="font-medium truncate">{name}</span>
+        <Link href="/" className="text-primary underline">
+          กลับหน้าหลัก
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/components/CopyPageLinkButton.tsx
+++ b/components/CopyPageLinkButton.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { Button } from "@/components/ui/buttons/button"
+import { toast } from "sonner"
+
+export function CopyPageLinkButton() {
+  const handleClick = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        toast.success("คัดลอกลิงก์สำเร็จ ส่งให้ลูกค้าได้เลย")
+      })
+      .catch(() => {
+        toast.error("ไม่สามารถคัดลอกลิงก์ได้")
+      })
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleClick}>
+      คัดลอกลิงก์หน้านี้
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- enhance collection detail layout with breadcrumb, subtitle, and share link
- add copy-link button with toast
- show sticky navigation bar when scrolling
- handle invalid collection slug gracefully

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875a49b47988325a23989663639d646