### PR TITLE
Add mock assistant sidebar to admin pages

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -12,6 +12,7 @@ import { AdminCollectionsProvider } from "@/contexts/admin-collections-context"
 import { AdminToast } from "@/components/admin/AdminToast"
 import QuickActionBar from "@/components/admin/QuickActionBar"
 import ErrorBoundary from "@/components/ErrorBoundary"
+import AssistantSidebar from "@/components/admin/AssistantSidebar"
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const { loading, isAdmin, conflict } = useAdminGuard()
@@ -54,12 +55,13 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 </SheetContent>
               </Sheet>
             )}
-            <div className="flex flex-1 flex-col">
+            <div className="flex flex-1 flex-col md:pr-60">
               <Topbar onMenuClick={() => setSidebarOpen(true)} />
               <main className="flex-1 p-4 pb-20 md:pb-4">{children}</main>
               <AdminToast />
               <QuickActionBar />
             </div>
+            <AssistantSidebar className="hidden md:block" />
           </div>
         </AdminProductsProvider>
       </AdminCollectionsProvider>

--- a/components/admin/AssistantSidebar.tsx
+++ b/components/admin/AssistantSidebar.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/buttons/button"
+import {
+  getAssistantSuggestions,
+  recordAssistantAction,
+  loadAssistantActions,
+  getAssistantActions,
+  type AssistantSuggestion,
+} from "@/lib/mock-assistant"
+
+export default function AssistantSidebar({ className = "" }: { className?: string }) {
+  const [input, setInput] = useState("")
+  const [suggestions, setSuggestions] = useState<AssistantSuggestion[]>([])
+  const [history, setHistory] = useState<string[]>([])
+
+  useEffect(() => {
+    loadAssistantActions()
+    setHistory(getAssistantActions())
+  }, [])
+
+  const handleSend = () => {
+    const list = getAssistantSuggestions(input)
+    setSuggestions(list)
+  }
+
+  const accept = (text: string) => {
+    recordAssistantAction(text)
+    setHistory(getAssistantActions())
+    setSuggestions([])
+  }
+
+  const cancel = (id: string) => {
+    setSuggestions((cur) => cur.filter((s) => s.id !== id))
+  }
+
+  const exportData = (type: "csv" | "json") => {
+    const data =
+      type === "csv"
+        ? suggestions.map((s) => `"${s.text}"`).join("\n")
+        : JSON.stringify(suggestions.map((s) => s.text), null, 2)
+    const blob = new Blob([data], { type: "text/plain;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `suggestions.${type}`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <aside className={`w-60 border-l p-4 space-y-3 ${className}`}> 
+      <h2 className="font-bold">Assistant</h2>
+      <Textarea
+        placeholder="Ask the assistant"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <Button className="w-full" onClick={handleSend}>
+        Send
+      </Button>
+      {suggestions.length === 0 && (
+        <p className="text-sm text-muted-foreground">No suggestions found</p>
+      )}
+      {suggestions.length > 0 && (
+        <ul className="space-y-2">
+          {suggestions.map((s) => (
+            <li key={s.id} className="border p-2 rounded text-sm space-y-2">
+              <p>{s.text}</p>
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" size="sm" onClick={() => cancel(s.id)}>
+                  Cancel
+                </Button>
+                <Button variant="secondary" size="sm" onClick={() => accept(s.text)}>
+                  Accept
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {suggestions.length > 0 && (
+        <div className="flex gap-2 pt-2">
+          <Button variant="outline" size="sm" onClick={() => exportData("csv")}>CSV</Button>
+          <Button variant="outline" size="sm" onClick={() => exportData("json")}>JSON</Button>
+        </div>
+      )}
+      {history.length > 0 && (
+        <div>
+          <h3 className="mt-4 text-sm font-semibold">Recent Actions</h3>
+          <ul className="list-disc pl-4 text-sm space-y-1">
+            {history.map((h, idx) => (
+              <li key={idx}>{h}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  )
+}
+

--- a/lib/mock-assistant.ts
+++ b/lib/mock-assistant.ts
@@ -1,0 +1,37 @@
+export interface AssistantSuggestion {
+  id: string
+  text: string
+}
+
+const actions: string[] = []
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('assistantActions', JSON.stringify(actions))
+  }
+}
+
+export function loadAssistantActions() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('assistantActions')
+    if (stored) actions.splice(0, actions.length, ...JSON.parse(stored))
+  }
+}
+
+export function getAssistantActions() {
+  return actions
+}
+
+export function recordAssistantAction(text: string) {
+  actions.unshift(text)
+  if (actions.length > 5) actions.pop()
+  save()
+}
+
+export function getAssistantSuggestions(input: string): AssistantSuggestion[] {
+  if (!input.trim()) return []
+  return Array.from({ length: 3 }).map((_, i) => ({
+    id: `${Date.now()}-${i}`,
+    text: `${input} suggestion ${i + 1}`,
+  }))
+}


### PR DESCRIPTION
## Summary
- add `AssistantSidebar` with simple mock suggestions
- keep last 5 actions in `mock-assistant`
- display the assistant sidebar on admin pages

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687620c175808325862f1068874e1d09