### PR TITLE
Add client-side task management

### DIFF
--- a/app/team/[role]/page.tsx
+++ b/app/team/[role]/page.tsx
@@ -1,15 +1,65 @@
-import { mockTasks } from "@/lib/mock-tasks"
+"use client"
+
+import { useEffect, useState } from "react"
+import { getTasks, addTask } from "@/lib/mock-tasks"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import type { Task } from "@/types/task"
 
 export default function TeamRolePage({ params }: { params: { role: string } }) {
   const { role } = params
-  const tasks = mockTasks.filter((t) => t.role === role)
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [title, setTitle] = useState("")
+  const [dueDate, setDueDate] = useState("")
+
+  useEffect(() => {
+    setTasks(getTasks().filter((t) => t.role === role))
+  }, [role])
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    addTask({ role, title, dueDate })
+    setTasks(getTasks().filter((t) => t.role === role))
+    setTitle("")
+    setDueDate("")
+  }
+
+  const now = new Date()
+  const soon = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)
+  const urgent = tasks.filter(
+    (t) => t.dueDate && new Date(t.dueDate) <= soon && t.status !== "completed",
+  )
 
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold mb-6">งานสำหรับทีม {role}</h1>
+        <form onSubmit={handleAdd} className="flex space-x-2 mb-6">
+          <Input
+            placeholder="ชื่องาน"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <Input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+          <Button type="submit">เพิ่มงาน</Button>
+        </form>
+        {urgent.length > 0 && (
+          <div className="mb-6">
+            <h2 className="font-semibold mb-2">งานเร่งด่วน</h2>
+            <ul className="list-disc pl-5 space-y-1">
+              {urgent.map((t) => (
+                <li key={t.id}>{t.title}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         {tasks.length > 0 ? (
           <div className="grid gap-4">
             {tasks.map((task) => (
@@ -40,3 +90,4 @@ export default function TeamRolePage({ params }: { params: { role: string } }) {
     </div>
   )
 }
+

--- a/lib/mock-tasks.ts
+++ b/lib/mock-tasks.ts
@@ -1,6 +1,8 @@
-import type { Task } from "@/types/task"
+import type { Task, TaskStatus } from "@/types/task"
 
-export const mockTasks: Task[] = [
+const STORAGE_KEY = "tasks"
+
+const initialTasks: Task[] = [
   {
     id: "TASK-001",
     role: "production",
@@ -33,3 +35,54 @@ export const mockTasks: Task[] = [
     status: "pending",
   },
 ]
+
+export let mockTasks: Task[] = [...initialTasks]
+
+function saveTasks() {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mockTasks))
+  }
+}
+
+export function loadTasks() {
+  if (typeof window === "undefined") return
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (raw) {
+    try {
+      mockTasks = JSON.parse(raw) as Task[]
+    } catch {
+      mockTasks = [...initialTasks]
+    }
+  } else {
+    saveTasks()
+  }
+}
+
+export function getTasks() {
+  if (typeof window !== "undefined") loadTasks()
+  return mockTasks
+}
+
+export function addTask(task: Omit<Task, "id"> & { id?: string }) {
+  const newTask: Task = {
+    id: task.id || Date.now().toString(),
+    status: "pending",
+    ...task,
+  }
+  mockTasks.push(newTask)
+  saveTasks()
+  return newTask
+}
+
+export function updateTaskStatus(id: string, status: TaskStatus) {
+  const t = mockTasks.find((task) => task.id === id)
+  if (t) {
+    t.status = status
+    saveTasks()
+  }
+}
+
+export function deleteTask(id: string) {
+  mockTasks = mockTasks.filter((t) => t.id !== id)
+  saveTasks()
+}


### PR DESCRIPTION
## Summary
- persist tasks in localStorage and expose helpers
- allow staff to add tasks per role from `/team/[role]`
- highlight urgent tasks on the role page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876979e85188325bc9f950fe4667f60