### PR TITLE
Add mock CRM features to chat

### DIFF
--- a/app/admin/chat/page.tsx
+++ b/app/admin/chat/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { loadConversations, listConversations, addTag } from '@/lib/mock-conversations'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function AdminChatPage() {
+  const [filter, setFilter] = useState('')
+  const [convs, setConvs] = useState(listConversations())
+
+  useEffect(() => {
+    loadConversations()
+    setConvs(listConversations(filter || undefined))
+  }, [filter])
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">แชทลูกค้า</h1>
+        <div className="flex space-x-2">
+          <Input
+            placeholder="ค้นหาด้วยแท็ก"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+        <ul className="space-y-2">
+          {convs.map((c) => (
+            <li key={c.id} className="border p-2 rounded flex justify-between">
+              <div>
+                <p>Conversation {c.id}</p>
+                {c.tags.length > 0 && (
+                  <p className="text-sm text-gray-500">{c.tags.join(', ')}</p>
+                )}
+              </div>
+              <div className="space-x-2">
+                <Link href={`/chat/history/${c.id}`}>ดูบิล</Link>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const tag = prompt('เพิ่มแท็ก')
+                    if (tag) {
+                      addTag(c.id, tag)
+                      setConvs(listConversations(filter || undefined))
+                    }
+                  }}
+                >
+                  เพิ่มแท็ก
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/chat/history/[id]/page.tsx
+++ b/app/chat/history/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useParams } from 'next/navigation'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { loadConversations, getConversation } from '@/lib/mock-conversations'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export default function ChatHistoryPage() {
+  const params = useParams<{ id: string }>()
+  const id = params.id
+  const [conv, setConv] = useState(() => getConversation(id))
+
+  useEffect(() => {
+    loadConversations()
+    setConv(getConversation(id))
+  }, [id])
+
+  if (!conv) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>ไม่พบข้อมูล</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-xl font-bold">ประวัติการส่งบิล</h1>
+        {conv.bills.length > 0 ? (
+          <ul className="space-y-2">
+            {conv.bills.map((b) => (
+              <li key={b} className="border p-2 rounded">
+                <Link href={`/chat-bill/${b}`}>บิล {b}</Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-500">ยังไม่เคยส่งบิล</p>
+        )}
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -17,7 +17,15 @@ import {
   addChatActivity,
   loadChatActivity,
 } from "@/lib/mock-chat-activity";
+import {
+  loadConversations,
+  setConversationNote,
+  addCallLog,
+  addTag,
+  getConversation,
+} from "@/lib/mock-conversations";
 import { useAuth } from "@/contexts/auth-context";
+import { useParams, useRouter } from "next/navigation";
 
 export default function ChatPage() {
   const { user, guestId } = useAuth();
@@ -25,7 +33,12 @@ export default function ChatPage() {
     process.env.NEXT_PUBLIC_CHATWOOT_URL || "http://localhost:3000";
   const [message, setMessage] = useState(chatWelcome);
   const [showError, setShowError] = useState(false);
+  const [noteModal, setNoteModal] = useState(false);
+  const [noteInput, setNoteInput] = useState("");
+  const [aiSuggest, setAiSuggest] = useState<string | null>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const router = useRouter();
+  const convoId = user?.id || guestId!;
 
   const handleReload = () => {
     if (iframeRef.current) {
@@ -41,18 +54,59 @@ export default function ChatPage() {
     setMessage(chatWelcome);
     loadChatActivity();
     addChatActivity(user?.id || guestId!, "open_chat");
+    loadConversations();
   }, [chatwootUrl]);
+
+  const conversation = getConversation(convoId);
 
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
-      <div className="flex-1">
+      <div className="flex-1 relative">
         <iframe
           ref={iframeRef}
           src={chatwootUrl}
           className="w-full h-full border-none"
           onError={() => setShowError(true)}
         />
+        <div className="absolute top-2 left-2 space-x-2">
+          {conversation && (
+            <span className="px-2 py-1 text-xs bg-blue-600 text-white rounded">
+              {conversation.isNew ? 'ลูกค้าใหม่' : 'ลูกค้าซ้ำ'}
+            </span>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setNoteModal(true)}
+          >
+            บันทึกโน้ตลูกค้า
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAiSuggest('แนะนำบิลตัวอย่าง')}
+          >
+            แนะนำบิลที่ควรส่ง
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => router.push(`/chat/history/${convoId}`)}
+          >
+            ย้อนดูบิลทั้งหมด
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              addCallLog(convoId)
+              alert('บันทึกการโทรกลับแล้ว')
+            }}
+          >
+            โทรกลับลูกค้า
+          </Button>
+        </div>
       </div>
       <Footer />
       <Dialog open={showError} onOpenChange={setShowError}>
@@ -71,6 +125,40 @@ export default function ChatPage() {
                 Facebook page
               </Link>
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={noteModal} onOpenChange={setNoteModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>บันทึกโน้ตลูกค้า</DialogTitle>
+          </DialogHeader>
+          <textarea
+            className="w-full border p-2 rounded"
+            value={noteInput}
+            onChange={(e) => setNoteInput(e.target.value)}
+          />
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setConversationNote(convoId, noteInput)
+                setNoteModal(false)
+                setNoteInput('')
+              }}
+            >
+              บันทึก
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={!!aiSuggest} onOpenChange={() => setAiSuggest(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>AI Suggestion</DialogTitle>
+          </DialogHeader>
+          <p>{aiSuggest}</p>
+          <DialogFooter>
+            <Button onClick={() => setAiSuggest(null)}>ปิด</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/components/admin/chat/CreateChatBillDialog.tsx
+++ b/components/admin/chat/CreateChatBillDialog.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/inputs/input'
 import { Label } from '@/components/ui/label'
 import { getProducts } from '@/lib/mock-products'
 import { createChatBill } from '@/lib/mock-chat-bills'
+import { addConversationBill } from '@/lib/mock-conversations'
 
 export default function CreateChatBillDialog({
   onCreated,
@@ -51,6 +52,9 @@ export default function CreateChatBillDialog({
       discount,
       total: items.reduce((s, i) => s + i.price, 0) - discount,
     })
+    if (sessionId) {
+      addConversationBill(sessionId, bill.billId)
+    }
     setOpen(false)
     onCreated(bill.billId)
     // reset

--- a/lib/mock-conversations.ts
+++ b/lib/mock-conversations.ts
@@ -1,0 +1,78 @@
+export interface Conversation {
+  id: string
+  customerId: string
+  note?: string
+  tags: string[]
+  bills: string[]
+  callHistory: string[]
+  isNew: boolean
+}
+
+export let conversations: Conversation[] = []
+
+export function loadConversations() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('conversations')
+    if (stored) conversations = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('conversations', JSON.stringify(conversations))
+  }
+}
+
+export function getConversation(id: string): Conversation | undefined {
+  return conversations.find((c) => c.id === id)
+}
+
+export function upsertConversation(data: Partial<Conversation> & { id: string }) {
+  const existing = getConversation(data.id)
+  if (existing) {
+    Object.assign(existing, data)
+  } else {
+    conversations.push({
+      id: data.id,
+      customerId: data.customerId || data.id,
+      note: data.note || '',
+      tags: data.tags || [],
+      bills: [],
+      callHistory: [],
+      isNew: true,
+    })
+  }
+  save()
+}
+
+export function setConversationNote(id: string, note: string) {
+  const conv = getConversation(id)
+  if (!conv) return
+  conv.note = note
+  save()
+}
+
+export function addConversationBill(id: string, billId: string) {
+  const conv = getConversation(id)
+  if (!conv) return
+  conv.bills.unshift(billId)
+  save()
+}
+
+export function addCallLog(id: string) {
+  const conv = getConversation(id)
+  if (!conv) return
+  conv.callHistory.unshift(new Date().toISOString())
+  save()
+}
+
+export function addTag(id: string, tag: string) {
+  const conv = getConversation(id)
+  if (!conv) return
+  if (!conv.tags.includes(tag)) conv.tags.push(tag)
+  save()
+}
+
+export function listConversations(tag?: string): Conversation[] {
+  return tag ? conversations.filter((c) => c.tags.includes(tag)) : conversations
+}


### PR DESCRIPTION
## Summary
- mock conversation store
- create admin chat page for filtering conversations by tag
- support adding chat bills to conversation history
- add customer note and call back modal on chat page
- show history of sent bills

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875c6eda0f083259f90a4d44527192b