### PR TITLE
Add favorite fabrics modal

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { supabase } from "@/lib/supabase"
 import { getCollections } from "@/lib/mock-collections"
 import { WishlistButton } from "@/components/WishlistButton"
+import { FavoriteFabricsDialog } from "@/components/FavoriteFabricsDialog"
 import { mockFabrics } from "@/lib/mock-fabrics"
 import { FabricsList } from "@/components/FabricsList"
 import { CopyPageLinkButton } from "@/components/CopyPageLinkButton"
@@ -78,6 +79,9 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
             </BreadcrumbItem>
           </BreadcrumbList>
         </Breadcrumb>
+        <div className="flex justify-end">
+          <FavoriteFabricsDialog />
+        </div>
         <div className="flex items-center space-x-2">
           <h1 className="text-3xl font-bold">{data.name}</h1>
           <WishlistButton slug={data.slug} />

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
+import { FavoriteButton } from "@/components/FavoriteButton"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
@@ -42,6 +43,10 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                   ดูด้วยกันบ่อย
                 </span>
               )}
+              <FavoriteButton
+                slug={slug}
+                className="absolute bottom-2 right-2 z-10 bg-white/80 rounded-full p-1"
+              />
               <Checkbox
                 checked={checked}
                 onCheckedChange={() => toggleCompare(slug)}

--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -3,13 +3,20 @@
 import { Heart } from 'lucide-react'
 import { useFavorites } from '@/contexts/favorites-context'
 
-export function FavoriteButton({ slug }: { slug: string }) {
+export function FavoriteButton({ slug, className }: { slug: string; className?: string }) {
   const { favorites, toggleFavorite } = useFavorites()
   const active = favorites.includes(slug)
 
   return (
-    <button onClick={() => toggleFavorite(slug)} aria-label="toggle favorite">
-      <Heart className={`h-6 w-6 ${active ? 'text-red-500' : 'text-gray-500'}`} fill={active ? 'currentColor' : 'none'} />
+    <button
+      onClick={() => toggleFavorite(slug)}
+      aria-label="toggle favorite"
+      className={className}
+    >
+      <Heart
+        className={`h-6 w-6 ${active ? 'text-red-500' : 'text-gray-500'}`}
+        fill={active ? 'currentColor' : 'none'}
+      />
     </button>
   )
 }

--- a/components/FavoriteFabricsDialog.tsx
+++ b/components/FavoriteFabricsDialog.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import Image from "next/image"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/modals/dialog"
+import { Button } from "@/components/ui/buttons/button"
+import { useFavorites } from "@/contexts/favorites-context"
+import { mockFabrics } from "@/lib/mock-fabrics"
+import { toast } from "sonner"
+
+export function FavoriteFabricsDialog() {
+  const { favorites, toggleFavorite } = useFavorites()
+  const items = mockFabrics.filter(f => favorites.includes(f.slug))
+
+  const handleCopy = (slug: string) => {
+    const url = `${window.location.origin}/fabrics/${slug}`
+    navigator.clipboard.writeText(url)
+      .then(() => toast.success("คัดลอกลิงก์สำเร็จ"))
+      .catch(() => toast.error("ไม่สามารถคัดลอกลิงก์ได้"))
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">ลายที่ชอบ</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>ลายผ้าที่ชอบ</DialogTitle>
+        </DialogHeader>
+        {items.length === 0 ? (
+          <p className="text-center text-sm text-gray-600">ยังไม่มีลายผ้าที่ชอบ</p>
+        ) : (
+          <div className="space-y-4">
+            {items.map(f => (
+              <div key={f.id} className="flex items-center gap-4">
+                <Image src={f.images[0] || '/placeholder.svg'} alt={f.name} width={80} height={80} className="rounded" />
+                <div className="flex-1">
+                  <p className="font-medium">{f.name}</p>
+                  <p className="text-sm text-gray-500">รหัส: {f.sku}</p>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Button variant="outline" size="sm" onClick={() => toggleFavorite(f.slug)}>
+                    ลบออกจากรายการนี้
+                  </Button>
+                  <Button variant="secondary" size="sm" onClick={() => handleCopy(f.slug)}>
+                    คัดลอกลิงก์ลายนี้
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/contexts/favorites-context.tsx
+++ b/contexts/favorites-context.tsx
@@ -12,8 +12,14 @@ interface FavoritesContextValue {
 const FavoritesContext = createContext<FavoritesContextValue | null>(null)
 
 export function FavoritesProvider({ children }: { children: ReactNode }) {
-  const [favorites, setFavorites] = useLocalStorage<string[]>('favorites', [])
-  const [counts, setCounts] = useLocalStorage<Record<string, number>>('favorite-counts', {})
+  const [favorites, setFavorites] = useLocalStorage<string[]>(
+    'favFabrics',
+    [],
+  )
+  const [counts, setCounts] = useLocalStorage<Record<string, number>>(
+    'favFabricCounts',
+    {},
+  )
 
   const toggleFavorite = (slug: string) => {
     setFavorites(prev => {


### PR DESCRIPTION
## Summary
- save favorites to `favFabrics` localStorage key
- add `FavoriteButton` styling prop
- show favorite toggle on fabric cards
- show `ลายที่ชอบ` modal on collection page

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6875abb4e124832595e9d47892a425d1