### PR TITLE
Add AI assistant ping test page

### DIFF
--- a/app/ping-ai/page.tsx
+++ b/app/ping-ai/page.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { useToast } from "@/hooks/use-toast"
+
+const lastReplies: string[] = []
+
+async function pingAssistant(): Promise<string> {
+  // simulate async call returning JSON
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(JSON.stringify({ reply: "pong", time: Date.now() }))
+    }, 1000)
+  })
+}
+
+export default function PingAIPage() {
+  const { toast } = useToast()
+  const [error, setError] = useState(false)
+
+  const handlePing = async () => {
+    setError(false)
+    try {
+      const result = await Promise.race([
+        pingAssistant(),
+        new Promise((_ , reject) => setTimeout(() => reject(new Error("timeout")), 1500))
+      ]) as string
+      toast({ title: "AI assistant connected (mock)" })
+      try {
+        JSON.parse(result)
+        lastReplies.push(result)
+        if (lastReplies.length > 3) lastReplies.shift()
+        console.log("assistant replies", [...lastReplies])
+      } catch (e) {
+        setError(true)
+        toast({ title: "Invalid reply format", variant: "destructive" })
+      }
+    } catch {
+      setError(true)
+      toast({ title: "No response", variant: "destructive" })
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center flex-col space-y-4">
+      <Button onClick={handlePing}>Ping AI assistant</Button>
+      {error && <p className="text-destructive">Mock error connecting to assistant</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/ping-ai` page with a button that pings a mock AI assistant
- show connection status via toast messages
- log last three replies and handle invalid JSON

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_687631a2dfd88325a730aa4dbf4ac004