### PR TITLE
Customer admin enhancements

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -167,6 +167,9 @@ export default function CustomerDetailPage({
         <Link href="/chat">
           <Button variant="outline">เปิดใน Chatwoot</Button>
         </Link>
+        <Link href={`/admin/orders?customer=${customer.id}`}>
+          <Button variant="outline">ดูออเดอร์ทั้งหมดของลูกค้านี้</Button>
+        </Link>
 
         <Card>
           <CardHeader>

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -19,7 +19,12 @@ import {
   loadCustomerNotes,
   listCustomerNotes,
 } from "@/lib/mock-customer-notes"
-import { loadCustomerTags, listCustomerTags } from "@/lib/mock-customer-tags"
+import {
+  loadCustomerTags,
+  listCustomerTags,
+  defaultTags,
+  customerTags,
+} from "@/lib/mock-customer-tags"
 import { loadFlaggedUsers, getFlagStatus } from "@/lib/mock-flagged-users"
 import { downloadCSV, downloadPDF } from "@/lib/mock-export"
 
@@ -29,6 +34,7 @@ export default function AdminCustomersPage() {
   const [searchTerm, setSearchTerm] = useState("")
   const [behaviorFilter, setBehaviorFilter] = useState("all")
   const [tagFilter, setTagFilter] = useState("all")
+  const [tags, setTags] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
   const [newName, setNewName] = useState("")
@@ -38,6 +44,7 @@ export default function AdminCustomersPage() {
     loadCustomerNotes()
     loadCustomerTags()
     loadFlaggedUsers()
+    setTags(Array.from(new Set([...defaultTags, ...customerTags.map((t) => t.tag)])))
     loadData()
   }, [])
 
@@ -237,9 +244,11 @@ export default function AdminCustomersPage() {
                   onChange={(e) => setTagFilter(e.target.value)}
                 >
                   <option value="all">แท็กทั้งหมด</option>
-                  <option value="สายหวาน">สายหวาน</option>
-                  <option value="ขาประจำ">ขาประจำ</option>
-                  <option value="อารมณ์ร้อน">อารมณ์ร้อน</option>
+                  {tags.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
                 </select>
                 <Button onClick={() => downloadCSV(customers, 'customers.csv')}>
                   Export CSV

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Badge } from "@/components/ui/badge"
@@ -10,6 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/modals/dialog"
 import { Search, ArrowLeft, Eye, FileText, Edit, Copy, ExternalLink } from "lucide-react"
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
 import { toast } from "sonner"
 import { mockOrders, setPackingStatus, setOrderStatus } from "@/lib/mock-orders"
 import { mockCustomers } from "@/lib/mock-customers"
@@ -49,6 +50,12 @@ export default function AdminOrdersPage() {
   const [customerFilter, setCustomerFilter] = useState<string>("all")
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
   const [bills, setBills] = useState(mockBills)
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const c = searchParams.get("customer")
+    if (c) setCustomerFilter(c)
+  }, [searchParams])
 
   const filteredOrders = orders.filter((order) => {
     const matchesSearch =
@@ -449,10 +456,16 @@ export default function AdminOrdersPage() {
             </Table>
             </div>
 
-            {filteredOrders.length === 0 && (
+            {orders.length === 0 ? (
               <div className="text-center py-8">
-                <p className="text-gray-500">ไม่พบคำสั่งซื้อที่ตรงกับเงื่อนไขการค้นหา</p>
+                <p className="text-gray-500">ยังไม่มีออเดอร์ในระบบ</p>
               </div>
+            ) : (
+              filteredOrders.length === 0 && (
+                <div className="text-center py-8">
+                  <p className="text-gray-500">ไม่พบคำสั่งซื้อที่ตรงกับเงื่อนไขการค้นหา</p>
+                </div>
+              )
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- link from customer profile to orders list filtered by that customer
- make admin customer tag filter dynamic
- allow orders page to read customer from query param
- show fallback when no orders exist

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c79c2f4c832586df8d2a4688f1e2