### PR TITLE
Add notification service worker

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/buttons/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card";
@@ -19,6 +19,37 @@ export default function AdminIndex() {
 
   const [orders, setOrders] = useState<Order[]>(mockOrders);
   const [debugOpen, setDebugOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('Notification' in window)) {
+      toast.warning('เบราว์เซอร์ไม่รองรับการแจ้งเตือน');
+      return;
+    }
+
+    Notification.requestPermission().then((permission) => {
+      if (permission !== 'granted') return;
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .register('/sw.js')
+          .then((reg) => {
+            const list = [...mockNotifications, ...chatNotifications];
+            list.forEach((n) => {
+              reg.active?.postMessage({
+                title: 'SofaCover',
+                options: { body: n.message },
+              });
+            });
+          })
+          .catch(() => {
+            toast.warning('ไม่สามารถลงทะเบียน Service Worker ได้');
+          });
+      } else {
+        toast.warning('เบราว์เซอร์ไม่รองรับ Service Worker');
+      }
+    });
+  }, []);
 
   let todayCount = 0;
   let todayIncome = 0;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,14 @@
+self.addEventListener('install', (e) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (e) => {
+  self.clients.claim();
+});
+
+self.addEventListener('message', (event) => {
+  const { title, options } = event.data || {};
+  if (title) {
+    self.registration.showNotification(title, options || {});
+  }
+});


### PR DESCRIPTION
## Summary
- register a simple service worker at `public/sw.js`
- request Notification permission in the admin dashboard
- forward notifications to the service worker with fallbacks for unsupported browsers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68764fdbf8ec83258e61385ea0a38b52