### PR TITLE
Add COD badge and tracking inputs

### DIFF
--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -92,6 +92,7 @@ const initialMockOrders: Order[] = [
     packingStatus: "packing",
     shipping_date: "2024-01-15T08:00:00Z",
     delivery_note: "ส่งตามเวลาทำการ",
+    cod: true,
     scheduledDelivery: "2024-01-18T10:00",
     timeline: [
       {

--- a/types/order.ts
+++ b/types/order.ts
@@ -79,6 +79,8 @@ export interface Order {
   total: number
   status: OrderStatus
   depositPercent?: number
+  /** Cash on delivery flag */
+  cod?: boolean
   note?: string
   chatNote?: string
   createdAt: string


### PR DESCRIPTION
## Summary
- show COD badge for cash on delivery orders
- allow editing tracking codes with a mock save
- display fallback message when tracking number is missing

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6876eafb8084832587ccdd661185ad3a