### PR TITLE
Centralize collection admin forms

### DIFF
--- a/app/admin/collections/page.tsx
+++ b/app/admin/collections/page.tsx
@@ -8,11 +8,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/
 import { Input } from "@/components/ui/inputs/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/modals/dialog"
-import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { Form } from "@/components/ui/form"
 import { ArrowLeft, Plus, Edit, Trash2, Search } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
 import type { Collection } from "@/types/collection"
+import { CollectionForm } from "@/components/collection/CollectionForm"
 
 interface CollectionWithFabrics extends Collection {
   fabrics: { id: string; name: string }[]
@@ -119,73 +120,7 @@ export default function AdminCollectionsPage() {
                 </DialogTitle>
               </DialogHeader>
               <Form {...form}>
-                <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-                  <FormField
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ชื่อคอลเลกชัน</FormLabel>
-                        <FormControl>
-                          <Input placeholder="ชื่อคอลเลกชัน" {...field} />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    name="slug"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Slug</FormLabel>
-                        <FormControl>
-                          <Input placeholder="slug" {...field} />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    name="description"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>คำอธิบาย</FormLabel>
-                        <FormControl>
-                          <Input placeholder="คำอธิบาย" {...field} />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    name="priceRange"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ช่วงราคา</FormLabel>
-                        <FormControl>
-                          <Input placeholder="เช่น ฿100 - ฿300" {...field} />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    name="images"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>รูปทั้งหมด (คั่นด้วย comma)</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="url1,url2"
-                            value={field.value.join(',')}
-                            onChange={(e) => field.onChange(e.target.value.split(','))}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                  <div className="flex justify-end space-x-2 pt-4">
-                    <Button variant="outline" onClick={() => setIsDialogOpen(false)} type="button">
-                      ยกเลิก
-                    </Button>
-                    <Button type="submit">บันทึก</Button>
-                  </div>
-                </form>
+                <CollectionForm form={form} onSubmit={handleSubmit} />
               </Form>
             </DialogContent>
           </Dialog>

--- a/components/collection/CollectionForm.tsx
+++ b/components/collection/CollectionForm.tsx
@@ -1,0 +1,98 @@
+"use client"
+import type { Collection } from "@/types/collection"
+import { Form, FormField, FormItem, FormLabel, FormControl } from "@/components/ui/form"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { UseFormReturn } from "react-hook-form"
+import { SeoFields } from "@/components/common/SeoFields"
+import { Toggle } from "@/components/common/Toggle"
+
+export interface CollectionFormProps {
+  form: UseFormReturn<Collection & { tags?: string; seoDescription?: string; featured?: boolean }>
+  onSubmit: (values: Collection & { tags?: string; seoDescription?: string; featured?: boolean }) => void
+}
+
+export function CollectionForm({ form, onSubmit }: CollectionFormProps) {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>ชื่อคอลเลกชัน</FormLabel>
+              <FormControl>
+                <Input placeholder="ชื่อคอลเลกชัน" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="slug"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Slug</FormLabel>
+              <FormControl>
+                <Input placeholder="slug" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>คำอธิบาย</FormLabel>
+              <FormControl>
+                <Input placeholder="คำอธิบาย" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="priceRange"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>ช่วงราคา</FormLabel>
+              <FormControl>
+                <Input placeholder="เช่น ฿100 - ฿300" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="images"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>รูปทั้งหมด (คั่นด้วย comma)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="url1,url2"
+                  value={field.value.join(',')}
+                  onChange={(e) => field.onChange(e.target.value.split(','))}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <SeoFields />
+        <FormField
+          name="featured"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="flex items-center space-x-2">
+                <span>แนะนำ</span>
+                <FormControl>
+                  <Toggle checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormLabel>
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end pt-4">
+          <Button type="submit">บันทึก</Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/components/common/SeoFields.tsx
+++ b/components/common/SeoFields.tsx
@@ -1,0 +1,32 @@
+"use client"
+import { Input } from "@/components/ui/inputs/input"
+import { FormField, FormItem, FormLabel, FormControl } from "@/components/ui/form"
+
+export function SeoFields() {
+  return (
+    <>
+      <FormField
+        name="tags"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>แท็ก</FormLabel>
+            <FormControl>
+              <Input placeholder="tag1,tag2" {...field} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <FormField
+        name="seoDescription"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>คำอธิบาย SEO</FormLabel>
+            <FormControl>
+              <Input placeholder="คำอธิบาย" {...field} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}

--- a/components/common/Toggle.tsx
+++ b/components/common/Toggle.tsx
@@ -1,0 +1,14 @@
+"use client"
+import { Switch } from "@/components/ui/switch"
+
+export function Toggle({
+  label,
+  ...props
+}: React.ComponentProps<typeof Switch> & { label?: string }) {
+  return (
+    <label className="flex items-center space-x-2">
+      <Switch {...props} />
+      {label && <span>{label}</span>}
+    </label>
+  )
+}


### PR DESCRIPTION
## Summary
- extract collection form component
- add generic SEO and toggle components
- refactor admin collection pages to use the shared form

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876342f042c8325a0ca2ab99d2bb32a