### PR TITLE
Link orders to conversations

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -10,7 +10,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/
 import { Separator } from "@/components/ui/separator"
 import OrderStatusDropdown from "@/components/admin/orders/OrderStatusDropdown"
 import { OrderTimeline, type TimelineEntry } from "@/components/order/OrderTimeline"
-import { mockOrders, setPackingStatus, setOrderStatus } from "@/lib/mock-orders"
+import {
+  mockOrders,
+  setPackingStatus,
+  setOrderStatus,
+  setConversationId as updateConversationId,
+} from "@/lib/mock-orders"
 import { mockProducts } from "@/lib/mock-products"
 import { useCart } from "@/contexts/cart-context"
 import type { Order } from "@/types/order"
@@ -46,6 +51,7 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
   const [packingStatus, setPackingStatusState] = useState<PackingStatus>(order?.packingStatus ?? "packing")
   const [scheduledDelivery, setScheduledDelivery] = useState(order?.scheduledDelivery || "")
   const [chatNote, setChatNote] = useState(order?.chatNote || "")
+  const [conversationId, setConversationIdState] = useState(order?.conversationId || "")
   const [payment, setPayment] = useState(() => getPayment(id))
   const [chatSent, setChatSent] = useState<boolean>(mockChatStatus[id] || false)
   const [showSendModal, setShowSendModal] = useState(false)
@@ -352,6 +358,45 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
             }}>
               เพิ่มบันทึกการโทร/ส่ง
             </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>เชื่อมต่อแชท</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <input
+              className="border rounded w-full p-2"
+              value={conversationId}
+              onChange={(e) => setConversationIdState(e.target.value)}
+              placeholder="conversation id"
+            />
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  updateConversationId(order.id, conversationId)
+                  mockOrders[orderIndex].conversationId = conversationId
+                  toast.success('บันทึกแล้ว')
+                }}
+              >
+                บันทึก
+              </Button>
+              {conversationId && (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    updateConversationId(order.id, '')
+                    mockOrders[orderIndex].conversationId = undefined
+                    setConversationIdState('')
+                    toast.success('ลบการเชื่อมต่อแล้ว')
+                  }}
+                >
+                  ลบ
+                </Button>
+              )}
+            </div>
           </CardContent>
         </Card>
 

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -140,6 +140,22 @@ export function setOrderStatus(orderId: string, status: OrderStatus) {
   }
 }
 
+export function setConversationId(orderId: string, conversationId: string) {
+  const order = mockOrders.find((o) => o.id === orderId)
+  if (!order) return
+  if (order.conversationId !== conversationId) {
+    order.conversationId = conversationId || undefined
+    order.timeline.push({
+      timestamp: new Date().toISOString(),
+      status: order.status,
+      updatedBy: 'admin@nutlove.co',
+      note: conversationId
+        ? `linked to conversation ${conversationId}`
+        : 'conversation unlinked',
+    })
+  }
+}
+
 export async function fetchOrders(): Promise<Order[]> {
   if (!supabase) {
     return Promise.resolve(mockOrders)

--- a/types/order.ts
+++ b/types/order.ts
@@ -81,6 +81,7 @@ export interface Order {
   depositPercent?: number
   note?: string
   chatNote?: string
+  conversationId?: string
   createdAt: string
   shippingAddress: {
     name: string
@@ -142,6 +143,7 @@ export interface ManualOrder {
   }>
   notes?: string
   attachments: string[]
+  conversationId?: string
   publicLink: string
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Summary
- add `conversationId` field to order types
- allow updating order conversation via new `setConversationId` helper
- let admins set or remove conversation IDs from order detail page

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_687640c8851083258777e2eb9a9c0df3