### PR TITLE
Add chat quick replies and last seen tracker

### DIFF
--- a/components/admin/SendToChatModal.tsx
+++ b/components/admin/SendToChatModal.tsx
@@ -1,9 +1,34 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { logEvent } from "@/lib/logs"
+import { faqItems, loadFaq, type FaqItem } from "@/lib/mock-faq"
+import {
+  loadChatLastSeen,
+  getChatLastSeen,
+  setChatLastSeen,
+} from "@/lib/mock-read-status"
 
 export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose: () => void }) {
   const [message, setMessage] = useState(`📦 รายการคำสั่งซื้อ #${orderId}\nยอดรวม: 999 บาท`)
   const [customer, setCustomer] = useState("ลูกค้า A (Facebook)")
+  const [faqs, setFaqs] = useState<FaqItem[]>([])
+  const [highlight, setHighlight] = useState(false)
+  const [lastSeen, setLastSeen] = useState<string | undefined>()
+
+  useEffect(() => {
+    loadFaq()
+    setFaqs([...faqItems])
+    loadChatLastSeen()
+  }, [])
+
+  useEffect(() => {
+    setLastSeen(getChatLastSeen(customer))
+  }, [customer])
+
+  const insertReply = (text: string) => {
+    setMessage((m) => (m ? m + "\n" + text : text))
+    setHighlight(true)
+    setTimeout(() => setHighlight(false), 300)
+  }
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -21,8 +46,24 @@ export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          className="w-full h-32 border p-2 rounded"
+          className={`w-full h-32 border p-2 rounded ${highlight ? 'border-blue-500' : ''}`}
         />
+        <div className="flex flex-wrap gap-2">
+          {faqs.map((f) => (
+            <button
+              key={f.id}
+              onClick={() => insertReply(f.answer)}
+              className="px-2 py-1 bg-gray-100 rounded text-sm hover:bg-gray-200"
+            >
+              {f.question}
+            </button>
+          ))}
+        </div>
+        <p className="text-sm text-gray-500">
+          {lastSeen
+            ? `ลูกค้าอ่านล่าสุดเมื่อ ${new Date(lastSeen).toLocaleString('th-TH')}`
+            : 'ไม่พบข้อมูลล่าสุดของลูกค้า'}
+        </p>
         <div className="flex justify-end gap-2">
           <button className="text-gray-500" onClick={onClose}>ยกเลิก</button>
           <button
@@ -30,6 +71,7 @@ export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose
             onClick={() => {
               logEvent('send_bill_chat', { orderId, customer })
               alert(`✅ ส่งข้อความไปยังแชทแล้ว:\n\n${message}`)
+              setChatLastSeen(customer)
               onClose()
             }}
           >

--- a/lib/mock-read-status.ts
+++ b/lib/mock-read-status.ts
@@ -4,10 +4,17 @@ export interface NotificationStatus {
 }
 
 let status: Record<string, NotificationStatus> = {}
+let chatLastSeen: Record<string, string> = {}
 
 function save() {
   if (typeof window !== 'undefined') {
     localStorage.setItem('adminNotificationStatus', JSON.stringify(status))
+  }
+}
+
+function saveLastSeen() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chatLastSeen', JSON.stringify(chatLastSeen))
   }
 }
 
@@ -18,6 +25,13 @@ export function loadNotificationStatus() {
   }
 }
 
+export function loadChatLastSeen() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('chatLastSeen')
+    if (stored) chatLastSeen = JSON.parse(stored)
+  }
+}
+
 export function getStatus(id: string): NotificationStatus {
   return status[id] || { read: false, pinned: false }
 }
@@ -25,6 +39,15 @@ export function getStatus(id: string): NotificationStatus {
 export function markRead(id: string) {
   status[id] = { ...getStatus(id), read: true }
   save()
+}
+
+export function setChatLastSeen(id: string, ts: string = new Date().toISOString()) {
+  chatLastSeen[id] = ts
+  saveLastSeen()
+}
+
+export function getChatLastSeen(id: string): string | undefined {
+  return chatLastSeen[id]
 }
 
 export function togglePin(id: string) {


### PR DESCRIPTION
## Summary
- extend `mock-read-status.ts` with chat last seen functions
- enhance `SendToChatModal` with FAQ quick reply chips
- display last seen info in the modal and update when sending

## Testing
- `pnpm eslint components/admin/SendToChatModal.tsx lib/mock-read-status.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c78b1da8832584f3c4e850a13a2a