### PR TITLE
Add mock QA + KPI pages

### DIFF
--- a/app/admin/chat/page.tsx
+++ b/app/admin/chat/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/buttons/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/inputs/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Dialog,
   DialogContent,
@@ -37,6 +38,7 @@ import {
 import type { Conversation } from '@/types/conversation'
 import {
   addTag,
+  addAdminComment,
   listConversations,
   loadConversations,
   searchByTag,
@@ -48,6 +50,8 @@ export default function AdminChatPage() {
   const [convos, setConvos] = useState<Conversation[]>([])
   const [selected, setSelected] = useState<string | null>(null)
   const [tag, setTag] = useState('')
+  const [commenting, setCommenting] = useState<string | null>(null)
+  const [comment, setComment] = useState('')
 
   useEffect(() => {
     loadConversations()
@@ -60,12 +64,25 @@ export default function AdminChatPage() {
     setTag('')
   }
 
+  const openComment = (id: string) => {
+    setCommenting(id)
+    setComment('')
+  }
+
   const add = () => {
     if (selected && tag) {
       addTag(selected, tag)
       setConvos([...listConversations()])
     }
     setSelected(null)
+  }
+
+  const saveComment = () => {
+    if (commenting) {
+      addAdminComment(commenting, comment)
+      setConvos([...listConversations()])
+    }
+    setCommenting(null)
   }
 
   const stats = (() => {
@@ -103,6 +120,12 @@ export default function AdminChatPage() {
             </Button>
           </Link>
           <h1 className="text-3xl font-bold">การสนทนาลูกค้า</h1>
+          <Button asChild variant="secondary">
+            <Link href="/chat/qa">ดูแชทที่ถูกประเมินต่ำ</Link>
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href="/admin/chat/ranking">อันดับแอดมิน</Link>
+          </Button>
         </div>
         <Card>
           <CardHeader>
@@ -125,8 +148,9 @@ export default function AdminChatPage() {
                   <TableHead>ลูกค้า</TableHead>
                   <TableHead>แท็ก</TableHead>
                   <TableHead>เรตติ้ง</TableHead>
+                  <TableHead>คอมเมนต์</TableHead>
                   <TableHead>ตอบด่วน</TableHead>
-                  <TableHead className="w-40"></TableHead>
+                  <TableHead className="w-48"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -146,6 +170,7 @@ export default function AdminChatPage() {
                       </div>
                     </TableCell>
                     <TableCell>{c.rating ? `${c.rating}/5` : '-'}</TableCell>
+                    <TableCell>{c.adminComment ?? '-'}</TableCell>
                     <TableCell>
                       <Select onValueChange={quickReply}>
                         <SelectTrigger className="w-32">
@@ -184,6 +209,13 @@ export default function AdminChatPage() {
                       >
                         แจ้งหัวหน้าทีม
                       </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openComment(c.id)}
+                      >
+                        เพิ่มคอมเมนต์
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -207,6 +239,22 @@ export default function AdminChatPage() {
           />
           <DialogFooter>
             <Button onClick={add}>บันทึก</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={!!commenting} onOpenChange={() => setCommenting(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>บันทึกคอมเมนต์</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            rows={4}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="ความคิดเห็น"
+          />
+          <DialogFooter>
+            <Button onClick={saveComment}>บันทึก</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/app/admin/chat/ranking/page.tsx
+++ b/app/admin/chat/ranking/page.tsx
@@ -1,0 +1,87 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { getAdminRanking, loadConversations, exportKpiCsv, getKpiSummary } from "@/lib/mock-conversations"
+
+export default function RankingPage() {
+  const [data, setData] = useState(() => getAdminRanking())
+  const [summary, setSummary] = useState(() => getKpiSummary())
+
+  useEffect(() => {
+    loadConversations()
+    setData(getAdminRanking())
+    setSummary(getKpiSummary())
+  }, [])
+
+  const exportCsv = () => {
+    const blob = new Blob([exportKpiCsv()], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'kpi.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">จัดอันดับแอดมิน</h1>
+          <Button asChild>
+            <Link href="/admin/chat">กลับ</Link>
+          </Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>สรุป KPI</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div>แชทรวม: {summary.totalChats}</div>
+            <div>คะแนนเฉลี่ย: {summary.avgRating.toFixed(2)}</div>
+            <div>ตอบช้า: {summary.slow}</div>
+            <div>ตอบเร็ว: {summary.fast}</div>
+            <Button onClick={exportCsv}>Export CSV</Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>อันดับ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Admin</TableHead>
+                  <TableHead>คะแนนเฉลี่ย</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.map((r) => (
+                  <TableRow key={r.adminId}>
+                    <TableCell>{r.adminId}</TableCell>
+                    <TableCell>{r.avgRating}</TableCell>
+                  </TableRow>
+                ))}
+                {data.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={2} className="text-center py-8">
+                      ไม่มีข้อมูล
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/chat/qa/page.tsx
+++ b/app/chat/qa/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { listLowRatingConversations, loadConversations } from "@/lib/mock-conversations"
+
+export default function ChatQaPage() {
+  const [data, setData] = useState(() => listLowRatingConversations())
+
+  useEffect(() => {
+    loadConversations()
+    setData(listLowRatingConversations())
+  }, [])
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">แชทที่ถูกประเมินต่ำ</h1>
+          <Button asChild>
+            <Link href="/admin/chat">กลับ</Link>
+          </Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ลูกค้า</TableHead>
+                  <TableHead>คะแนน</TableHead>
+                  <TableHead>ความคิดเห็นแอดมิน</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.map((c) => (
+                  <TableRow key={c.id}>
+                    <TableCell>{c.customerName}</TableCell>
+                    <TableCell>{c.rating ?? '-'}</TableCell>
+                    <TableCell>{c.adminComment ?? '-'}</TableCell>
+                  </TableRow>
+                ))}
+                {data.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-center py-8">
+                      ไม่มีข้อมูล
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/chat/rate/[id]/page.tsx
+++ b/app/chat/rate/[id]/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Button } from "@/components/ui/buttons/button"
+import { setRating, loadConversations } from "@/lib/mock-conversations"
+
+export default function RateChatPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [rated, setRated] = useState(false)
+
+  useEffect(() => {
+    loadConversations()
+  }, [])
+
+  const giveRating = (r: number) => {
+    setRating(id, r)
+    setRated(true)
+    setTimeout(() => router.push('/chat'), 1000)
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen items-center">
+      <Navbar />
+      <div className="flex-1 flex flex-col items-center justify-center space-y-4">
+        {rated ? (
+          <p>ขอบคุณสำหรับการประเมิน</p>
+        ) : (
+          <>
+            <p className="text-lg">ให้คะแนนแชทครั้งนี้</p>
+            <div className="flex space-x-2">
+              {[1, 2, 3, 4, 5].map((n) => (
+                <Button key={n} onClick={() => giveRating(n)}>{n}</Button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/lib/mock-conversations.ts
+++ b/lib/mock-conversations.ts
@@ -7,6 +7,8 @@ export let conversations: Conversation[] = [
     customerName: 'John Doe',
     lastMessage: 'สอบถามราคาเบาะโซฟา',
     tags: ['ถามราคา'],
+    adminId: '1',
+    responseTime: 2,
     updatedAt: new Date().toISOString(),
   },
   {
@@ -15,6 +17,9 @@ export let conversations: Conversation[] = [
     customerName: 'Jane Smith',
     lastMessage: 'จะโอนพรุ่งนี้',
     tags: ['รอโอน'],
+    adminId: '1',
+    responseTime: 7,
+    rating: 2,
     updatedAt: new Date().toISOString(),
   },
 ]
@@ -64,4 +69,67 @@ export function setRating(id: string, rating: number) {
     convo.rating = rating
     save()
   }
+}
+
+export function addAdminComment(id: string, comment: string) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.adminComment = comment
+    save()
+  }
+}
+
+export function addManagerComment(id: string, comment: string) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.managerComment = comment
+    save()
+  }
+}
+
+export function recordResponseTime(id: string, minutes: number) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.responseTime = minutes
+    save()
+  }
+}
+
+export function listLowRatingConversations(threshold = 3) {
+  return conversations.filter((c) => (c.rating || 0) <= threshold)
+}
+
+export function getAdminRanking(period: 'day' | 'week' = 'day') {
+  const start = new Date()
+  start.setDate(start.getDate() - (period === 'day' ? 1 : 7))
+  const stats = new Map<string, { total: number; count: number }>()
+  for (const c of conversations) {
+    if (!c.adminId || !c.rating) continue
+    if (new Date(c.updatedAt) < start) continue
+    const data = stats.get(c.adminId) || { total: 0, count: 0 }
+    data.total += c.rating
+    data.count += 1
+    stats.set(c.adminId, data)
+  }
+  return Array.from(stats.entries())
+    .map(([adminId, { total, count }]) => ({
+      adminId,
+      avgRating: Number((total / count).toFixed(2)),
+    }))
+    .sort((a, b) => b.avgRating - a.avgRating)
+}
+
+export function getKpiSummary() {
+  const totalChats = conversations.length
+  const avgRating =
+    conversations.reduce((a, c) => a + (c.rating || 0), 0) /
+    (totalChats || 1)
+  const slow = conversations.filter((c) => (c.responseTime || 0) > 5).length
+  const fast = conversations.filter((c) => (c.responseTime || 0) <= 5).length
+  return { totalChats, avgRating, slow, fast }
+}
+
+export function exportKpiCsv() {
+  const s = getKpiSummary()
+  return `totalChats,avgRating,slowResponses,fastResponses\n${s.totalChats},${s.avgRating},${s.slow},${s.fast}\n`
 }

--- a/types/conversation.ts
+++ b/types/conversation.ts
@@ -5,5 +5,13 @@ export interface Conversation {
   lastMessage: string
   tags: string[]
   rating?: number
+  /** comment from the handling admin */
+  adminComment?: string
+  /** comment from team lead */
+  managerComment?: string
+  /** id of handling admin */
+  adminId?: string
+  /** response time in minutes */
+  responseTime?: number
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
- extend conversation model with admin details and timing fields
- store and compute mock metrics in `mock-conversations`
- show QA and KPI links on admin chat page
- add page to rate chats
- add page to view low ratings and admin ranking

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875e5824a608325a1364d42a01042f4