### PR TITLE
Add basic tag and category features for fabrics

### DIFF
--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -30,6 +30,8 @@ interface Fabric {
   price_min: number
   price_max: number
   collection_name?: string | null
+  tags?: string[]
+  category?: string
 }
 
 export default function AdminFabricsPage() {
@@ -110,7 +112,8 @@ export default function AdminFabricsPage() {
   const filteredFabrics = fabrics.filter((f) => {
     const matchesSearch =
       f.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      f.collection_name?.toLowerCase().includes(searchTerm.toLowerCase())
+      f.collection_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      f.tags?.some((t) => t.toLowerCase().includes(searchTerm.toLowerCase()))
     const matchesCollection =
       collectionFilter === "all" || f.collection_id === collectionFilter
     return matchesSearch && matchesCollection
@@ -135,12 +138,15 @@ export default function AdminFabricsPage() {
               <p className="text-gray-600">เพิ่ม แก้ไข และลบผ้าในระบบ</p>
             </div>
           </div>
-          <Link href="/admin/fabrics/create">
-            <Button>
-              <Plus className="mr-2 h-4 w-4" />
-              เพิ่มผ้าใหม่
-            </Button>
-          </Link>
+          <div className="flex space-x-2">
+            <Link href="/admin/fabrics/create">
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                เพิ่มผ้าใหม่
+              </Button>
+            </Link>
+            <Button variant="outline">เพิ่มแท็กใหม่</Button>
+          </div>
         </div>
 
         <Card>

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { mockFabrics } from "@/lib/mock-fabrics"
 import { notFound } from "next/navigation"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 import { MessageSquare, Share2, Receipt } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import { CopyToClipboardButton } from "@/components/CopyToClipboardButton"
 import { FabricSuggestions } from "@/components/FabricSuggestions"
 
@@ -26,6 +27,8 @@ interface Fabric {
   image_urls?: string[] | null
   price_min?: number | null
   price_max?: number | null
+  tags?: string[]
+  category?: string
 }
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
@@ -79,6 +82,8 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
       image_urls: f!.images,
       price_min: f!.price,
       price_max: f!.price,
+      tags: f!.tags,
+      category: f!.category,
     }
   } else {
     const { data, error } = await supabase
@@ -123,8 +128,11 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
             />
           </div>
           <div className="space-y-4">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 flex-wrap">
               <h1 className="text-3xl font-bold">{fabric.name}</h1>
+              {fabric.category && (
+                <Badge variant="secondary" className="text-xs">{fabric.category}</Badge>
+              )}
               <WishlistButton slug={fabric.slug || fabric.id} />
               <FavoriteButton slug={fabric.slug || fabric.id} />
             </div>
@@ -147,7 +155,18 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
                 </Link>
               </p>
             )}
-            {fabric.description && <p className="text-gray-700 whitespace-pre-line">{fabric.description}</p>}
+            {fabric.description && (
+              <p className="text-gray-700 whitespace-pre-line">{fabric.description}</p>
+            )}
+            {fabric.tags && (
+              <div className="flex flex-wrap gap-2 pt-2">
+                {fabric.tags.map((t) => (
+                  <Badge key={t} variant="outline" className="text-xs">
+                    {t}
+                  </Badge>
+                ))}
+              </div>
+            )}
             <div className="flex space-x-4 pt-2">
               <a
                 href={`https://m.me/elfsofacover?text=${encodeURIComponent(

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { FabricsList } from "@/components/FabricsList"
+import Link from "next/link"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
@@ -18,9 +19,15 @@ interface Fabric {
   sku?: string | null
   image_url?: string | null
   image_urls?: string[] | null
+  tags?: string[]
+  category?: string
 }
 
-export default async function FabricsPage() {
+export default async function FabricsPage({
+  searchParams,
+}: {
+  searchParams: { category?: string }
+}) {
   let fabrics: Fabric[] = []
   if (!supabase) {
     fabrics = mockFabrics.map((f) => ({
@@ -29,11 +36,13 @@ export default async function FabricsPage() {
       name: f.name,
       sku: f.sku,
       image_urls: f.images,
+      tags: f.tags,
+      category: f.category,
     }))
   } else {
     const { data, error } = await supabase
       .from("fabrics")
-      .select("id, slug, name, sku, image_url, image_urls")
+      .select("id, slug, name, sku, image_url, image_urls, tags, category")
 
     if (error || !data) {
       return (
@@ -47,11 +56,27 @@ export default async function FabricsPage() {
     fabrics = data as Fabric[]
   }
 
+  const categories = Array.from(new Set(mockFabrics.map((f) => f.category)))
+
+  if (searchParams.category) {
+    fabrics = fabrics.filter((f) => f.category === searchParams.category)
+  }
+
   return (
     <div className="min-h-screen">
       <Navbar />
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">แกลเลอรี่ลายผ้า</h1>
+        <div className="flex flex-wrap gap-2 mb-6">
+          <Link href="/fabrics" className="underline text-sm">
+            ทั้งหมด
+          </Link>
+          {categories.map((c) => (
+            <Link key={c} href={`/fabrics?category=${c}`} className="underline text-sm">
+              {c}
+            </Link>
+          ))}
+        </div>
         <FabricsList fabrics={fabrics} />
       </div>
       <Footer />

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,0 +1,18 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { FabricsList } from "@/components/FabricsList"
+import { mockFabrics } from "@/lib/mock-fabrics"
+
+export default function TagDetailPage({ params }: { params: { tag: string } }) {
+  const fabrics = mockFabrics.filter((f) => f.tags.includes(params.tag))
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <h1 className="text-3xl font-bold mb-4">แท็ก: {params.tag}</h1>
+        <FabricsList fabrics={fabrics} />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,0 +1,24 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import Link from "next/link"
+import { mockFabrics } from "@/lib/mock-fabrics"
+
+export default function TagsPage() {
+  const tags = Array.from(new Set(mockFabrics.flatMap((f) => f.tags)))
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <h1 className="text-3xl font-bold mb-4">แท็กทั้งหมด</h1>
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <Link key={tag} href={`/tags/${tag}`} className="underline text-primary">
+              {tag}
+            </Link>
+          ))}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
+import { Badge } from "@/components/ui/badge"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
@@ -15,6 +16,8 @@ interface Fabric {
   sku?: string | null
   image_url?: string | null
   image_urls?: string[] | null
+  tags?: string[]
+  category?: string
 }
 
 export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
@@ -42,6 +45,11 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                   ดูด้วยกันบ่อย
                 </span>
               )}
+              {fabric.category && (
+                <Badge variant="secondary" className="absolute bottom-2 left-2 text-[10px]">
+                  {fabric.category}
+                </Badge>
+              )}
               <Checkbox
                 checked={checked}
                 onCheckedChange={() => toggleCompare(slug)}
@@ -58,8 +66,17 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                     className="object-cover"
                   />
                 </div>
-                <div className="p-2 text-center">
+                <div className="p-2 text-center space-y-1">
                   <p className="font-medium line-clamp-2">{fabric.name}</p>
+                  {fabric.tags && (
+                    <div className="flex flex-wrap justify-center gap-1">
+                      {fabric.tags.map((t) => (
+                        <Badge key={t} variant="outline" className="text-[10px]">
+                          {t}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </Link>
             </div>

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -9,6 +9,8 @@ export interface Fabric {
   price: number
   images: string[]
   collectionSlug: string
+  tags: string[]
+  category: 'ผ้าพื้น' | 'ผ้าลาย' | 'ผ้าเนื้อพิเศษ'
 }
 
 export const mockFabrics: Fabric[] = [
@@ -18,9 +20,11 @@ export const mockFabrics: Fabric[] = [
     slug: 'soft-linen',
     sku: 'FBC-001',
     color: 'ครีม',
-    price: 990,
+  price: 990,
     images: ['/images/039.jpg', '/images/040.jpg'],
     collectionSlug: 'cozy-earth',
+    tags: ['linen', 'soft'],
+    category: 'ผ้าพื้น',
   },
   {
     id: 'f02',
@@ -31,6 +35,8 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/041.jpg', '/images/042.jpg'],
     collectionSlug: 'cozy-earth',
+    tags: ['cotton', 'soft'],
+    category: 'ผ้าพื้น',
   },
   {
     id: 'f03',
@@ -41,6 +47,8 @@ export const mockFabrics: Fabric[] = [
     price: 1290,
     images: ['/images/043.jpg', '/images/044.jpg'],
     collectionSlug: 'modern-loft',
+    tags: ['velvet', 'luxury'],
+    category: 'ผ้าเนื้อพิเศษ',
   },
   {
     id: 'f04',
@@ -51,6 +59,8 @@ export const mockFabrics: Fabric[] = [
     price: 1190,
     images: ['/images/045.jpg', '/images/046.jpg'],
     collectionSlug: 'modern-loft',
+    tags: ['stripe', 'pattern'],
+    category: 'ผ้าลาย',
   },
   {
     id: 'f05',
@@ -61,6 +71,8 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/047.jpg', '/images/035.jpg'],
     collectionSlug: 'vintage-vibes',
+    tags: ['floral', 'pattern'],
+    category: 'ผ้าลาย',
   },
 ]
 


### PR DESCRIPTION
## Summary
- extend `Fabric` mock data with `tags` and `category`
- show category badges and tag chips in fabric list and detail pages
- add /tags pages to browse fabrics by tag
- filter fabrics by category on gallery page
- allow admin search by tags and add placeholder button for new tags

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875c9f377188325948e53369a59ef4f