### PR TITLE
Remove Supabase logic from fabrics

### DIFF
--- a/app/admin/fabrics/[id]/edit/page.tsx
+++ b/app/admin/fabrics/[id]/edit/page.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 import { useAuth } from "@/contexts/auth-context"
-import { supabase } from "@/lib/supabase"
-import { prepareFabricImage } from "@/lib/image-handler"
+import { mockFabrics } from "@/lib/mock-fabrics"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
@@ -39,29 +38,15 @@ export default function EditFabricPage({ params }: EditFabricPageProps) {
   }, [isAuthenticated, user, router])
 
   useEffect(() => {
-    const fetchFabric = async () => {
-      if (!supabase || !params.id) {
-        setLoading(false)
-        return
-      }
-      const { data, error } = await supabase
-        .from("fabrics")
-        .select("name, image_url, collection_id")
-        .eq("id", params.id)
-        .single()
-      if (error || !data) {
-        console.error("Failed to fetch fabric", error)
-        router.push("/admin/fabrics")
-        return
-      }
-      setName(data.name || "")
-      setImageUrl(data.image_url || "")
-      setPreviewUrl(data.image_url || "")
-      setCollectionId(data.collection_id || "")
-      setLoading(false)
+    const f = mockFabrics.find((fab) => fab.id === params.id)
+    if (f) {
+      setName(f.name)
+      setImageUrl(f.images[0])
+      setPreviewUrl(f.images[0])
+      setCollectionId(f.collectionSlug)
     }
-    fetchFabric()
-  }, [params.id, router])
+    setLoading(false)
+  }, [params.id])
 
   if (!isAuthenticated || user?.role !== "admin") {
     return null
@@ -71,52 +56,9 @@ export default function EditFabricPage({ params }: EditFabricPageProps) {
     return <div>Loading...</div>
   }
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!supabase) return
-
-    let uploadedUrl = imageUrl
-
-    if (imageFile) {
-      let slug = 'fabric'
-      if (collectionId) {
-        const { data } = await supabase
-          .from('collections')
-          .select('slug')
-          .eq('id', collectionId)
-          .single()
-        if (data?.slug) slug = data.slug
-      }
-      const processedFile = await prepareFabricImage(imageFile, slug, 1, 'image/webp')
-      const fileName = processedFile.name
-      const { error: uploadError } = await supabase.storage
-        .from("fabric-images")
-        .upload(fileName, processedFile)
-      if (uploadError) {
-        console.error("Failed to upload image", uploadError)
-        return
-      }
-      const { data } = supabase.storage
-        .from("fabric-images")
-        .getPublicUrl(fileName)
-      uploadedUrl = data.publicUrl
-      setImageUrl(uploadedUrl)
-    }
-
-    const { error } = await supabase
-      .from("fabrics")
-      .update({
-        name,
-        image_url: uploadedUrl,
-        collection_id: collectionId,
-      })
-      .eq("id", params.id)
-
-    if (error) {
-      console.error("Failed to update fabric", error)
-      return
-    }
-
+    // mock update only
     router.push("/admin/fabrics")
   }
 

