### PR TITLE
Add fabric mock tester

### DIFF
--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -1,6 +1,6 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
-import { FabricsList } from "@/components/FabricsList"
+import { FabricMockTester } from "@/components/FabricMockTester"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
@@ -52,7 +52,7 @@ export default async function FabricsPage() {
       <Navbar />
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">แกลเลอรี่ลายผ้า</h1>
-        <FabricsList fabrics={fabrics} />
+        <FabricMockTester fabrics={fabrics} />
       </div>
       <Footer />
       <AnalyticsTracker event="ViewContent" />

--- a/components/FabricMockTester.tsx
+++ b/components/FabricMockTester.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { FabricsList } from './FabricsList'
+import { Button } from '@/components/ui/buttons/button'
+import { useToast } from '@/hooks/use-toast'
+import { validateMockFabrics, resetMockFabrics } from '@/lib/mock-fabrics'
+
+interface Fabric {
+  id: string
+  slug: string | null
+  name: string
+  sku?: string | null
+  image_url?: string | null
+  image_urls?: string[] | null
+}
+
+export function FabricMockTester({ fabrics }: { fabrics: Fabric[] }) {
+  const { toast } = useToast()
+  const [states, setStates] = useState<Record<string, boolean>>({})
+
+  const runTest = () => {
+    const { states: s, errors } = validateMockFabrics()
+    setStates(s)
+    console.log('Fabric mock test:', errors.length === 0 ? 'pass' : 'fail', errors)
+    if (errors.length > 0) {
+      alert('Fabric mock data error')
+      toast({ title: 'Data error: missing fields', variant: 'destructive' })
+    } else {
+      toast({ title: 'Fabric mock is ready' })
+    }
+  }
+
+  const handleReset = () => {
+    resetMockFabrics()
+    runTest()
+  }
+
+  useEffect(() => {
+    runTest()
+  }, [])
+
+  return (
+    <div>
+      <div className="flex gap-2 mb-4">
+        <Button onClick={runTest}>Test fabric mock</Button>
+        <Button variant="outline" onClick={handleReset}>
+          Reset mock fabric
+        </Button>
+      </div>
+      <FabricsList fabrics={fabrics} testStates={states} />
+    </div>
+  )
+}

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -17,7 +17,13 @@ interface Fabric {
   image_urls?: string[] | null
 }
 
-export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
+export function FabricsList({
+  fabrics,
+  testStates = {},
+}: {
+  fabrics: Fabric[]
+  testStates?: Record<string, boolean>
+}) {
   const { items, toggleCompare } = useCompare()
   const router = useRouter()
 
@@ -32,6 +38,7 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
           const slug = fabric.slug || fabric.id
           const checked = items.includes(slug)
           const coViewed = mockCoViewLog[slug]?.length
+          const valid = testStates[slug]
           return (
             <div
               key={slug}
@@ -40,6 +47,11 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
               {coViewed && (
                 <span className="absolute top-2 right-2 bg-primary text-white text-xs px-2 py-1 rounded">
                   ดูด้วยกันบ่อย
+                </span>
+              )}
+              {valid !== undefined && (
+                <span className="absolute bottom-2 right-2 text-xl">
+                  {valid ? '✅' : '❌'}
                 </span>
               )}
               <Checkbox

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -11,7 +11,7 @@ export interface Fabric {
   collectionSlug: string
 }
 
-export const mockFabrics: Fabric[] = [
+const initialMockFabrics: Fabric[] = [
   {
     id: 'f01',
     name: 'Soft Linen',
@@ -63,6 +63,27 @@ export const mockFabrics: Fabric[] = [
     collectionSlug: 'vintage-vibes',
   },
 ]
+
+export let mockFabrics: Fabric[] = initialMockFabrics.map((f) => ({ ...f }))
+
+export function resetMockFabrics() {
+  mockFabrics = initialMockFabrics.map((f) => ({ ...f }))
+}
+
+export function validateMockFabrics() {
+  const states: Record<string, boolean> = {}
+  const errors: string[] = []
+  if (!Array.isArray(mockFabrics) || mockFabrics.length === 0) {
+    errors.push('mock fabrics array is empty')
+  } else {
+    mockFabrics.forEach((f) => {
+      const ok = Boolean(f.id && f.name && f.slug && f.images?.length)
+      states[f.slug] = ok
+      if (!ok) errors.push(`missing fields for ${f.slug || f.id}`)
+    })
+  }
+  return { states, errors }
+}
 
 export async function getFabrics() {
   if (!supabase) {


### PR DESCRIPTION
## Summary
- validate mock fabric data on demand
- show pass/fail badge on fabric cards
- reset mock fabrics to initial state
- replace gallery page with tester wrapper

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6876318dff808325b570a10654ee1f70