### PR TITLE
Add dev alert preview and log viewer

### DIFF
--- a/app/dev-test/alert/[id]/page.tsx
+++ b/app/dev-test/alert/[id]/page.tsx
@@ -1,0 +1,17 @@
+"use client"
+import EmptyState from "@/components/EmptyState"
+import { getMockAlert } from "@/lib/mock-alerts"
+
+export default function AlertPreview({ params }: { params: { id: string } }) {
+  const alert = getMockAlert(params.id)
+  if (!alert) return <EmptyState title="ไม่มี mock alert" />
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">{alert.title}</h1>
+      <p>{alert.message}</p>
+      {alert.image && (
+        <img src={alert.image} alt={alert.title} className="max-w-xs" />
+      )}
+    </div>
+  )
+}

--- a/app/dev-test/page.tsx
+++ b/app/dev-test/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { mockLogs } from "@/lib/mock-logs"
+
+export default function DevTestPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Dev Logs</h1>
+      {mockLogs.length === 0 ? (
+        <p className="text-gray-500">ไม่มี log</p>
+      ) : (
+        <ul className="space-y-2">
+          {mockLogs.map((l) => (
+            <li key={l.id} className="border p-2 rounded">
+              <div className="text-xs text-gray-500">
+                {new Date(l.timestamp).toLocaleString()}
+              </div>
+              <div>{l.message}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/lib/mock-alerts.ts
+++ b/lib/mock-alerts.ts
@@ -1,6 +1,26 @@
 import { mockClaims } from './mock-claims'
 import { mockOrders } from './mock-orders'
 
+export interface MockAlert {
+  id: string
+  title: string
+  message: string
+  image?: string
+}
+
+export const mockAlerts: MockAlert[] = [
+  {
+    id: 'sample',
+    title: 'แจ้งเตือนตัวอย่าง',
+    message: 'นี่คือข้อความแจ้งเตือนสำหรับการทดสอบระบบ',
+    image: '/placeholder.svg?height=200&width=200',
+  },
+]
+
+export function getMockAlert(id: string): MockAlert | undefined {
+  return mockAlerts.find((a) => a.id === id)
+}
+
 export function getGlobalAlertCount(): number {
   const claimCount = mockClaims.filter(
     (c) => c.status === 'pending' || c.status === 'claim_waiting',

--- a/lib/mock-logs.ts
+++ b/lib/mock-logs.ts
@@ -1,0 +1,21 @@
+export interface DevLog {
+  id: string
+  message: string
+  timestamp: string
+}
+
+export let mockLogs: DevLog[] = [
+  {
+    id: '1',
+    message: 'ระบบเริ่มทำงาน',
+    timestamp: new Date().toISOString(),
+  },
+]
+
+export function addMockLog(message: string) {
+  mockLogs.push({
+    id: Date.now().toString(),
+    message,
+    timestamp: new Date().toISOString(),
+  })
+}


### PR DESCRIPTION
## Summary
- extend mock-alerts.ts with alert dataset and loader
- add mock-logs.ts for dev logging
- create /dev-test page to display logs
- add /dev-test/alert/[id] page for alert previews

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876c79fe67c8325ad3d3198971c2536