### PR TITLE
Add Supabase offline toggle

### DIFF
--- a/app/admin/dev-only/dev/page.tsx
+++ b/app/admin/dev-only/dev/page.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import { useAuth } from "@/contexts/auth-context"
-import { isDevMock } from "@/lib/mock-settings"
+import { isDevMock, supabaseDown, loadSupabaseDown, setSupabaseDown } from "@/lib/mock-settings"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Button } from "@/components/ui/buttons/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   mockOrders,
   regenerateMockOrders,
@@ -17,6 +19,12 @@ import {
 
 export default function AdminDevPage() {
   const { user, isAuthenticated } = useAuth()
+  const [isOffline, setIsOffline] = useState(supabaseDown)
+
+  useEffect(() => {
+    loadSupabaseDown()
+    setIsOffline(supabaseDown)
+  }, [])
   if (!isDevMock) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -38,6 +46,11 @@ export default function AdminDevPage() {
     console.log("mockCustomers", mockCustomers)
   }
 
+  const toggleOffline = (val: boolean) => {
+    setIsOffline(val)
+    setSupabaseDown(val)
+  }
+
   const handleGenerate = () => {
     regenerateMockOrders()
     regenerateMockCustomers()
@@ -51,6 +64,19 @@ export default function AdminDevPage() {
           ล้างข้อมูล
         </Button>
         <Button onClick={handleGenerate}>สร้างข้อมูลตัวอย่าง</Button>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="offline"
+          checked={isOffline}
+          onCheckedChange={(v) => toggleOffline(Boolean(v))}
+        />
+        <label htmlFor="offline">จำลองกรณี Supabase ล่ม</label>
+        {isOffline && (
+          <Button variant="outline" size="sm" onClick={() => toggleOffline(false)}>
+            รีเซตโหมด
+          </Button>
+        )}
       </div>
       <Card>
         <CardHeader>

--- a/lib/mock-settings.ts
+++ b/lib/mock-settings.ts
@@ -1,6 +1,7 @@
 export const isDevMock = true;
 export let autoMessage = "ขอบคุณที่สั่งซื้อกับเรา";
 export let socialLinks = { facebook: "", line: "" };
+export let supabaseDown = false
 
 export function loadAutoMessage() {
   if (typeof window !== 'undefined') {
@@ -27,6 +28,20 @@ export function setSocialLinks(links: { facebook: string; line: string }) {
   socialLinks = links;
   if (typeof window !== 'undefined') {
     localStorage.setItem('socialLinks', JSON.stringify(links));
+  }
+}
+
+export function loadSupabaseDown() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('supabaseDown')
+    if (stored) supabaseDown = JSON.parse(stored)
+  }
+}
+
+export function setSupabaseDown(val: boolean) {
+  supabaseDown = val
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('supabaseDown', JSON.stringify(val))
   }
 }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,11 +1,14 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { supabaseDown, loadSupabaseDown } from './mock-settings'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 let client: SupabaseClient | null = null
 
-if (supabaseUrl && supabaseAnonKey) {
+loadSupabaseDown()
+
+if (supabaseUrl && supabaseAnonKey && !supabaseDown) {
   client = createClient(supabaseUrl, supabaseAnonKey)
 }
 


### PR DESCRIPTION
## Summary
- add `supabaseDown` flag in mock settings
- respect `supabaseDown` when creating Supabase client
- allow toggling offline mode from dev admin page

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876eb02b02c832589b97beca9e6b51f