--- a/app/admin/fabrics/[id]/page.tsx
+++ b/app/admin/fabrics/[id]/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { useAuth } from "@/contexts/auth-context"
-import { supabase } from "@/lib/supabase"
+import { mockFabrics } from "@/lib/mock-fabrics"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 
@@ -44,34 +44,21 @@ export default function FabricDetailPage({ params }: FabricDetailPageProps) {
   }, [isAuthenticated, user, router])
 
   useEffect(() => {
-    const fetchFabric = async () => {
-      if (!supabase || !params.id) {
-        setLoading(false)
-        return
-      }
-      const { data, error } = await supabase
-        .from("fabrics")
-        .select("id, name, sku, collection_id, image_urls, price_min, price_max")
-        .eq("id", params.id)
-        .single()
-      if (error || !data) {
-        console.error("Failed to fetch fabric", error)
-        router.push("/admin/fabrics")
-        return
-      }
-      setFabric(data)
-      const { data: collection } = await supabase
-        .from("collections")
-        .select("name")
-        .eq("id", data.collection_id)
-        .single()
-      if (collection) {
-        setCollectionName(collection.name)
-      }
-      setLoading(false)
+    const f = mockFabrics.find((fab) => fab.id === params.id)
+    if (f) {
+      setFabric({
+        id: f.id,
+        name: f.name,
+        sku: f.sku,
+        collection_id: f.collectionSlug,
+        image_urls: f.images,
+        price_min: f.price,
+        price_max: f.price,
+      })
+      setCollectionName(f.collectionSlug)
     }
-    fetchFabric()
-  }, [params.id, router])
+    setLoading(false)
+  }, [params.id])
 
   if (!isAuthenticated || user?.role !== "admin") {
     return null

--- a/app/admin/fabrics/create/page.tsx
+++ b/app/admin/fabrics/create/page.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 import { useAuth } from "@/contexts/auth-context"
-import { supabase } from "@/lib/supabase"
-import { prepareFabricImage } from "@/lib/image-handler"
+import { mockFabrics } from "@/lib/mock-fabrics"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
@@ -37,59 +36,9 @@ export default function CreateFabricPage() {
     return null
   }
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!supabase) return
-
-    let uploadedUrl = imageUrl
-
-    if (imageFile) {
-      let slug = 'fabric'
-      if (collectionId) {
-        const { data } = await supabase
-          .from('collections')
-          .select('slug')
-          .eq('id', collectionId)
-          .single()
-        if (data?.slug) slug = data.slug
-      }
-      const processedFile = await prepareFabricImage(imageFile, slug, 1, 'image/webp')
-      const fileName = processedFile.name
-      const { error: uploadError } = await supabase.storage
-        .from("fabric-images")
-        .upload(fileName, processedFile)
-      if (uploadError) {
-        console.error("Failed to upload image", uploadError)
-        return
-      }
-      const { data } = supabase.storage
-        .from("fabric-images")
-        .getPublicUrl(fileName)
-      uploadedUrl = data.publicUrl
-      setImageUrl(uploadedUrl)
-    }
-
-    const { data: last } = await supabase
-      .from("fabrics")
-      .select("sku")
-      .order("sku", { ascending: false })
-      .limit(1)
-      .single()
-    const lastNum = last?.sku ? parseInt(last.sku.split("-")[1]) : 0
-    const sku = `FBC-${String(lastNum + 1).padStart(3, "0")}`
-
-    const { error } = await supabase.from("fabrics").insert({
-      name,
-      sku,
-      image_url: uploadedUrl,
-      collection_id: collectionId,
-    })
-
-    if (error) {
-      console.error("Failed to create fabric", error)
-      return
-    }
-
+    // mock create only
     router.push("/admin/fabrics")
   }
 

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -6,7 +6,6 @@ import Link from "next/link"
 import { WishlistButton } from "@/components/WishlistButton"
 import { FavoriteButton } from "@/components/FavoriteButton"
 import type { Metadata } from "next"
-import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
 import { notFound } from "next/navigation"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
