### PR TITLE
Add mock admin fabric management

### DIFF
--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -1,13 +1,16 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
-import Link from "next/link"
-import Image from "next/image"
-import { useAuth } from "@/contexts/auth-context"
-import { supabase } from "@/lib/supabase"
+import { Plus, Edit, Trash2 } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader as DHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/modals/dialog"
 import { Button } from "@/components/ui/buttons/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import {
   Table,
   TableBody,
@@ -16,234 +19,186 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { ArrowLeft, Edit, Plus, Trash2, Search } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
-
-interface Fabric {
-  id: string
-  name: string
-  sku: string
-  collection_id: string
-  image_url: string | null
-  price_min: number
-  price_max: number
-  collection_name?: string | null
-}
+import type { AdminFabric } from "@/mock/fabrics"
+import { mockFabrics, addFabric, updateFabric, deleteFabric } from "@/mock/fabrics"
 
 export default function AdminFabricsPage() {
-  const { user, isAuthenticated } = useAuth()
-  const router = useRouter()
+  const [fabrics, setFabrics] = useState<AdminFabric[]>([])
+  const [loading, setLoading] = useState(true)
   const { toast } = useToast()
-  const [fabrics, setFabrics] = useState<Fabric[]>([])
-  const [imgError, setImgError] = useState<Record<string, boolean>>({})
-  const [searchTerm, setSearchTerm] = useState("")
-  const [collectionFilter, setCollectionFilter] = useState("all")
-  const [collectionOptions, setCollectionOptions] = useState<{id: string; name: string}[]>([])
-
-  const handleDelete = async (id: string) => {
-    if (
-      typeof window !== "undefined" &&
-      !window.confirm("คุณต้องการลบลายผ้านี้ใช่หรือไม่?")
-    )
-      return
-
-    const previous = fabrics
-    setFabrics(fabrics.filter((f) => f.id !== id))
-
-    const { error } = await supabase?.from("fabrics").delete().eq("id", id)
-
-    if (error) {
-      console.error("Failed to delete fabric", error)
-      setFabrics(previous)
-      toast({
-        title: "เกิดข้อผิดพลาด",
-        description: "ไม่สามารถลบลายผ้าได้",
-        variant: "destructive",
-      })
-    } else {
-      toast({ title: "ลบลายผ้าแล้ว" })
-    }
-  }
 
   useEffect(() => {
-    if (!isAuthenticated) {
-      router.push("/login")
-      return
-    }
-    if (user?.role !== "admin") {
-      router.push("/")
-      return
-    }
-  }, [isAuthenticated, user, router])
-
-  useEffect(() => {
-    const fetchFabrics = async () => {
-      if (!supabase) return
-      const { data: fabricsData, error } = await supabase
-        .from("fabrics")
-        .select("id, name, sku, collection_id, image_url, price_min, price_max")
-      if (error || !fabricsData) {
-        console.error("Failed to fetch fabrics", error)
-        return
-      }
-      const { data: collectionsData } = await supabase
-        .from("collections")
-        .select("id, name")
-      const collectionMap: Record<string, string> = {}
-      collectionsData?.forEach((c) => {
-        collectionMap[c.id] = c.name
-      })
-      if (collectionsData) {
-        setCollectionOptions(collectionsData)
-      }
-      const withCollectionName = fabricsData.map((f) => ({
-        ...f,
-        collection_name: collectionMap[f.collection_id] || null,
-      }))
-      setFabrics(withCollectionName)
-    }
-    fetchFabrics()
+    const timer = setTimeout(() => {
+      setFabrics([...mockFabrics])
+      setLoading(false)
+    }, 300)
+    return () => clearTimeout(timer)
   }, [])
 
-  const filteredFabrics = fabrics.filter((f) => {
-    const matchesSearch =
-      f.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      f.collection_name?.toLowerCase().includes(searchTerm.toLowerCase())
-    const matchesCollection =
-      collectionFilter === "all" || f.collection_id === collectionFilter
-    return matchesSearch && matchesCollection
-  })
+  const [openAdd, setOpenAdd] = useState(false)
+  const [addName, setAddName] = useState("")
+  const [addPrice, setAddPrice] = useState("")
+  const [addFiles, setAddFiles] = useState<File[]>([])
+  const [saving, setSaving] = useState(false)
 
-  if (!isAuthenticated || user?.role !== "admin") {
-    return null
+  const addPreviews = addFiles.map(f => URL.createObjectURL(f))
+
+  const handleAdd = () => {
+    setSaving(true)
+    const imgs = addPreviews.slice()
+    addFabric({ name: addName, price: Number(addPrice || 0), images: imgs })
+    setFabrics([...mockFabrics])
+    setOpenAdd(false)
+    setAddName("")
+    setAddPrice("")
+    setAddFiles([])
+    setSaving(false)
+    toast({ title: "เพิ่มลายผ้าแล้ว" })
+  }
+
+  const [editing, setEditing] = useState<AdminFabric | null>(null)
+  const [editName, setEditName] = useState("")
+  const [editPrice, setEditPrice] = useState("")
+  const [editFiles, setEditFiles] = useState<File[]>([])
+
+  const editPreviews = editFiles.length
+    ? editFiles.map(f => URL.createObjectURL(f))
+    : editing?.images || []
+
+  const openEdit = (fab: AdminFabric) => {
+    setEditing(fab)
+    setEditName(fab.name)
+    setEditPrice(String(fab.price))
+    setEditFiles([])
+  }
+
+  const handleEdit = () => {
+    if (!editing) return
+    setSaving(true)
+    const imgs = editFiles.length ? editPreviews.slice() : editing.images
+    updateFabric(editing.id, { name: editName, price: Number(editPrice || 0), images: imgs })
+    setFabrics([...mockFabrics])
+    setSaving(false)
+    setEditing(null)
+    toast({ title: "บันทึกการแก้ไขแล้ว" })
+  }
+
+  const handleDelete = (id: string) => {
+    if (typeof window !== "undefined" && !window.confirm("ยืนยันการลบ?")) return
+    deleteFabric(id)
+    setFabrics([...mockFabrics])
+    toast({ title: "ลบลายผ้าแล้ว" })
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-8">
-          <div className="flex items-center space-x-4">
-            <Link href="/admin/dashboard">
-              <Button variant="outline" size="icon">
-                <ArrowLeft className="h-4 w-4" />
-              </Button>
-            </Link>
-            <div>
-              <h1 className="text-3xl font-bold">จัดการผ้า</h1>
-              <p className="text-gray-600">เพิ่ม แก้ไข และลบผ้าในระบบ</p>
-            </div>
-          </div>
-          <Link href="/admin/fabrics/create">
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">จัดการผ้า (mock)</h1>
+        <Dialog open={openAdd} onOpenChange={setOpenAdd}>
+          <DialogTrigger asChild>
             <Button>
-              <Plus className="mr-2 h-4 w-4" />
-              เพิ่มผ้าใหม่
+              <Plus className="mr-2 h-4 w-4" /> เพิ่มลายผ้าใหม่
             </Button>
-          </Link>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-              <CardTitle>รายการผ้า ({filteredFabrics.length})</CardTitle>
-              <div className="flex items-center space-x-2">
-                <div className="relative">
-                  <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    placeholder="ค้นหา..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-8 w-60"
-                  />
-                </div>
-                <Select value={collectionFilter} onValueChange={setCollectionFilter}>
-                  <SelectTrigger className="w-40">
-                    <SelectValue placeholder="คอลเลกชัน" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">ทั้งหมด</SelectItem>
-                    {collectionOptions.map((c) => (
-                      <SelectItem key={c.id} value={c.id}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="overflow-x-auto">
-            {filteredFabrics.length > 0 ? (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>รูปภาพ</TableHead>
-                    <TableHead>ชื่อผ้า</TableHead>
-                    <TableHead>ราคา</TableHead>
-                    <TableHead>คอลเลกชัน</TableHead>
-                    <TableHead className="text-right">การจัดการ</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredFabrics.map((fabric) => (
-                    <TableRow key={fabric.id}>
-                      <TableCell>
-                        <div className="h-20 w-20 flex items-center justify-center">
-                          {fabric.image_url && !imgError[fabric.id] ? (
-                            <Image
-                              src={fabric.image_url}
-                              alt={fabric.name}
-                              width={80}
-                              height={80}
-                              className="rounded-md object-cover"
-                              onError={() =>
-                                setImgError((prev) => ({ ...prev, [fabric.id]: true }))
-                              }
-                            />
-                          ) : (
-                            <span className="text-sm text-gray-500">No image</span>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>{fabric.name}</TableCell>
-                      <TableCell>
-                        ฿{fabric.price_min.toLocaleString()} - ฿{fabric.price_max.toLocaleString()}
-                      </TableCell>
-                      <TableCell>{fabric.collection_name || "-"}</TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex items-center justify-end space-x-2">
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => router.push(`/admin/fabrics/${fabric.id}/edit`)}
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => handleDelete(fabric.id)}
-                            className="text-red-600 hover:text-red-700"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
+          </DialogTrigger>
+          <DialogContent className="max-w-lg">
+            <DHeader>
+              <DialogTitle>เพิ่มลายผ้า</DialogTitle>
+            </DHeader>
+            <div className="space-y-4">
+              <Input placeholder="ชื่อผ้า" value={addName} onChange={e => setAddName(e.target.value)} />
+              <Input placeholder="ราคา" type="number" value={addPrice} onChange={e => setAddPrice(e.target.value)} />
+              <Input type="file" multiple onChange={e => setAddFiles(Array.from(e.target.files ?? []))} />
+              {addPreviews.length > 0 && (
+                <div className="flex gap-2 flex-wrap">
+                  {addPreviews.map(src => (
+                    <img key={src} src={src} alt="preview" className="h-20 w-20 object-cover rounded" />
                   ))}
-                </TableBody>
-              </Table>
-            ) : (
-              <div className="text-center py-8">
-                {fabrics.length === 0
-                  ? "ยังไม่มีผ้าในระบบ"
-                  : "ไม่พบผ้าที่ตรงกับเงื่อนไขการค้นหา"}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                </div>
+              )}
+            </div>
+            <DialogFooter>
+              <Button onClick={handleAdd} disabled={saving || !addName}>
+                บันทึก
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>รายการผ้า ({fabrics.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-center py-8 text-sm text-gray-500">กำลังโหลด...</p>
+          ) : fabrics.length === 0 ? (
+            <p className="text-center py-8 text-sm text-gray-500">ไม่มีข้อมูลผ้า</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>รูป</TableHead>
+                  <TableHead>ชื่อ</TableHead>
+                  <TableHead>ราคา</TableHead>
+                  <TableHead className="text-right">จัดการ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {fabrics.map(f => (
+                  <TableRow key={f.id}>
+                    <TableCell>
+                      {f.images[0] ? (
+                        <img src={f.images[0]} alt={f.name} className="h-12 w-12 object-cover rounded" />
+                      ) : (
+                        <span className="text-xs text-gray-500">ไม่มีรูป</span>
+                      )}
+                    </TableCell>
+                    <TableCell>{f.name}</TableCell>
+                    <TableCell>฿{f.price.toLocaleString()}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Dialog open={editing?.id === f.id} onOpenChange={v => (v ? openEdit(f) : setEditing(null))}>
+                          <DialogTrigger asChild>
+                            <Button variant="outline" size="icon" onClick={() => openEdit(f)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent className="max-w-lg">
+                            <DHeader>
+                              <DialogTitle>แก้ไขลายผ้า</DialogTitle>
+                            </DHeader>
+                            <div className="space-y-4">
+                              <Input value={editName} onChange={e => setEditName(e.target.value)} />
+                              <Input type="number" value={editPrice} onChange={e => setEditPrice(e.target.value)} />
+                              <Input type="file" multiple onChange={e => setEditFiles(Array.from(e.target.files ?? []))} />
+                              {editPreviews.length > 0 && (
+                                <div className="flex gap-2 flex-wrap">
+                                  {editPreviews.map(src => (
+                                    <img key={src} src={src} alt="preview" className="h-20 w-20 object-cover rounded" />
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <DialogFooter>
+                              <Button onClick={handleEdit} disabled={saving || !editName}>บันทึก</Button>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
+                        <Button variant="outline" size="icon" onClick={() => handleDelete(f.id)} className="text-red-600">
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/mock/fabrics.ts
+++ b/mock/fabrics.ts
@@ -1,0 +1,50 @@
+export interface AdminFabric {
+  id: string
+  name: string
+  price: number
+  images: string[]
+}
+
+export const mockFabrics: AdminFabric[] = [
+  {
+    id: 'FAB-001',
+    name: 'Soft Linen',
+    price: 990,
+    images: ['/images/039.jpg', '/images/040.jpg'],
+  },
+  {
+    id: 'FAB-002',
+    name: 'Cozy Cotton',
+    price: 1090,
+    images: ['/images/041.jpg', '/images/042.jpg'],
+  },
+  {
+    id: 'FAB-003',
+    name: 'Velvet Dream',
+    price: 1290,
+    images: ['/images/043.jpg', '/images/044.jpg'],
+  },
+]
+
+export function addFabric(data: Omit<AdminFabric, 'id'>): AdminFabric {
+  const fabric: AdminFabric = {
+    id: `FAB-${Math.random().toString(36).slice(2, 8)}`,
+    ...data,
+  }
+  mockFabrics.unshift(fabric)
+  return fabric
+}
+
+export function updateFabric(id: string, data: Partial<Omit<AdminFabric, 'id'>>) {
+  const idx = mockFabrics.findIndex(f => f.id === id)
+  if (idx > -1) {
+    mockFabrics[idx] = { ...mockFabrics[idx], ...data }
+  }
+}
+
+export function deleteFabric(id: string) {
+  const idx = mockFabrics.findIndex(f => f.id === id)
+  if (idx > -1) {
+    mockFabrics.splice(idx, 1)
+  }
+}


### PR DESCRIPTION
## Summary
- add mock fabric dataset with CRUD helpers
- rewrite admin fabrics page to manage fabrics in-memory with modals

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6875c0d6e8208325a7ab3ff6471a92fb