### PR TITLE
Add mock fabric analytics and compare link

### DIFF
--- a/app/admin/reports/fabrics/page.tsx
+++ b/app/admin/reports/fabrics/page.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/cards/card"
+import { getMonthlyFabricRanking } from "@/lib/get-monthly-fabric-ranking"
+import { getCollectionViewStats } from "@/lib/get-collection-view-stats"
+
+export default function AdminFabricReports() {
+  const fabricStats = getMonthlyFabricRanking()
+  const collectionStats = getCollectionViewStats()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/reports">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">รายงานลายผ้า (mock)</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>ลายผ้ายอดนิยมประจำเดือน</CardTitle>
+          </CardHeader>
+          <CardContent className="h-60">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={fabricStats}>
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="views" fill="#8884d8" name="ยอดดู" />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>ยอดดูตามคอลเลกชัน</CardTitle>
+          </CardHeader>
+          <CardContent className="h-60">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={collectionStats}>
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="views" fill="#82ca9d" name="ยอดดู" />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
 import Image from "next/image"
 import Link from "next/link"
 import { Navbar } from "@/components/navbar"
@@ -23,14 +24,17 @@ interface Fabric {
 export default function ComparePage() {
   const { items, clear } = useCompare()
   const [fabrics, setFabrics] = useState<Fabric[]>([])
+  const searchParams = useSearchParams()
 
   useEffect(() => {
+    const param = searchParams.get('ids')
+    const list = items.length ? items : param ? param.split(',') : []
     setFabrics(
       mockFabrics
-        .filter((f) => items.includes(f.slug))
+        .filter((f) => list.includes(f.slug))
         .map((f) => ({ ...f }))
     )
-  }, [items])
+  }, [items, searchParams])
 
   if (fabrics.length === 0) {
     return (

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -22,7 +22,8 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
   const router = useRouter()
 
   const handleCompare = () => {
-    router.push(`/compare`)
+    const query = items.join(',')
+    router.push(`/compare?ids=${query}`)
   }
 
   return (

--- a/lib/get-collection-view-stats.ts
+++ b/lib/get-collection-view-stats.ts
@@ -1,0 +1,20 @@
+import { mockCollections } from './mock-collections'
+import { mockFabrics } from './mock-fabrics'
+import { mockFabricViews } from './mock-fabric-views'
+
+export interface CollectionViewStat {
+  slug: string
+  name: string
+  views: number
+}
+
+export function getCollectionViewStats(): CollectionViewStat[] {
+  const totals: Record<string, number> = {}
+  for (const f of mockFabrics) {
+    const views = mockFabricViews[f.slug] || 0
+    totals[f.collectionSlug] = (totals[f.collectionSlug] || 0) + views
+  }
+  return mockCollections
+    .map((c) => ({ slug: c.slug, name: c.name, views: totals[c.slug] || 0 }))
+    .sort((a, b) => b.views - a.views)
+}

--- a/lib/get-monthly-fabric-ranking.ts
+++ b/lib/get-monthly-fabric-ranking.ts
@@ -1,0 +1,19 @@
+import { mockFabrics } from './mock-fabrics'
+import { mockFabricViews } from './mock-fabric-views'
+
+export interface FabricViewStat {
+  slug: string
+  name: string
+  views: number
+}
+
+export function getMonthlyFabricRanking(): FabricViewStat[] {
+  return mockFabrics
+    .map((f) => ({
+      slug: f.slug,
+      name: f.name,
+      views: mockFabricViews[f.slug] || 0,
+    }))
+    .sort((a, b) => b.views - a.views)
+    .slice(0, 10)
+}

--- a/lib/mock-fabric-views.ts
+++ b/lib/mock-fabric-views.ts
@@ -1,0 +1,7 @@
+export const mockFabricViews: Record<string, number> = {
+  'soft-linen': 120,
+  'cozy-cotton': 95,
+  'velvet-dream': 80,
+  'classic-stripe': 60,
+  'floral-muse': 50,
+}


### PR DESCRIPTION
## Summary
- add mock views data for fabrics
- compute monthly fabric ranking and collection view stats
- new admin report page to show charts for fabric views
- open compare page with query param
- update compare page to parse `ids` from URL

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875c6ded4b4832596a412b77e643828