### PR TITLE
Add chat inbox mock with filtering

### DIFF
--- a/app/chat-inbox/page.tsx
+++ b/app/chat-inbox/page.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Switch } from "@/components/ui/switch"
+import type { Conversation } from "@/types/conversation"
+import {
+  loadConversations,
+  listConversations,
+  toggleArchive,
+} from "@/lib/mock-conversations"
+
+export default function ChatInboxPage() {
+  const [convos, setConvos] = useState<Conversation[]>([])
+  const [filter, setFilter] = useState("latest")
+  const [showArchived, setShowArchived] = useState(false)
+
+  useEffect(() => {
+    loadConversations()
+    setConvos([...listConversations()])
+  }, [])
+
+  const filtered = convos
+    .filter((c) =>
+      showArchived ? c.archived : !c.archived,
+    )
+    .filter((c) => {
+      if (filter === "unanswered") return !c.answered && c.status === "open"
+      if (filter === "closed") return c.status === "closed"
+      return true
+    })
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+
+  const toggle = (id: string) => {
+    toggleArchive(id)
+    setConvos([...listConversations()])
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">แชทเพจ</h1>
+        <div className="flex items-center justify-between">
+          <Tabs value={filter} onValueChange={setFilter} className="w-full">
+            <TabsList>
+              <TabsTrigger value="unanswered">ยังไม่ตอบ</TabsTrigger>
+              <TabsTrigger value="latest">ล่าสุด</TabsTrigger>
+              <TabsTrigger value="closed">ปิดแล้ว</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <div className="flex items-center space-x-2">
+            <Switch checked={showArchived} onCheckedChange={setShowArchived} />
+            <span className="text-sm">จัดเก็บ</span>
+          </div>
+        </div>
+        <div className="space-y-2">
+          {filtered.map((c) => (
+            <Card key={c.id} className="flex items-center justify-between">
+              <CardHeader>
+                <CardTitle>{c.customerName}</CardTitle>
+                <p className="text-sm text-gray-500 line-clamp-1">
+                  {c.lastMessage}
+                </p>
+              </CardHeader>
+              <CardContent className="space-x-2 flex items-center">
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/chat/${c.id}`}>เปิด</Link>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => toggle(c.id)}
+                  className="text-xs"
+                >
+                  {c.archived ? "ยกเลิก" : "จัดเก็บ"}
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+          {filtered.length === 0 && (
+            <p className="text-center py-8 text-gray-500">ไม่มีข้อมูล</p>
+          )}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/lib/mock-conversations.ts
+++ b/lib/mock-conversations.ts
@@ -8,6 +8,9 @@ export let conversations: Conversation[] = [
     lastMessage: 'สอบถามราคาเบาะโซฟา',
     tags: ['ถามราคา'],
     updatedAt: new Date().toISOString(),
+    status: 'open',
+    answered: false,
+    archived: false,
   },
   {
     id: 'conv-002',
@@ -16,6 +19,9 @@ export let conversations: Conversation[] = [
     lastMessage: 'จะโอนพรุ่งนี้',
     tags: ['รอโอน'],
     updatedAt: new Date().toISOString(),
+    status: 'closed',
+    answered: true,
+    archived: false,
   },
 ]
 
@@ -62,6 +68,30 @@ export function setRating(id: string, rating: number) {
   const convo = conversations.find((c) => c.id === id)
   if (convo) {
     convo.rating = rating
+    save()
+  }
+}
+
+export function toggleArchive(id: string) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.archived = !convo.archived
+    save()
+  }
+}
+
+export function setStatus(id: string, status: Conversation['status']) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.status = status
+    save()
+  }
+}
+
+export function setAnswered(id: string, answered: boolean) {
+  const convo = conversations.find((c) => c.id === id)
+  if (convo) {
+    convo.answered = answered
     save()
   }
 }

--- a/types/conversation.ts
+++ b/types/conversation.ts
@@ -6,4 +6,7 @@ export interface Conversation {
   tags: string[]
   rating?: number
   updatedAt: string
+  status: 'open' | 'closed'
+  answered: boolean
+  archived?: boolean
 }


### PR DESCRIPTION
## Summary
- extend `Conversation` type with status, answered and archive flags
- add archive and status helpers in `mock-conversations`
- implement `/chat-inbox` page to list and archive threads

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876e738374483259e315960de979cec