### PR TITLE
Add mock collection version history

### DIFF
--- a/app/admin/collections/logs/page.tsx
+++ b/app/admin/collections/logs/page.tsx
@@ -1,0 +1,72 @@
+"use client"
+import Link from "next/link"
+import { useEffect, useState } from "react"
+import { ArrowLeft } from "lucide-react"
+import { getCollections } from "@/lib/mock-collections"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import type { CollectionHistory } from "@/types/collection"
+
+interface Entry { name: string; history: CollectionHistory }
+
+export default function CollectionLogsPage() {
+  const [entries, setEntries] = useState<Entry[]>([])
+  useEffect(() => {
+    getCollections().then((cols) => {
+      const all: Entry[] = []
+      cols.forEach((c) =>
+        c.history.forEach((h) => all.push({ name: c.name, history: h })),
+      )
+      all.sort(
+        (a, b) =>
+          new Date(b.history.timestamp).getTime() -
+          new Date(a.history.timestamp).getTime(),
+      )
+      setEntries(all)
+    })
+  }, [])
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center space-x-4 mb-8">
+          <Link href="/admin/collections">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ประวัติคอลเลกชัน</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Logs ({entries.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>เวลา</TableHead>
+                  <TableHead>คอลเลกชัน</TableHead>
+                  <TableHead>เวอร์ชัน</TableHead>
+                  <TableHead>แอดมิน</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map((e, i) => (
+                  <TableRow key={i}>
+                    <TableCell>
+                      {new Date(e.history.timestamp).toLocaleString()}
+                    </TableCell>
+                    <TableCell>{e.name}</TableCell>
+                    <TableCell>{e.history.version}</TableCell>
+                    <TableCell>{e.history.admin}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/components/collection/CollectionHistory.tsx
+++ b/components/collection/CollectionHistory.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { format } from "date-fns"
+import type { CollectionHistory } from "@/types/collection"
+import { Button } from "@/components/ui/buttons/button"
+
+interface Props {
+  history: CollectionHistory[]
+  onRevert?: () => void
+}
+
+export function CollectionHistory({ history, onRevert }: Props) {
+  const sorted = [...history].sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+  )
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-2">
+        {sorted.map((h, i) => (
+          <li key={i} className="flex items-center space-x-2">
+            <span className="w-44 text-sm text-gray-500">
+              {format(new Date(h.timestamp), "dd MMM yyyy HH:mm")}
+            </span>
+            <span className="text-sm">v{h.version}</span>
+            <span className="text-sm text-muted-foreground">{h.admin}</span>
+          </li>
+        ))}
+      </ul>
+      {onRevert && history.length > 0 && (
+        <Button variant="outline" onClick={onRevert}>ย้อนกลับเวอร์ชันก่อนหน้า</Button>
+      )}
+    </div>
+  )
+}

--- a/types/collection.ts
+++ b/types/collection.ts
@@ -1,8 +1,22 @@
-export interface Collection {
+export interface CollectionData {
   id: string
   name: string
   slug: string
   priceRange: string
   description: string
   images: string[]
+  version: number
+  guide: string[]
+  guideAddedBy?: string
+}
+
+export interface CollectionHistory {
+  version: number
+  admin: string
+  timestamp: string
+  data: CollectionData
+}
+
+export interface Collection extends CollectionData {
+  history: CollectionHistory[]
 }


### PR DESCRIPTION
## Summary
- support collection version tracking with history
- expose collection timeline view component
- add admin collections logs page
- show version, history and guides in admin collections page
- update context and mock data for versioning

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6875e5f8ca4c8325a14d4afbda6e1726