### PR TITLE
Implement basic stock validation

### DIFF
--- a/app/order/new/page.tsx
+++ b/app/order/new/page.tsx
@@ -10,9 +10,11 @@ import { OrderSummary } from "@/components/order/order-summary"
 import type { OrderItem } from "@/types/order"
 import { supabase } from "@/lib/supabase"
 import { mockProducts } from "@/lib/mock-products"
+import { useToast } from "@/hooks/use-toast"
 
 export default function NewOrderPage() {
   const router = useRouter()
+  const { toast } = useToast()
   const searchParams = useSearchParams()
   const defaultProduct = searchParams.get("product")
   const [items, setItems] = useState<OrderItem[]>([])
@@ -45,6 +47,18 @@ export default function NewOrderPage() {
   const total = subtotal - discount + shippingCost + tax
 
   const createOrder = async () => {
+    for (const item of items) {
+      const product = mockProducts.find((p) => p.name === item.productName)
+      if (product && product.stock !== undefined && item.quantity > product.stock) {
+        toast({
+          title: "สต็อกไม่พอ",
+          description: `${product.name} เหลือ ${product.stock} ชิ้น`,
+          variant: "destructive",
+        })
+        return
+      }
+    }
+
     const order = {
       id: `o-${Date.now()}`,
       items,

--- a/components/admin/chat/CreateChatBillDialog.tsx
+++ b/components/admin/chat/CreateChatBillDialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/buttons/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/inputs/input'
 import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
 import { getProducts } from '@/lib/mock-products'
 import { createChatBill } from '@/lib/mock-chat-bills'
 
@@ -21,7 +22,7 @@ export default function CreateChatBillDialog({
   onCreated: (id: string) => void
 }) {
   const [open, setOpen] = useState(false)
-  const [products, setProducts] = useState<Array<{id:string,name:string,price:number}>>([])
+  const [products, setProducts] = useState<Array<{id:string,name:string,price:number,stock:number}>>([])
   const [selected, setSelected] = useState<Record<string, boolean>>({})
   const [discount, setDiscount] = useState(0)
   const [fbName, setFbName] = useState('')
@@ -31,7 +32,9 @@ export default function CreateChatBillDialog({
 
   useEffect(() => {
     getProducts().then((prods) =>
-      setProducts(prods.map((p) => ({ id: p.id, name: p.name, price: p.price })))
+      setProducts(
+        prods.map((p) => ({ id: p.id, name: p.name, price: p.price, stock: p.stock ?? 0 }))
+      )
     )
   }, [])
 
@@ -89,8 +92,18 @@ export default function CreateChatBillDialog({
             <p className="font-medium">เลือกสินค้า</p>
             {products.map((p) => (
               <label key={p.id} className="flex items-center space-x-2">
-                <Checkbox checked={!!selected[p.id]} onCheckedChange={(v)=>setSelected({ ...selected, [p.id]: Boolean(v) })} />
-                <span>{p.name} (฿{p.price.toLocaleString()})</span>
+                <Checkbox
+                  checked={!!selected[p.id]}
+                  onCheckedChange={(v) =>
+                    setSelected({ ...selected, [p.id]: Boolean(v) })
+                  }
+                />
+                <span>
+                  {p.name} (฿{p.price.toLocaleString()})
+                  <Badge variant="secondary" className="ml-2">
+                    เหลือ {p.stock} ชิ้น
+                  </Badge>
+                </span>
               </label>
             ))}
           </div>

--- a/lib/mock-products.ts
+++ b/lib/mock-products.ts
@@ -27,6 +27,7 @@ export const mockProducts: Product[] = [
     status: "active",
     tags: ["premium", "velvet", "curated"],
     curated: true,
+    stock: 8,
   },
   {
     id: "2",
@@ -53,6 +54,7 @@ export const mockProducts: Product[] = [
     status: "active",
     tags: ["cotton", "standard"],
     curated: false,
+    stock: 12,
   },
   {
     id: "3",
@@ -78,6 +80,7 @@ export const mockProducts: Product[] = [
     status: "active",
     tags: ["waterproof", "pro", "curated"],
     curated: true,
+    stock: 5,
   },
   {
     id: "4",
@@ -103,6 +106,7 @@ export const mockProducts: Product[] = [
     status: "active",
     tags: ["luxury", "leather"],
     curated: false,
+    stock: 3,
   },
 ]
 

--- a/types/product.ts
+++ b/types/product.ts
@@ -19,4 +19,5 @@ export interface Product {
   status?: "active" | "draft"
   tags?: string[]
   curated?: boolean
+  stock?: number
 }


### PR DESCRIPTION
## Summary
- add `stock` field to `Product` type and mock data
- show remaining stock in CreateChatBillDialog
- check stock before creating an order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875ca07dbb88325aafc00e33497ecfb