### PR TITLE
Add quote attachment support to chat modal

### DIFF
--- a/components/admin/SendToChatModal.tsx
+++ b/components/admin/SendToChatModal.tsx
@@ -1,9 +1,22 @@
 import { useState } from "react"
 import { logEvent } from "@/lib/logs"
+import { quoteBlock } from "@/lib/mock-chat"
+import { addChatAttachment } from "@/lib/mock-attachments"
 
 export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose: () => void }) {
   const [message, setMessage] = useState(`📦 รายการคำสั่งซื้อ #${orderId}\nยอดรวม: 999 บาท`)
   const [customer, setCustomer] = useState("ลูกค้า A (Facebook)")
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+
+  const handleFile = (f: File) => {
+    if (f.size > 2 * 1024 * 1024) {
+      alert('ไฟล์ใหญ่เกินไป (2MB)')
+      return
+    }
+    setFile(f)
+    setPreview(URL.createObjectURL(f))
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -23,11 +36,25 @@ export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose
           onChange={(e) => setMessage(e.target.value)}
           className="w-full h-32 border p-2 rounded"
         />
+        <div className="flex items-center gap-2">
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => e.target.files && handleFile(e.target.files[0])}
+          />
+          <Button variant="outline" onClick={() => setMessage((m) => m + '\n' + quoteBlock)}>
+            แนบใบเสนอราคา
+          </Button>
+        </div>
+        {preview && (
+          <img src={preview} alt="preview" className="w-32 h-32 object-cover" />
+        )}
         <div className="flex justify-end gap-2">
           <button className="text-gray-500" onClick={onClose}>ยกเลิก</button>
           <button
             className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-            onClick={() => {
+            onClick={async () => {
+              if (file) await addChatAttachment(file)
               logEvent('send_bill_chat', { orderId, customer })
               alert(`✅ ส่งข้อความไปยังแชทแล้ว:\n\n${message}`)
               onClose()

--- a/lib/mock-attachments.ts
+++ b/lib/mock-attachments.ts
@@ -1,0 +1,33 @@
+export interface ChatAttachment {
+  id: string
+  name: string
+  url: string
+}
+
+export let chatAttachments: ChatAttachment[] = []
+
+export async function addChatAttachment(file: File): Promise<ChatAttachment> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('read-error'))
+    reader.readAsDataURL(file)
+  })
+  const entry: ChatAttachment = {
+    id: Date.now().toString(),
+    name: file.name,
+    url: dataUrl,
+  }
+  chatAttachments = [entry, ...chatAttachments]
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatAttachments', JSON.stringify(chatAttachments))
+  }
+  return entry
+}
+
+export function loadChatAttachments() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatAttachments')
+    if (stored) chatAttachments = JSON.parse(stored)
+  }
+}

--- a/lib/mock-chat.ts
+++ b/lib/mock-chat.ts
@@ -1,4 +1,5 @@
 export let chatWelcome = 'สวัสดีค่ะ มีอะไรให้ช่วยไหม?'
+export const quoteBlock = '📑 ใบเสนอราคา: https://example.com/quote.pdf'
 
 export function loadChatWelcome() {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- add mock attachments store
- support quote block text in mock chat
- allow quote insertion and file upload preview when sending chat message

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876c44bdac0832596f67e430e677e66