### PR TITLE
Add customer alert flags and preferences

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -47,6 +47,11 @@ import {
   getFlagStatus,
 } from "@/lib/mock-flagged-users"
 import { getLatestChatMessage } from "@/lib/mock-chat-messages"
+import {
+  loadNotificationSettings,
+  getCustomerAlertSettings,
+  setCustomerAlertFlag,
+} from "@/lib/mock-notification-settings"
 
 export default function CustomerDetailPage({
   params,
@@ -62,6 +67,13 @@ export default function CustomerDetailPage({
     loadCustomerNotes()
     loadCustomerTags()
     loadFlaggedUsers()
+    loadNotificationSettings()
+    const flags = getCustomerAlertSettings(id)
+    if (flags) {
+      setVip(flags.vip)
+      setBlacklist(flags.blacklist)
+      setNotify(flags.notify)
+    }
   }, [])
 
   useEffect(() => {
@@ -82,6 +94,9 @@ export default function CustomerDetailPage({
   const [muted, setMuted] = useState<boolean>(customer.muted ?? false)
   const [noteInput, setNoteInput] = useState("")
   const [tagInput, setTagInput] = useState("")
+  const [vip, setVip] = useState(false)
+  const [blacklist, setBlacklist] = useState(false)
+  const [notify, setNotify] = useState(false)
   const latestMessage = getLatestChatMessage(customer.id)
 
   return (
@@ -236,6 +251,47 @@ export default function CustomerDetailPage({
                 setCustomerMuted(customer.id, v)
               }}
             />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>การตั้งค่าพิเศษ</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span>VIP</span>
+              <Switch
+                checked={vip}
+                onCheckedChange={(v) => {
+                  setVip(v)
+                  setCustomerAlertFlag(customer.id, 'vip', v)
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Blacklist</span>
+              <Switch
+                checked={blacklist}
+                onCheckedChange={(v) => {
+                  setBlacklist(v)
+                  setCustomerAlertFlag(customer.id, 'blacklist', v)
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span>ขอแจ้งเตือนพิเศษ</span>
+              <Switch
+                checked={notify}
+                onCheckedChange={(v) => {
+                  setNotify(v)
+                  setCustomerAlertFlag(customer.id, 'notify', v)
+                }}
+              />
+            </div>
+            {!vip && !blacklist && !notify && (
+              <p className="text-sm text-gray-500">ลูกค้านี้ยังไม่มีการตั้งค่าพิเศษ</p>
+            )}
           </CardContent>
         </Card>
 

--- a/lib/mock-notification-settings.ts
+++ b/lib/mock-notification-settings.ts
@@ -1,5 +1,13 @@
 export type NotificationCategory = 'order' | 'claim' | 'chat'
 
+export interface CustomerAlertSettings {
+  vip: boolean
+  blacklist: boolean
+  notify: boolean
+}
+
+let customerFlags: Record<string, CustomerAlertSettings> = {}
+
 let settings: Record<NotificationCategory, boolean> = {
   order: true,
   claim: false,
@@ -9,6 +17,7 @@ let settings: Record<NotificationCategory, boolean> = {
 function save() {
   if (typeof window !== 'undefined') {
     localStorage.setItem('adminNotificationSettings', JSON.stringify(settings))
+    localStorage.setItem('customerAlertSettings', JSON.stringify(customerFlags))
   }
 }
 
@@ -16,6 +25,8 @@ export function loadNotificationSettings() {
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('adminNotificationSettings')
     if (stored) settings = JSON.parse(stored)
+    const flags = localStorage.getItem('customerAlertSettings')
+    if (flags) customerFlags = JSON.parse(flags)
   }
 }
 
@@ -25,5 +36,19 @@ export function getNotificationSettings() {
 
 export function setNotificationSetting(type: NotificationCategory, value: boolean) {
   settings = { ...settings, [type]: value }
+  save()
+}
+
+export function getCustomerAlertSettings(id: string): CustomerAlertSettings | undefined {
+  return customerFlags[id]
+}
+
+export function setCustomerAlertFlag(
+  id: string,
+  flag: keyof CustomerAlertSettings,
+  value: boolean,
+) {
+  const current = customerFlags[id] || { vip: false, blacklist: false, notify: false }
+  customerFlags[id] = { ...current, [flag]: value }
   save()
 }


### PR DESCRIPTION
## Summary
- support VIP/Blacklist/Notify flags in notification settings
- show alert flag controls on customer detail page

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876d9e7d87483258706f7ea37381301