### PR TITLE
Add payment channel and note input

### DIFF
--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -215,6 +215,10 @@ export default function AdminOrderDetailPage({ params }: { params: { id: string 
             <div className="space-y-1">
               <p>วันที่: {new Date(payment.date).toLocaleDateString('th-TH')}</p>
               <p>จำนวน: ฿{payment.amount.toLocaleString()}</p>
+              <p>ช่องทาง: {payment.channel}</p>
+              {payment.note && (
+                <p className="text-sm text-gray-600">หมายเหตุ: {payment.note}</p>
+              )}
               {payment.slip && <p className="text-sm text-gray-600">{payment.slip}</p>}
               {!payment.verified && (
                 <Button size="sm" onClick={() => {

--- a/app/b/[id]/payment/page.tsx
+++ b/app/b/[id]/payment/page.tsx
@@ -5,6 +5,13 @@ import Link from "next/link"
 import { Button } from "@/components/ui/buttons/button"
 import { Input } from "@/components/ui/inputs/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { toast } from "sonner"
 import { addPayment } from "@/lib/mock/payment"
 import { mockOrders } from "@/lib/mock-orders"
@@ -16,6 +23,8 @@ export default function PaymentPage({ params }: { params: { id: string } }) {
   const [date, setDate] = useState("")
   const [amount, setAmount] = useState("")
   const [slip, setSlip] = useState<File | null>(null)
+  const [channel, setChannel] = useState("")
+  const [note, setNote] = useState("")
 
   if (!order) {
     return (
@@ -27,10 +36,16 @@ export default function PaymentPage({ params }: { params: { id: string } }) {
   }
 
   const handleSubmit = () => {
+    if (!channel) {
+      toast.error("กรุณาเลือกช่องทาง")
+      return
+    }
     const p = addPayment(id, {
       date,
       amount: parseFloat(amount) || 0,
       slip: slip?.name,
+      channel,
+      note,
     })
     if (p) {
       toast.success("บันทึกการแจ้งโอนแล้ว")
@@ -50,6 +65,23 @@ export default function PaymentPage({ params }: { params: { id: string } }) {
         <div>
           <Label htmlFor="amt">จำนวนเงิน</Label>
           <Input id="amt" type="number" value={amount} onChange={e => setAmount(e.target.value)} />
+        </div>
+        <div>
+          <Label htmlFor="channel">ช่องทางชำระเงิน</Label>
+          <Select value={channel} onValueChange={setChannel}>
+            <SelectTrigger id="channel" className="w-full">
+              <SelectValue placeholder="เลือกช่องทาง" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="qr">QR</SelectItem>
+              <SelectItem value="transfer">โอนบัญชี</SelectItem>
+              <SelectItem value="cash">เงินสด</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor="note">หมายเหตุการชำระเงิน</Label>
+          <Input id="note" value={note} onChange={e => setNote(e.target.value)} />
         </div>
         <Input type="file" onChange={e => setSlip(e.target.files?.[0] ?? null)} />
         <Button onClick={handleSubmit}>Confirm Payment</Button>

--- a/lib/mock/payment.ts
+++ b/lib/mock/payment.ts
@@ -3,6 +3,8 @@ export interface Payment {
   date: string
   amount: number
   slip?: string
+  channel: string
+  note?: string
   verified?: boolean
 }
 
@@ -12,7 +14,10 @@ export function getPayment(orderId: string): Payment | undefined {
   return payments.find(p => p.orderId === orderId)
 }
 
-export function addPayment(orderId: string, data: Omit<Payment, 'orderId' | 'verified'>): Payment | null {
+export function addPayment(
+  orderId: string,
+  data: Omit<Payment, 'orderId' | 'verified'>,
+): Payment | null {
   if (!orderId) return null
   const payment: Payment = { orderId, verified: false, ...data }
   payments.push(payment)


### PR DESCRIPTION
## Summary
- extend mock payment model with channel and note
- capture channel and note on payment page
- display new payment info on admin order page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c782612c832598955f5cb50fccf0