### PR TITLE
Add collection filter and SEO metadata

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,50 +1,19 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import Image from "next/image"
 import Link from "next/link"
 import { getCollections } from "@/lib/mock-collections"
+import { mockFabrics } from "@/lib/mock-fabrics"
+import type { Metadata } from "next"
 import type { Collection } from "@/types/collection"
 
+export const metadata: Metadata = {
+  title: "คอลเลกชันลายผ้า | SofaCover Pro",
+  description: "เลือกชมกลุ่มลายผ้าทั้งหมด",
+}
 
-export default function CollectionsPage() {
-  const [collections, setCollections] = useState<Collection[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    const fetchCollections = async () => {
-      try {
-        const data = await getCollections()
-        setCollections(data.slice(0))
-      } catch (err) {
-        setError("ไม่สามารถโหลดข้อมูลคอลเลกชันได้")
-      }
-      setLoading(false)
-    }
-
-    fetchCollections()
-  }, [])
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="min-h-screen">
-        <Navbar />
-        <div className="container mx-auto px-4 py-8 text-red-500">{error}</div>
-        <Footer />
-      </div>
-    )
-  }
+export default async function CollectionsPage() {
+  const collections = await getCollections()
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -66,11 +35,14 @@ export default function CollectionsPage() {
                     </div>
                   ))}
                 </div>
-                <div className="p-3 md:p-4">
+                <div className="p-3 md:p-4 space-y-1">
                   <h3 className="font-semibold text-sm md:text-base truncate">
                     {collection.name}
                   </h3>
-                  <p className="text-xs text-gray-600 mt-1">{collection.priceRange}</p>
+                  <p className="text-xs text-gray-600">
+                    {mockFabrics.filter((f) => f.collectionSlug === collection.slug).length} ลายผ้า
+                  </p>
+                  <p className="text-xs text-primary underline">ดูรายละเอียด</p>
                 </div>
               </Link>
             ))}

--- a/components/CollectionFabricFilter.tsx
+++ b/components/CollectionFabricFilter.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { useState } from "react"
+import { FabricsList } from "./FabricsList"
+
+interface Fabric {
+  id: string
+  slug: string | null
+  name: string
+  sku?: string | null
+  images: string[]
+  collectionSlug: string
+  tags?: string[]
+}
+
+export function CollectionFabricFilter({ fabrics, tags }: { fabrics: Fabric[]; tags: string[] }) {
+  const [active, setActive] = useState<string>("all")
+  const filtered = active === "all" ? fabrics : fabrics.filter((f) => f.tags?.includes(active))
+  return (
+    <div className="space-y-4">
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          <button
+            className={`px-3 py-1 rounded border text-sm ${active === "all" ? "bg-primary text-white" : ""}`}
+            onClick={() => setActive("all")}
+          >
+            ทั้งหมด
+          </button>
+          {tags.map((t) => (
+            <button
+              key={t}
+              className={`px-3 py-1 rounded border text-sm ${active === t ? "bg-primary text-white" : ""}`}
+              onClick={() => setActive(t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+      <FabricsList fabrics={filtered} />
+    </div>
+  )
+}

--- a/lib/mock-collections.ts
+++ b/lib/mock-collections.ts
@@ -35,6 +35,8 @@ export interface Collection {
   slug: string
   priceRange: string
   description: string
+  banner?: string
+  tags?: string[]
   images: string[]
 }
 
@@ -44,6 +46,8 @@ export const mockCollections: Collection[] = Array.from({ length: 40 }, (_, i) =
   name: `คอลเลกชัน #${i + 1}`,
   priceRange: '',
   description: `ลายผ้าในชุด ${i + 1}`,
+  banner: '/placeholder.jpg',
+  tags: ['tag-a', 'tag-b'],
   images: [
     '/placeholder.jpg',
     '/placeholder.jpg',
@@ -58,7 +62,7 @@ export async function getCollections(): Promise<Collection[]> {
   }
   const { data, error } = await supabase
     .from('collections')
-    .select('id, name, slug, price_range, description, all_images')
+    .select('id, name, slug, price_range, description, banner, tags, all_images')
     .order('created_at', { ascending: false })
 
   if (error || !data) {
@@ -72,6 +76,8 @@ export async function getCollections(): Promise<Collection[]> {
     slug: c.slug,
     priceRange: c.price_range,
     description: c.description,
+    banner: c.banner,
+    tags: c.tags || [],
     images: c.all_images || [],
   })) as Collection[]
 }

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -9,10 +9,11 @@ export interface Fabric {
   price: number
   images: string[]
   collectionSlug: string
+  tags?: string[]
 }
 
 export const mockFabrics: Fabric[] = [
-  {
+  { 
     id: 'f01',
     name: 'Soft Linen',
     slug: 'soft-linen',
@@ -21,6 +22,7 @@ export const mockFabrics: Fabric[] = [
     price: 990,
     images: ['/images/039.jpg', '/images/040.jpg'],
     collectionSlug: 'cozy-earth',
+    tags: ['linen', 'basic'],
   },
   {
     id: 'f02',
@@ -31,6 +33,7 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/041.jpg', '/images/042.jpg'],
     collectionSlug: 'cozy-earth',
+    tags: ['cotton'],
   },
   {
     id: 'f03',
@@ -41,6 +44,7 @@ export const mockFabrics: Fabric[] = [
     price: 1290,
     images: ['/images/043.jpg', '/images/044.jpg'],
     collectionSlug: 'modern-loft',
+    tags: ['velvet', 'premium'],
   },
   {
     id: 'f04',
@@ -51,6 +55,7 @@ export const mockFabrics: Fabric[] = [
     price: 1190,
     images: ['/images/045.jpg', '/images/046.jpg'],
     collectionSlug: 'modern-loft',
+    tags: ['pattern'],
   },
   {
     id: 'f05',
@@ -61,6 +66,7 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/047.jpg', '/images/035.jpg'],
     collectionSlug: 'vintage-vibes',
+    tags: ['floral'],
   },
 ]
 

--- a/types/collection.ts
+++ b/types/collection.ts
@@ -4,5 +4,7 @@ export interface Collection {
   slug: string
   priceRange: string
   description: string
+  banner?: string
+  tags?: string[]
   images: string[]
 }


### PR DESCRIPTION
## Summary
- support banners and tags for collections
- allow filtering fabrics by tag
- show fabric count on collections list
- add metadata for collection pages

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6875c3d5b67c83258743eef20c337a2a