### PR TITLE
Add shipping method selection

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -56,8 +56,17 @@ export default function CheckoutPage() {
   const [agreeTerms, setAgreeTerms] = useState(false)
   const [checklist, setChecklist] = useState({ confirmSize: false, confirmColor: false })
   const [isProcessing, setIsProcessing] = useState(false)
+  const [deliveryMethod, setDeliveryMethod] = useState("")
 
-  const shipping = state.total >= 1500 ? 0 : 100
+  const calcShipping = (method: string) => {
+    if (!method || state.total >= 1500) return 0
+    const base = shippingInfo.city === "กรุงเทพฯ" ? 40 : 60
+    if (method === "EMS") return base + 20
+    if (method === "COD") return base + 30
+    return base
+  }
+
+  const shipping = calcShipping(deliveryMethod)
   const tax = Math.round(state.total * 0.07)
   const discountAmount = appliedCoupon
     ? appliedCoupon.type === "percentage"
@@ -136,7 +145,7 @@ export default function CheckoutPage() {
           postalCode: shippingInfo.postalCode,
           phone: shippingInfo.phone,
         },
-        delivery_method: "",
+        delivery_method: deliveryMethod,
         tracking_number: "",
         shipping_fee: shipping,
         shipping_status: "pending" as ShippingStatus,
@@ -277,7 +286,7 @@ export default function CheckoutPage() {
                         </SelectContent>
                       </Select>
                     </div>
-                    <div className="space-y-2">
+                  <div className="space-y-2">
                       <Label htmlFor="postalCode">รหัสไปรษณีย์ *</Label>
                       <Input
                         id="postalCode"
@@ -286,6 +295,20 @@ export default function CheckoutPage() {
                         required
                       />
                     </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="deliveryMethod">วิธีจัดส่ง</Label>
+                    <Select value={deliveryMethod} onValueChange={setDeliveryMethod}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="เลือกวิธีจัดส่ง" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Flash">Flash</SelectItem>
+                        <SelectItem value="EMS">EMS</SelectItem>
+                        <SelectItem value="COD">COD</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div className="space-y-2">

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -228,6 +228,14 @@ export default function OrderDetailPage({ params }: { params: { id: string } }) 
                   <span>จำนวนสินค้า:</span>
                   <span>{order.items.reduce((sum, item) => sum + item.quantity, 0)} ชิ้น</span>
                 </div>
+                <div className="flex justify-between">
+                  <span>วิธีจัดส่ง:</span>
+                  <span>{order.delivery_method || "ยังไม่ได้เลือกวิธีจัดส่ง"}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>ค่าจัดส่ง:</span>
+                  <span>{order.shipping_fee ? `฿${order.shipping_fee}` : "ฟรี"}</span>
+                </div>
                 <Separator />
                 <div className="flex justify-between font-bold">
                   <span>ยอดรวม:</span>

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -177,7 +177,7 @@ export default function OrdersPage() {
                   <div className="space-y-4">
                     {/* Order Items */}
                     <div className="space-y-2">
-                      {order.items.map((item, index) => (
+                    {order.items.map((item, index) => (
                         <div
                           key={index}
                           className="flex justify-between items-center py-2 border-b last:border-b-0"
@@ -196,6 +196,13 @@ export default function OrdersPage() {
                         </div>
                       ))}
                     </div>
+
+                    <p className="text-sm text-gray-600">
+                      วิธีจัดส่ง: {order.delivery_method || "ยังไม่ได้เลือกวิธีจัดส่ง"}
+                    </p>
+                    <p className="text-sm text-gray-600">
+                      ค่าจัดส่ง: {order.shipping_fee ? `฿${order.shipping_fee}` : "ฟรี"}
+                    </p>
 
                     {/* Order Total */}
                     <div className="flex justify-between items-center pt-4 border-t">


### PR DESCRIPTION
## Summary
- let users choose a shipping method at checkout
- store the method in mock orders
- display shipping method and fee on order pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e73fa23c8325ad6773746f44e745