### PR TITLE
Add collection tagging and admin merge tools

### DIFF
--- a/types/collection.ts
+++ b/types/collection.ts
@@ -5,4 +5,5 @@ export interface Collection {
   priceRange: string
   description: string
   images: string[]
+  tags?: string[]
 }


### PR DESCRIPTION
## Summary
- support optional `tags` in `Collection` type and mocks
- extend admin collections page to show fabrics, filter by tags or fabric names
- add merge and split actions with log recording

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_68761457900883259988a0ce76a590c6