### PR TITLE
Add fabric tone variant dropdown

### DIFF
--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/buttons/button"
-import Image from "next/image"
 import Link from "next/link"
 import { WishlistButton } from "@/components/WishlistButton"
 import { FavoriteButton } from "@/components/FavoriteButton"
@@ -13,6 +12,7 @@ import { AnalyticsTracker } from "@/components/analytics-tracker"
 import { MessageSquare, Share2, Receipt } from "lucide-react"
 import { CopyToClipboardButton } from "@/components/CopyToClipboardButton"
 import { FabricSuggestions } from "@/components/FabricSuggestions"
+import { FabricVariantDropdown } from "@/components/FabricVariantDropdown"
 
 interface Fabric {
   id: string
@@ -114,14 +114,10 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
           </Link>
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <div className="relative w-full aspect-square">
-            <Image
-              src={fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"}
-              alt={fabric.name}
-              fill
-              className="object-cover rounded-lg"
-            />
-          </div>
+          <FabricVariantDropdown
+            slug={params.slug}
+            defaultImage={fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"}
+          />
           <div className="space-y-4">
             <div className="flex items-center space-x-2">
               <h1 className="text-3xl font-bold">{fabric.name}</h1>

--- a/components/FabricVariantDropdown.tsx
+++ b/components/FabricVariantDropdown.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import Image from 'next/image'
+import { useState } from 'react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { mockFabricToneVariants } from '@/lib/mock-fabric-variants'
+
+interface Props {
+  slug: string
+  defaultImage: string
+}
+
+export function FabricVariantDropdown({ slug, defaultImage }: Props) {
+  const variants = mockFabricToneVariants[slug] || []
+  const [image, setImage] = useState(defaultImage)
+
+  if (variants.length === 0) {
+    return <p className="text-sm text-gray-500">ไม่มีเฉดสีอื่นสำหรับลายนี้</p>
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="relative w-full aspect-square">
+        <Image src={image} alt="fabric variant" fill className="object-cover rounded-lg" />
+      </div>
+      <Select onValueChange={value => setImage(value)} defaultValue={image}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="เลือกเฉดสี" />
+        </SelectTrigger>
+        <SelectContent>
+          {variants.map(v => (
+            <SelectItem key={v.image} value={v.image}>
+              {v.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/lib/mock-fabric-variants.ts
+++ b/lib/mock-fabric-variants.ts
@@ -1,0 +1,27 @@
+export interface FabricToneVariant {
+  label: string
+  image: string
+}
+
+export const mockFabricToneVariants: Record<string, FabricToneVariant[]> = {
+  'soft-linen': [
+    { label: 'ครีม', image: '/images/039.jpg' },
+    { label: 'เบจ', image: '/images/040.jpg' },
+  ],
+  'cozy-cotton': [
+    { label: 'เทาเข้ม', image: '/images/041.jpg' },
+    { label: 'เทาอ่อน', image: '/images/042.jpg' },
+  ],
+  'velvet-dream': [
+    { label: 'น้ำเงิน', image: '/images/043.jpg' },
+    { label: 'ฟ้าเข้ม', image: '/images/044.jpg' },
+  ],
+  'classic-stripe': [
+    { label: 'กรม', image: '/images/045.jpg' },
+    { label: 'ดำเทา', image: '/images/046.jpg' },
+  ],
+  'floral-muse': [
+    { label: 'ชมพู', image: '/images/047.jpg' },
+    { label: 'แดง', image: '/images/035.jpg' },
+  ],
+}


### PR DESCRIPTION
## Summary
- add mock fabric tone variant data
- create FabricVariantDropdown component
- use dropdown on fabric detail page

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6876d9de0ee08325a356e7adbf422541