### PR TITLE
Add fabric keywords and popularity

### DIFF
--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -16,7 +16,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { ArrowLeft, Edit, Plus, Trash2, Search } from "lucide-react"
+import { ArrowLeft, Edit, Plus, Trash2, Search, Eye } from "lucide-react"
+import { FabricDetailModal } from "@/components/admin/FabricDetailModal"
 import { Input } from "@/components/ui/inputs/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
@@ -30,6 +31,8 @@ interface Fabric {
   price_min: number
   price_max: number
   collection_name?: string | null
+  keywords?: string[]
+  popular?: boolean
 }
 
 export default function AdminFabricsPage() {
@@ -41,6 +44,7 @@ export default function AdminFabricsPage() {
   const [searchTerm, setSearchTerm] = useState("")
   const [collectionFilter, setCollectionFilter] = useState("all")
   const [collectionOptions, setCollectionOptions] = useState<{id: string; name: string}[]>([])
+  const [selected, setSelected] = useState<Fabric | null>(null)
 
   const handleDelete = async (id: string) => {
     if (
@@ -216,6 +220,13 @@ export default function AdminFabricsPage() {
                           <Button
                             variant="outline"
                             size="icon"
+                            onClick={() => setSelected(fabric)}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="icon"
                             onClick={() => router.push(`/admin/fabrics/${fabric.id}/edit`)}
                           >
                             <Edit className="h-4 w-4" />
@@ -243,6 +254,9 @@ export default function AdminFabricsPage() {
             )}
           </CardContent>
         </Card>
+        {selected && (
+          <FabricDetailModal fabric={selected} onClose={() => setSelected(null)} />
+        )}
       </div>
     </div>
   )

--- a/components/admin/FabricDetailModal.tsx
+++ b/components/admin/FabricDetailModal.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react"
+import Image from "next/image"
+import { Star } from "lucide-react"
+import type { Fabric } from "@/lib/mock-fabrics"
+import { mockFabrics } from "@/lib/mock-fabrics"
+
+export function FabricDetailModal({ fabric, onClose }: { fabric: Fabric; onClose: () => void }) {
+  const [keywords, setKeywords] = useState<string>(fabric.keywords?.join(', ') || '')
+  const [popular, setPopular] = useState<boolean>(!!fabric.popular)
+
+  const save = () => {
+    const idx = mockFabrics.findIndex((f) => f.id === fabric.id)
+    if (idx !== -1) {
+      mockFabrics[idx] = {
+        ...mockFabrics[idx],
+        keywords: keywords.split(',').map((k) => k.trim()).filter(Boolean),
+        popular,
+      }
+    }
+    onClose()
+  }
+
+  const parsed = keywords.split(',').map((k) => k.trim()).filter(Boolean)
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md space-y-4">
+        <div className="relative w-full h-48">
+          <Image src={fabric.images[0] || '/placeholder.svg'} alt={fabric.name} fill className="object-cover rounded" />
+        </div>
+        <h2 className="text-xl font-bold">{fabric.name}</h2>
+        <button
+          className={`flex items-center gap-2 ${popular ? 'text-yellow-500' : 'text-gray-600'}`}
+          onClick={() => setPopular(!popular)}
+        >
+          <Star className={popular ? 'fill-current' : ''} />
+          ติดดาวผ้ายอดนิยม
+        </button>
+        <div>
+          <label className="block text-sm font-medium mb-1">คำค้นหา</label>
+          <input
+            className="w-full border p-2 rounded"
+            value={keywords}
+            onChange={(e) => setKeywords(e.target.value)}
+            placeholder="เช่น ลายดอกไม้, ผ้านุ่ม"
+          />
+          <p className="text-sm text-gray-500 mt-1">
+            {parsed.length === 0 ? 'ผ้านี้ยังไม่มีคำค้น' : parsed.join(', ')}
+          </p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button className="text-gray-500" onClick={onClose}>ยกเลิก</button>
+          <button className="bg-primary text-white px-4 py-2 rounded" onClick={save}>บันทึก</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -9,6 +9,8 @@ export interface Fabric {
   price: number
   images: string[]
   collectionSlug: string
+  keywords?: string[]
+  popular?: boolean
 }
 
 export const mockFabrics: Fabric[] = [
@@ -21,6 +23,8 @@ export const mockFabrics: Fabric[] = [
     price: 990,
     images: ['/images/039.jpg', '/images/040.jpg'],
     collectionSlug: 'cozy-earth',
+    keywords: ['ลินิน', 'สีครีม'],
+    popular: false,
   },
   {
     id: 'f02',
@@ -31,6 +35,8 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/041.jpg', '/images/042.jpg'],
     collectionSlug: 'cozy-earth',
+    keywords: ['คอตตอน', 'สีเทา'],
+    popular: false,
   },
   {
     id: 'f03',
@@ -41,6 +47,8 @@ export const mockFabrics: Fabric[] = [
     price: 1290,
     images: ['/images/043.jpg', '/images/044.jpg'],
     collectionSlug: 'modern-loft',
+    keywords: ['ผ้ากำมะหยี่', 'สีน้ำเงิน'],
+    popular: false,
   },
   {
     id: 'f04',
@@ -51,6 +59,8 @@ export const mockFabrics: Fabric[] = [
     price: 1190,
     images: ['/images/045.jpg', '/images/046.jpg'],
     collectionSlug: 'modern-loft',
+    keywords: ['ลายทาง', 'สีน้ำเงินเข้ม'],
+    popular: false,
   },
   {
     id: 'f05',
@@ -61,6 +71,8 @@ export const mockFabrics: Fabric[] = [
     price: 1090,
     images: ['/images/047.jpg', '/images/035.jpg'],
     collectionSlug: 'vintage-vibes',
+    keywords: ['ลายดอกไม้', 'สีชมพู'],
+    popular: false,
   },
 ]
 


### PR DESCRIPTION
## Summary
- support SEO search keywords and popularity flag on fabrics
- implement FabricDetailModal for editing keywords
- show the modal from admin fabrics table

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c450df00832590be075684da0b31