### PR TITLE
Add dev test page with mock reset toggle

### DIFF
--- a/app/admin/dev-only/dev/bill-history/page.tsx
+++ b/app/admin/dev-only/dev/bill-history/page.tsx
@@ -1,6 +1,6 @@
 "use client"
-import { useState } from "react"
-import { isDevMock } from "@/lib/mock-settings"
+import { useState, useEffect } from "react"
+import { isDevMock, loadDevMode } from "@/lib/mock-settings"
 import { mockBills, confirmBill } from "@/lib/mock-bills"
 import { Button } from "@/components/ui/buttons/button"
 import EmptyState from "@/components/EmptyState"
@@ -8,8 +8,13 @@ import { cancelBill } from "@/lib/mock-bills"
 
 export default function DevBillHistory() {
   const [bills, setBills] = useState([...mockBills])
+  const [devMode, setDevMode] = useState(isDevMock)
+  useEffect(() => {
+    loadDevMode()
+    setDevMode(isDevMock)
+  }, [])
 
-  if (!isDevMock) return <EmptyState title="ไม่อนุญาต" />
+  if (!devMode) return <EmptyState title="ไม่อนุญาต" />
 
   const handleConfirm = (id: string) => {
     confirmBill(id)

--- a/app/admin/dev-only/dev/page.tsx
+++ b/app/admin/dev-only/dev/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useAuth } from "@/contexts/auth-context"
-import { isDevMock } from "@/lib/mock-settings"
+import { isDevMock, loadDevMode } from "@/lib/mock-settings"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Button } from "@/components/ui/buttons/button"
 import {
@@ -17,7 +18,12 @@ import {
 
 export default function AdminDevPage() {
   const { user, isAuthenticated } = useAuth()
-  if (!isDevMock) {
+  const [devMode, setDevMode] = useState(isDevMock)
+  useEffect(() => {
+    loadDevMode()
+    setDevMode(isDevMock)
+  }, [])
+  if (!devMode) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p>ไม่อนุญาต</p>

--- a/app/dev-test/page.tsx
+++ b/app/dev-test/page.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/contexts/auth-context"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Badge } from "@/components/ui/badge"
+import { resetMockDB } from "@/lib/reset-mock-db"
+import { isDevMock, loadDevMode, setDevMode } from "@/lib/mock-settings"
+
+export default function DevTestPage() {
+  const { user, isAuthenticated } = useAuth()
+  const router = useRouter()
+  const [devMode, setDevModeState] = useState(isDevMock)
+
+  useEffect(() => {
+    loadDevMode()
+    setDevModeState(isDevMock)
+    if (!isAuthenticated) {
+      router.push("/login")
+    } else if (user?.role !== "admin") {
+      router.push("/")
+    }
+  }, [isAuthenticated, user, router])
+
+  if (!isAuthenticated || user?.role !== "admin") return null
+
+  const toggleDev = () => {
+    const val = !devMode
+    setDevMode(val)
+    setDevModeState(val)
+  }
+
+  const handleReset = () => {
+    resetMockDB()
+    alert("รีเซ็ตข้อมูลแล้ว")
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="space-y-4 max-w-sm w-full">
+        <Card>
+          <CardHeader>
+            <CardTitle>โหมดนักพัฒนา</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Badge variant="secondary">{devMode ? "เปิดอยู่" : "ปิดอยู่"}</Badge>
+            <Button onClick={toggleDev}>{devMode ? "ปิด Dev Mode" : "เปิด Dev Mode"}</Button>
+          </CardContent>
+        </Card>
+        <Button variant="destructive" onClick={handleReset} className="w-full">
+          รีเซ็ต Mock DB
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-settings.ts
+++ b/lib/mock-settings.ts
@@ -1,4 +1,18 @@
-export const isDevMock = true;
+export let isDevMock = true;
+
+export function loadDevMode() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('devMode')
+    if (stored) isDevMock = JSON.parse(stored)
+  }
+}
+
+export function setDevMode(val: boolean) {
+  isDevMock = val
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('devMode', JSON.stringify(val))
+  }
+}
 export let autoMessage = "ขอบคุณที่สั่งซื้อกับเรา";
 export let socialLinks = { facebook: "", line: "" };
 

--- a/lib/reset-mock-db.ts
+++ b/lib/reset-mock-db.ts
@@ -1,0 +1,14 @@
+import { resetMockOrders } from './mock-orders'
+import { resetMockCustomers } from './mock-customers'
+import { mockAdminLogs } from './mock-admin-logs'
+import { mockBills } from './bills'
+
+export function resetMockDB() {
+  resetMockOrders()
+  resetMockCustomers()
+  mockAdminLogs.length = 0
+  mockBills.length = 0
+  if (typeof window !== 'undefined') {
+    localStorage.clear()
+  }
+}


### PR DESCRIPTION
## Summary
- create `/dev-test` admin route with dev mode toggle and reset button
- allow runtime switching of `isDevMock`
- expose a `resetMockDB` helper
- load dev mode state on developer pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c45c489c8325bc225baeab95f02a