### PR TITLE
Add last seen and admin log button

### DIFF
--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -47,6 +47,7 @@ import {
   getFlagStatus,
 } from "@/lib/mock-flagged-users"
 import { getLatestChatMessage } from "@/lib/mock-chat-messages"
+import { addMockLog } from "@/lib/mock-logs"
 
 export default function CustomerDetailPage({
   params,
@@ -94,6 +95,14 @@ export default function CustomerDetailPage({
             </Button>
           </Link>
           <h1 className="text-3xl font-bold">ข้อมูลลูกค้า</h1>
+          <Button
+            variant="outline"
+            onClick={() => {
+              addMockLog(`admin note for ${customer.id}`, user?.email || 'admin')
+            }}
+          >
+            บันทึกเหตุการณ์
+          </Button>
         </div>
 
         <CustomerCard customer={customer} />

--- a/app/admin/dev-only/logs/page.tsx
+++ b/app/admin/dev-only/logs/page.tsx
@@ -6,11 +6,11 @@ import { useAuth } from '@/contexts/auth-context'
 import { Button } from '@/components/ui/buttons/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { mockAdminLogs, addAdminLog } from '@/lib/mock-admin-logs'
+import { mockLogs, addMockLog } from '@/lib/mock-logs'
 
 export default function AdminLogsPage() {
   const { user, isAuthenticated } = useAuth()
-  const [logs, setLogs] = useState([...mockAdminLogs])
+  const [logs, setLogs] = useState([...mockLogs])
   const [filter, setFilter] = useState('all')
 
   const filtered = logs.filter((l) => {
@@ -48,7 +48,7 @@ export default function AdminLogsPage() {
           <CardHeader className="flex justify-between items-center">
             <CardTitle>Admin Logs ({filtered.length})</CardTitle>
             {process.env.NODE_ENV !== 'production' && (
-              <Button onClick={() => { addAdminLog('dev mock', 'admin'); setLogs([...mockAdminLogs]) }}>สร้าง log ใหม่ (dev only)</Button>
+            <Button onClick={() => { addMockLog('dev mock', 'admin'); setLogs([...mockLogs]) }}>สร้าง log ใหม่ (dev only)</Button>
             )}
             <select
               className="border rounded p-2 ml-2"

--- a/components/admin/customers/CustomerCard.tsx
+++ b/components/admin/customers/CustomerCard.tsx
@@ -32,6 +32,11 @@ export default function CustomerCard({ customer, className = "" }: { customer: C
           </div>
         )}
         {customer.note && <p className="text-sm text-gray-500">{customer.note}</p>}
+        <p className="text-sm text-gray-500">
+          {customer.lastSeen
+            ? `ใช้งานล่าสุด ${new Date(customer.lastSeen).toLocaleString('th-TH')}`
+            : 'ไม่มีข้อมูลการเข้าใช้งานของลูกค้า'}
+        </p>
       </CardContent>
     </Card>
   )

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -18,6 +18,8 @@ export interface Customer {
   /** point change history */
   pointHistory?: PointLog[]
   createdAt: string
+  /** last login timestamp */
+  lastSeen?: string
 }
 
 export interface PointLog {
@@ -45,6 +47,7 @@ const initialMockCustomers: Customer[] = [
     pointHistory: [
       { timestamp: new Date().toISOString(), change: 120, reason: "สมัครสมาชิก" },
     ],
+    lastSeen: new Date().toISOString(),
     createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -60,6 +63,7 @@ const initialMockCustomers: Customer[] = [
     note: "เก็บเงินปลายทาง",
     points: 60,
     tier: "Silver",
+    lastSeen: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
     createdAt: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -69,6 +73,7 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     points: 200,
     tier: "VIP",
+    lastSeen: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
     createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -78,6 +83,7 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     points: 10,
     tier: "Silver",
+    lastSeen: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
     createdAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -87,6 +93,7 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     points: 40,
     tier: "Gold",
+    lastSeen: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
     createdAt: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -96,6 +103,7 @@ const initialMockCustomers: Customer[] = [
     avatar: "/placeholder.svg?height=40&width=40",
     points: 80,
     tier: "Gold",
+    lastSeen: undefined,
     createdAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ]

--- a/lib/mock-logs.ts
+++ b/lib/mock-logs.ts
@@ -1,0 +1,17 @@
+export interface MockLog {
+  id: string
+  action: string
+  admin: string
+  timestamp: string
+}
+
+export let mockLogs: MockLog[] = []
+
+export function addMockLog(action: string, admin: string) {
+  mockLogs.push({
+    id: Date.now().toString(),
+    action,
+    admin,
+    timestamp: new Date().toISOString(),
+  })
+}


### PR DESCRIPTION
## Summary
- show a customer's last seen timestamp with fallback
- log arbitrary admin actions to a mock log store
- expose mock logs in dev-only log viewer
- allow logging from customer profile page
- extend mock customer data with last seen info

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6876edab13a0832588b2ddb7f31bd21f