@@ -29,78 +28,34 @@ interface Fabric {
 }
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
-  if (!supabase) {
-    const fabric = mockFabrics.find((f) => f.slug === params.slug)
-    if (!fabric) return {}
-    const title = `${fabric.name} | SofaCover Pro`
-    const description = `รายละเอียดลายผ้า ${fabric.name}`
-    const image = fabric.images[0]
-    return {
-      title,
-      description,
-      openGraph: { title, description, images: [{ url: image }] },
-    }
-  }
-  const { data } = await supabase
-    .from("fabrics")
-    .select("name, description, sku, image_url, image_urls")
-    .eq("slug", params.slug)
-    .single()
-  if (!data) return {}
-  const title = `${data.name} | SofaCover Pro`
-  const description = data.description || `รายละเอียดลายผ้า ${data.name}`
-  const image = data.image_urls?.[0] || data.image_url || "/placeholder.svg"
+  const fabric = mockFabrics.find((f) => f.slug === params.slug)
+  if (!fabric) return {}
+  const title = `${fabric.name} | SofaCover Pro`
+  const description = `รายละเอียดลายผ้า ${fabric.name}`
+  const image = fabric.images[0]
   return {
     title,
     description,
-    openGraph: {
-      title,
-      description,
-      images: [{ url: image }],
-    },
+    openGraph: { title, description, images: [{ url: image }] },
   }
 }
 
 export default async function FabricDetailPage({ params }: { params: { slug: string } }) {
-  let fabric: Fabric | null = null
-  let collection: { name: string; slug: string } | null = null
-
-  if (!supabase) {
-    const f = mockFabrics.find((fab) => fab.slug === params.slug)
-    if (!f) {
-      notFound()
-    }
-    fabric = {
-      id: f!.id,
-      slug: f!.slug,
-      name: f!.name,
-      sku: f!.sku,
-      description: '',
-      image_urls: f!.images,
-      price_min: f!.price,
-      price_max: f!.price,
-    }
-  } else {
-    const { data, error } = await supabase
-      .from("fabrics")
-      .select("id, slug, name, sku, description, size, collection_id, image_url, image_urls, price_min, price_max")
-      .eq("slug", params.slug)
-      .single()
-
-    if (error || !data) {
-      notFound()
-    }
-    fabric = data as Fabric
-
-    if (fabric.collection_id) {
-      const { data: col } = await supabase
-        .from("collections")
-        .select("name, slug")
-        .eq("id", fabric.collection_id)
-        .single()
-      if (col) collection = col
-    }
+  const f = mockFabrics.find((fab) => fab.slug === params.slug)
+  if (!f) {
+    notFound()
   }
+  const fabric: Fabric = {
+    id: f!.id,
+    slug: f!.slug,
+    name: f!.name,
+    sku: f!.sku,
+    description: '',
+    image_urls: f!.images,
+    price_min: f!.price,
+    price_max: f!.price,
+  }
+  const collection: { name: string; slug: string } | null = null
 
 
 

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -2,7 +2,6 @@ import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { FabricsList } from "@/components/FabricsList"
 import type { Metadata } from "next"
-import { supabase } from "@/lib/supabase"
 import { mockFabrics } from "@/lib/mock-fabrics"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 
@@ -21,31 +20,13 @@ interface Fabric {
 }
 
 export default async function FabricsPage() {
-  let fabrics: Fabric[] = []
-  if (!supabase) {
-    fabrics = mockFabrics.map((f) => ({
-      id: f.id,
-      slug: f.slug,
-      name: f.name,
-      sku: f.sku,
-      image_urls: f.images,
-    }))
-  } else {
-    const { data, error } = await supabase
-      .from("fabrics")
-      .select("id, slug, name, sku, image_url, image_urls")
-
-    if (error || !data) {
-      return (
-        <div className="min-h-screen">
-          <Navbar />
-          <div className="container mx-auto px-4 py-8 text-red-500">ไม่สามารถโหลดข้อมูลผ้าได้</div>
-          <Footer />
-        </div>
-      )
-    }
-    fabrics = data as Fabric[]
-  }
+  const fabrics: Fabric[] = mockFabrics.map((f) => ({
+    id: f.id,
+    slug: f.slug,
+    name: f.name,
+    sku: f.sku,
+    image_urls: f.images,
+  }))
 
   return (
     <div className="min-h-screen">

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -1,4 +1,3 @@
-import { supabase } from './supabase'
 
 export interface Fabric {
   id: string
@@ -64,14 +63,6 @@ export const mockFabrics: Fabric[] = [
   },
 ]
 
-export async function getFabrics() {
-  if (!supabase) {
-    return Promise.resolve(mockFabrics)
-  }
-  const { data, error } = await supabase.from('fabrics').select('*')
-  if (error || !data) {
-    console.error('Supabase fetch fabrics error', error)
-    return mockFabrics
-  }
-  return data as Fabric[]
+export function getFabrics(): Promise<Fabric[]> {
+  return Promise.resolve(mockFabrics)
 }


### PR DESCRIPTION
## Summary
- rely solely on mock data in `lib/mock-fabrics.ts`
- simplify fabrics gallery pages to use mock data
- drop Supabase logic from admin fabrics CRUD pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687699e935d88325a749a5619d514821