### PR TITLE
Add confirm payment modal

### DIFF
--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -7,8 +7,10 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { ArrowLeft, Download, MessageCircle, Package, Truck, CheckCircle } from "lucide-react"
 import Link from "next/link"
-import { mockOrders } from "@/lib/mock-orders"
+import { mockOrders, setOrderStatus } from "@/lib/mock-orders"
+import { confirmBill } from "@/lib/mock-bills"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
+import ConfirmPaymentDialog from "@/components/order/ConfirmPaymentDialog"
 import type { OrderStatus } from "@/types/order"
 import {
   getOrderStatusBadgeVariant,
@@ -18,6 +20,7 @@ import {
 export default function OrderDetailPage({ params }: { params: { id: string } }) {
   const { id } = params
   const order = mockOrders.find((o) => o.id === id)
+  const [showConfirm, setShowConfirm] = useState(false)
 
   if (!order) {
     return (
@@ -182,6 +185,21 @@ export default function OrderDetailPage({ params }: { params: { id: string } }) 
                 <CardTitle>การดำเนินการ</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
+                {order.status !== "paid" && (
+                  <Button
+                    className="w-full"
+                    onClick={() => setShowConfirm(true)}
+                  >
+                    ยืนยันการชำระเงิน
+                  </Button>
+                )}
+
+                <Link href={`/bill/${order.id}`}>
+                  <Button className="w-full bg-transparent" variant="outline">
+                    ดูบิล
+                  </Button>
+                </Link>
+
                 {order.status === "paid" && (
                   <Link href={`/invoice/${order.id}`}>
                     <Button className="w-full bg-transparent" variant="outline">
@@ -240,6 +258,16 @@ export default function OrderDetailPage({ params }: { params: { id: string } }) 
       </div>
 
       <Footer />
+      <ConfirmPaymentDialog
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        order={order}
+        onConfirm={() => {
+          setOrderStatus(order.id, 'paid')
+          confirmBill(order.id)
+          setShowConfirm(false)
+        }}
+      />
     </div>
   )
 }

--- a/components/order/ConfirmPaymentDialog.tsx
+++ b/components/order/ConfirmPaymentDialog.tsx
@@ -1,0 +1,45 @@
+"use client"
+import BillPreview from "@/components/BillPreview"
+import { Button } from "@/components/ui/buttons/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/modals/dialog"
+import type { Order } from "@/types/order"
+
+interface ConfirmPaymentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  order: Order
+  onConfirm: () => void
+}
+
+export default function ConfirmPaymentDialog({
+  open,
+  onOpenChange,
+  order,
+  onConfirm,
+}: ConfirmPaymentDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>ยืนยันการชำระเงิน</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto">
+          <BillPreview order={order} />
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">ยกเลิก</Button>
+          </DialogClose>
+          <Button onClick={onConfirm}>ยืนยัน</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add `ConfirmPaymentDialog` component for bill preview and confirmation
- use the new dialog in order details page
- link to bill and show confirm button

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6876f8fff5cc832583a534679d87ab1f