### PR TITLE
Add fullscreen gallery and fabric suggestions

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getCollections } from "@/lib/mock-collections"
 import { WishlistButton } from "@/components/WishlistButton"
 import { mockFabrics } from "@/lib/mock-fabrics"
 import { FabricsList } from "@/components/FabricsList"
+import { SharePageButton } from "@/components/SharePageButton"
 
 export default async function CollectionDetailPage({ params }: { params: { slug: string } }) {
   let data: any
@@ -37,7 +38,18 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
     }
   }
 
-  const fabrics = mockFabrics.filter((f) => f.collectionSlug === data.slug)
+  const fabrics = mockFabrics
+    .filter((f) => f.collectionSlug === data.slug)
+    .map((f) => ({
+      id: f.id,
+      slug: f.slug,
+      name: f.name,
+      image_urls: f.images,
+    }))
+
+  const suggestions = fabrics.length
+    ? [...fabrics].sort(() => 0.5 - Math.random()).slice(0, 4)
+    : []
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -65,6 +77,17 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
           </a>
         </div>
         <FabricsList fabrics={fabrics} />
+        <div className="mt-10">
+          <h2 className="text-xl font-bold mb-4">ลายผ้าอื่น ๆ ที่คุณอาจชอบ</h2>
+          {suggestions.length > 0 ? (
+            <FabricsList fabrics={suggestions} />
+          ) : (
+            <div className="text-center text-muted text-sm">ไม่มีลายผ้าอื่นในกลุ่มนี้</div>
+          )}
+          <div className="mt-4 text-center">
+            <SharePageButton />
+          </div>
+        </div>
       </div>
       <Footer />
     </div>

--- a/components/FabricGalleryModal.tsx
+++ b/components/FabricGalleryModal.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useState } from "react"
+import { Dialog, DialogContent } from "@/components/ui/modals/dialog"
+import { Button } from "@/components/ui/buttons/button"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+interface Props {
+  images: string[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function FabricGalleryModal({ images, open, onOpenChange }: Props) {
+  const [index, setIndex] = useState(0)
+  const [zoom, setZoom] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onOpenChange(false)
+      else if (e.key === "ArrowLeft") setIndex((i) => (i - 1 + images.length) % images.length)
+      else if (e.key === "ArrowRight") setIndex((i) => (i + 1) % images.length)
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [open, images.length, onOpenChange])
+
+  useEffect(() => {
+    if (open) {
+      setIndex(0)
+      setZoom(false)
+    }
+  }, [open])
+
+  const prev = () => setIndex((i) => (i - 1 + images.length) % images.length)
+  const next = () => setIndex((i) => (i + 1) % images.length)
+
+  const toggleZoom = () => setZoom((z) => !z)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="p-0 max-w-none w-screen h-screen bg-black">
+        <div className="relative w-full h-full flex items-center justify-center">
+          <Image
+            src={images[index]}
+            alt="fabric"
+            fill
+            sizes="100vw"
+            className={`object-contain transition-transform ${zoom ? "scale-150 cursor-zoom-out" : "cursor-zoom-in"}`}
+            onClick={toggleZoom}
+          />
+          {images.length > 1 && (
+            <>
+              <Button
+                size="icon"
+                variant="secondary"
+                className="absolute left-4 top-1/2 -translate-y-1/2"
+                onClick={prev}
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </Button>
+              <Button
+                size="icon"
+                variant="secondary"
+                className="absolute right-4 top-1/2 -translate-y-1/2"
+                onClick={next}
+              >
+                <ChevronRight className="h-5 w-5" />
+              </Button>
+            </>
+          )}
+          <Button size="sm" className="absolute top-4 left-4" onClick={() => onOpenChange(false)}>
+            ปิด
+          </Button>
+          <Button size="sm" className="absolute top-4 right-4" onClick={toggleZoom}>
+            ขยาย
+          </Button>
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white text-sm">เลื่อนดู</div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -7,6 +7,8 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
+import { useState } from "react"
+import { FabricGalleryModal } from "./FabricGalleryModal"
 
 interface Fabric {
   id: string
@@ -20,6 +22,7 @@ interface Fabric {
 export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
   const { items, toggleCompare } = useCompare()
   const router = useRouter()
+  const [viewer, setViewer] = useState<string[] | null>(null)
 
   const handleCompare = () => {
     router.push(`/compare`)
@@ -61,6 +64,21 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                 <div className="p-2 text-center">
                   <p className="font-medium line-clamp-2">{fabric.name}</p>
                 </div>
+                <Button
+                  size="sm"
+                  className="absolute bottom-2 right-2"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setViewer(
+                      fabric.image_urls || fabric.image_url
+                        ? fabric.image_urls || [fabric.image_url!]
+                        : []
+                    )
+                  }}
+                >
+                  ดูภาพเต็ม
+                </Button>
               </Link>
             </div>
           )
@@ -70,6 +88,13 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
         <div className="mt-4 text-center">
           <Button onClick={handleCompare}>เปรียบเทียบตอนนี้</Button>
         </div>
+      )}
+      {viewer && (
+        <FabricGalleryModal
+          images={viewer}
+          open={true}
+          onOpenChange={(o) => !o && setViewer(null)}
+        />
       )}
     </>
   )

--- a/components/SharePageButton.tsx
+++ b/components/SharePageButton.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { Button } from "@/components/ui/buttons/button"
+
+export function SharePageButton() {
+  const handleClick = () => {
+    const link = window.location.href
+    const message = `แนะนำลายผ้านี้ให้เพื่อน 👉 ${link}`
+    navigator.clipboard.writeText(message).catch(() => {})
+  }
+  return (
+    <Button onClick={handleClick}>ส่งต่อเพื่อน</Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add `FabricGalleryModal` for viewing fabric images in fullscreen
- enhance `FabricsList` with modal viewer button
- show related fabrics on collection page
- add button to copy page link for sharing

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6875a6fe6ab08325b61d8d3fad61de68