### PR TITLE
Add order tagging and quote creation

### DIFF
--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -11,7 +11,7 @@ import { Package, Eye, Download, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/auth-context";
 import { useCart } from "@/contexts/cart-context";
-import { mockOrders } from "@/lib/mock-orders";
+import { mockOrders, updateOrderTag } from "@/lib/mock-orders";
 import { mockProducts } from "@/lib/mock-products";
 import { mockFeedbacks } from "@/lib/mock-feedback";
 import { reviewReminder, loadReviewReminder } from "@/lib/mock-settings";
@@ -22,6 +22,7 @@ import {
   getOrderStatusText,
 } from "@/lib/order-status";
 import { Progress } from "@/components/ui/progress";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 function getProgress(status: OrderStatus) {
   switch (status) {
@@ -44,6 +45,7 @@ export default function OrdersPage() {
   const { dispatch } = useCart();
   const router = useRouter();
   const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [refresh, setRefresh] = useState(0);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -110,6 +112,13 @@ export default function OrdersPage() {
     }
   };
 
+  const handleCreateQuote = (order: Order) => {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem("quoteFromOrder", JSON.stringify(order));
+      router.push("/quotes/new");
+    }
+  };
+
   return (
     <div className="min-h-screen">
       <Navbar />
@@ -170,6 +179,22 @@ export default function OrdersPage() {
                         className="w-24"
                         value={getProgress(order.status)}
                       />
+                      <Select
+                        value={order.tag || ''}
+                        onValueChange={(v) => {
+                          updateOrderTag(order.id, v);
+                          setRefresh((r) => r + 1);
+                        }}
+                      >
+                        <SelectTrigger className="w-24">
+                          <SelectValue placeholder="แท็ก" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="">-</SelectItem>
+                          <SelectItem value="ด่วน">ด่วน</SelectItem>
+                          <SelectItem value="ติดตาม">ติดตาม</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                   </div>
                 </CardHeader>
@@ -229,6 +254,14 @@ export default function OrdersPage() {
                         onClick={() => handleReorder(order)}
                       >
                         สั่งซ้ำ
+                      </Button>
+
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleCreateQuote(order)}
+                      >
+                        สร้างใบเสนอราคาจากออเดอร์นี้
                       </Button>
 
                       <Link href="/chat">

--- a/app/quotes/new/page.tsx
+++ b/app/quotes/new/page.tsx
@@ -1,0 +1,107 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Input } from '@/components/ui/inputs/input'
+import { Label } from '@/components/ui/label'
+import { OrderItemsRepeater } from '@/components/OrderItemsRepeater'
+import type { OrderItem } from '@/types/order'
+import { addQuote } from '@/lib/mock-quotes'
+
+export default function QuoteFromOrderPage() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [items, setItems] = useState<OrderItem[]>([])
+  const [sent, setSent] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const raw = sessionStorage.getItem('quoteFromOrder')
+    if (!raw) return
+    try {
+      const order = JSON.parse(raw)
+      setName(order.customerName)
+      setEmail(order.customerEmail)
+      setPhone(order.shippingAddress?.phone || '')
+      setItems(
+        order.items.map((i: any) => ({
+          id: i.productId,
+          productName: i.productName,
+          quantity: i.quantity,
+          price: i.price,
+          size: i.size,
+          color: i.color,
+        }))
+      )
+      setReady(true)
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const submit = () => {
+    if (sent) return
+    addQuote({
+      customerName: name,
+      customerEmail: email,
+      customerPhone: phone,
+      items: items.map((i) => ({
+        productId: i.id,
+        productName: i.productName,
+        quantity: i.quantity,
+        price: i.price,
+        size: i.size,
+        color: i.color,
+      })),
+    })
+    setSent(true)
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <Card className="max-w-2xl mx-auto">
+          <CardHeader>
+            <CardTitle>ขอใบเสนอราคา</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {!ready ? (
+              <p className="text-center text-red-600">
+                ยังไม่สามารถสร้างใบเสนอราคาได้
+                <br />
+                <a href="/orders" className="underline">กลับไปที่ออเดอร์</a>
+              </p>
+            ) : !sent ? (
+              <>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">ชื่อ</Label>
+                    <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">อีเมล</Label>
+                    <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+                  </div>
+                  <div className="space-y-2 md:col-span-2">
+                    <Label htmlFor="phone">โทรศัพท์</Label>
+                    <Input id="phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+                  </div>
+                </div>
+                <OrderItemsRepeater items={items} onItemsChange={setItems} />
+                <Button className="w-full" onClick={submit}>ส่งคำขอ</Button>
+              </>
+            ) : (
+              <p className="text-center text-green-600">บันทึกคำขอเรียบร้อย</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -25,6 +25,7 @@ const initialMockOrders: Order[] = [
     depositPercent: 50,
     note: "Deposit received",
     chatNote: "",
+    tag: "ด่วน",
     createdAt: "2024-01-15T10:30:00Z",
     shippingAddress: {
       name: "John Doe",
@@ -77,6 +78,7 @@ const initialMockOrders: Order[] = [
     status: "paid",
     depositPercent: 100,
     chatNote: "",
+    tag: "ติดตาม",
     createdAt: "2024-01-14T14:20:00Z",
     shippingAddress: {
       name: "Jane Smith",
@@ -116,6 +118,7 @@ export function regenerateMockOrders() {
     ...o,
     items: o.items.map((i) => ({ ...i })),
     packingStatus: o.packingStatus,
+    tag: o.tag,
     timeline: o.timeline.map((t) => ({ ...t })),
   }))
 }
@@ -123,6 +126,11 @@ export function regenerateMockOrders() {
 export function setPackingStatus(orderId: string, status: PackingStatus) {
   const order = mockOrders.find((o) => o.id === orderId)
   if (order) order.packingStatus = status
+}
+
+export function setOrderTag(orderId: string, tag: string) {
+  const order = mockOrders.find((o) => o.id === orderId)
+  if (order) order.tag = tag
 }
 
 export function setOrderStatus(orderId: string, status: OrderStatus) {

--- a/lib/mock/orders.ts
+++ b/lib/mock/orders.ts
@@ -2,6 +2,7 @@ import type { Order, OrderStatus } from "@/types/order"
 import {
   mockOrders as baseOrders,
   setOrderStatus,
+  setOrderTag,
   getOrdersInRange,
   getDailySales,
   getTopSellingItems,
@@ -11,6 +12,10 @@ export const mockOrders: Order[] = baseOrders
 
 export function updateOrderStatus(id: string, status: OrderStatus) {
   setOrderStatus(id, status)
+}
+
+export function updateOrderTag(id: string, tag: string) {
+  setOrderTag(id, tag)
 }
 
 export { getOrdersInRange, getDailySales, getTopSellingItems }

--- a/types/order.ts
+++ b/types/order.ts
@@ -81,6 +81,8 @@ export interface Order {
   depositPercent?: number
   note?: string
   chatNote?: string
+  /** Custom tag for quick classification */
+  tag?: string
   createdAt: string
   shippingAddress: {
     name: string


### PR DESCRIPTION
## Summary
- allow orders to hold a `tag`
- attach tags to initial mock orders
- expose `setOrderTag` and `updateOrderTag`
- show a tag selector and quote creation button on the orders page
- create `/quotes/new` page for generating a quote from an order

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876eda802108325a1e686242ba10782