### PR TITLE
Add basic CRM mock features

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Plus, Search } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { Button } from '@/components/ui/buttons/button'
@@ -31,7 +32,8 @@ export default function AdminBillsPage() {
     shipping: number
     note: string
   } | null>(null)
-  const [search, setSearch] = useState('')
+  const params = useSearchParams()
+  const [search, setSearch] = useState(params.get('search') || '')
   const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'unpaid' | 'paid' | 'cancelled'>('all')
 
   const handleCreate = () => {

--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -31,6 +31,8 @@ import {
   updateCustomerPoints,
   setCustomerTier,
   setCustomerMuted,
+  toggleCustomerStar,
+  getFrequentProducts,
 } from "@/lib/mock-customers"
 import {
   loadCustomerNotes,
@@ -80,6 +82,7 @@ export default function CustomerDetailPage({
   const [pointDelta, setPointDelta] = useState(0)
   const [tierValue, setTierValue] = useState<string>(customer.tier || "Silver")
   const [muted, setMuted] = useState<boolean>(customer.muted ?? false)
+  const [favorites, setFavorites] = useState(() => getFrequentProducts(customer.id).slice(0,3))
   const [noteInput, setNoteInput] = useState("")
   const [tagInput, setTagInput] = useState("")
   const latestMessage = getLatestChatMessage(customer.id)
@@ -94,6 +97,15 @@ export default function CustomerDetailPage({
             </Button>
           </Link>
           <h1 className="text-3xl font-bold">ข้อมูลลูกค้า</h1>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              toggleCustomerStar(customer.id)
+              setFavorites(getFrequentProducts(customer.id).slice(0,3))
+            }}
+          >
+            {customer.starred ? '⭐ เลิกติดดาว' : '⭐ ติดดาว'}
+          </Button>
         </div>
 
         <CustomerCard customer={customer} />
@@ -161,11 +173,17 @@ export default function CustomerDetailPage({
         <div className="text-lg font-semibold">
           ยอดซื้อรวม: ฿{stats.totalSpent.toLocaleString()}
         </div>
+        {favorites.length > 0 && (
+          <div className="text-sm">สินค้าโปรด: {favorites.map(f => f.name).join(', ')}</div>
+        )}
         {latestMessage && (
           <div className="text-sm text-gray-600">แชทล่าสุด: {latestMessage.text}</div>
         )}
         <Link href="/chat">
           <Button variant="outline">เปิดใน Chatwoot</Button>
+        </Link>
+        <Link href={`/admin/bills?search=${encodeURIComponent(customer.name)}`}>
+          <Button variant="outline">ดูบิลเก่าทั้งหมดของลูกค้านี้</Button>
         </Link>
 
         <Card>

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -7,12 +7,14 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/inputs/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Search, ArrowLeft, Eye, Mail, Phone, ShoppingBag, Calendar } from "lucide-react"
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
 import Link from "next/link"
 import {
   fetchCustomers,
   getCustomerStats,
   getCustomerOrders,
   addCustomer,
+  getNewVsReturning,
   type Customer,
 } from "@/lib/mock-customers"
 import {
@@ -33,6 +35,7 @@ export default function AdminCustomersPage() {
   const [showAdd, setShowAdd] = useState(false)
   const [newName, setNewName] = useState("")
   const [newEmail, setNewEmail] = useState("")
+  const [ratio, setRatio] = useState({ new: 0, returning: 0 })
 
   useEffect(() => {
     loadCustomerNotes()
@@ -60,6 +63,8 @@ export default function AdminCustomersPage() {
       )
 
       setCustomers(customersData)
+      const r = getNewVsReturning()
+      setRatio(r)
     } catch (error) {
       console.error("Error loading data:", error)
     } finally {
@@ -273,7 +278,9 @@ export default function AdminCustomersPage() {
                           <span className="text-sm font-medium">{customer.name.charAt(0).toUpperCase()}</span>
                         </div>
                         <div>
-                          <p className="font-medium">{customer.name}</p>
+                          <p className="font-medium">
+                            {customer.starred && '⭐ '} {customer.name}
+                          </p>
                           <p className="text-sm text-gray-500">ID: {customer.id}</p>
                         </div>
                       </div>
@@ -342,6 +349,22 @@ export default function AdminCustomersPage() {
                 <p className="text-gray-500">ไม่พบลูกค้าที่ตรงกับเงื่อนไขการค้นหา</p>
               </div>
             )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="h-32">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie dataKey="value" data={[{name:'ใหม่', value: ratio.new},{name:'ขาประจำ', value: ratio.returning}]} fill="#8884d8" label>
+                    <Cell fill="#38bdf8" />
+                    <Cell fill="#6366f1" />
+                  </Pie>
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -49,6 +49,12 @@ export default function AdminOrdersPage() {
   const [customerFilter, setCustomerFilter] = useState<string>("all")
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
   const [bills, setBills] = useState(mockBills)
+  const customerTotal =
+    customerFilter === 'all'
+      ? 0
+      : orders
+          .filter((o) => o.customerId === customerFilter)
+          .reduce((s, o) => s + o.total, 0)
 
   const filteredOrders = orders.filter((order) => {
     const matchesSearch =
@@ -152,6 +158,11 @@ export default function AdminOrdersPage() {
                     ))}
                   </SelectContent>
                 </Select>
+                {customerFilter !== 'all' && (
+                  <span className="text-sm text-gray-600">
+                    ยอดรวมลูกค้า: ฿{customerTotal.toLocaleString()}
+                  </span>
+                )}
                 <Button variant="outline" onClick={() => {
                   const id = window.prompt("สแกน QR เพื่อค้นหาออเดอร์")
                   if (!id) return

--- a/components/admin/customers/CustomerCard.tsx
+++ b/components/admin/customers/CustomerCard.tsx
@@ -9,7 +9,10 @@ export default function CustomerCard({ customer, className = "" }: { customer: C
   return (
     <Card className={className}>
       <CardHeader>
-        <CardTitle>{customer.name}</CardTitle>
+        <CardTitle>
+          {customer.starred && <span className="mr-1">⭐</span>}
+          {customer.name}
+        </CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">
         <div className="flex items-center space-x-2">

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -18,6 +18,8 @@ export function createBill(
   const bill: Bill = {
     id,
     orderId,
+    phone: order?.shippingAddress.phone,
+    customerId: customer?.id,
     status,
     payments: [],
     createdAt: new Date().toISOString(),
@@ -64,4 +66,25 @@ export function cleanupOldBills(days: number) {
       new Date(b.createdAt).getTime() >= cutoff ||
       (b.status !== "cancelled" && b.status !== "paid"),
   )
+}
+
+export function getBillsByCustomer(customerId: string) {
+  return mockBills.filter((b) => b.customerId === customerId)
+}
+
+export function groupBillsByCustomer() {
+  const groups: Record<string, Bill[]> = {}
+  mockBills.forEach((b) => {
+    if (!b.customerId) return
+    if (!groups[b.customerId]) groups[b.customerId] = []
+    groups[b.customerId].push(b)
+  })
+  return groups
+}
+
+export function sumCustomerBills(customerId: string) {
+  return getBillsByCustomer(customerId).reduce((s, b) => {
+    const order = mockOrders.find((o) => o.id === b.orderId)
+    return s + (order?.total || 0)
+  }, 0)
 }

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -15,6 +15,8 @@ export interface Customer {
   tier?: "Silver" | "Gold" | "VIP"
   /** mute notifications */
   muted?: boolean
+  /** mark VIP */
+  starred?: boolean
   /** point change history */
   pointHistory?: PointLog[]
   createdAt: string
@@ -42,6 +44,7 @@ const initialMockCustomers: Customer[] = [
     note: "ชอบผ้ากำมะหยี่",
     points: 120,
     tier: "Gold",
+    starred: true,
     pointHistory: [
       { timestamp: new Date().toISOString(), change: 120, reason: "สมัครสมาชิก" },
     ],
@@ -177,4 +180,35 @@ export function setCustomerMuted(id: string, muted: boolean) {
   const customer = mockCustomers.find((c) => c.id === id)
   if (!customer) return
   customer.muted = muted
+}
+
+export function toggleCustomerStar(id: string) {
+  const customer = mockCustomers.find((c) => c.id === id)
+  if (!customer) return
+  customer.starred = !customer.starred
+}
+
+export function getFrequentProducts(customerId: string) {
+  const counts: Record<string, number> = {}
+  mockOrders
+    .filter((o) => o.customerId === customerId)
+    .forEach((o) => {
+      o.items.forEach((it) => {
+        counts[it.productName] = (counts[it.productName] || 0) + it.quantity
+      })
+    })
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }))
+}
+
+export function getNewVsReturning() {
+  let newCount = 0
+  let returning = 0
+  mockCustomers.forEach((c) => {
+    const orders = mockOrders.filter((o) => o.customerId === c.id)
+    if (orders.length > 1) returning += 1
+    else if (orders.length === 1) newCount += 1
+  })
+  return { new: newCount, returning }
 }

--- a/types/bill.ts
+++ b/types/bill.ts
@@ -12,6 +12,7 @@ export interface Bill {
   id: string
   orderId: string
   phone?: string
+  customerId?: string
   pin?: string
   status: BillStatus
   payments: BillPayment[]


### PR DESCRIPTION
## Summary
- link bills to customers by phone and customerId
- add utilities for grouping bills by customer and computing totals
- support VIP stars and favorite product tracking on customer pages
- show customer bill history links and purchase stats
- pre-fill bill search via query param and add customer order summaries

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687614614d548325a062d08503d6c96f