### PR TITLE
Fix order form action buttons

### DIFF
--- a/components/OrderItemsRepeater.tsx
+++ b/components/OrderItemsRepeater.tsx
@@ -210,7 +210,13 @@ export function OrderItemsRepeater({ items, onItemsChange }: OrderItemsRepeaterP
                       )}
                     </div>
                   </div>
+                  {/*
+                   * Without an explicit type, this button submits the parent
+                   * form when clicked, preventing the item remove handler from
+                   * working as expected.
+                   */}
                   <Button
+                    type="button"
                     variant="outline"
                     size="icon"
                     onClick={() => removeItem(item.id)}
@@ -376,7 +382,11 @@ export function OrderItemsRepeater({ items, onItemsChange }: OrderItemsRepeaterP
             )}
           </div>
 
-          <Button onClick={addItem} className="w-full">
+          {/*
+           * Specify type="button" to avoid submitting the form when adding
+           * new items. This ensures only the addItem handler runs.
+           */}
+          <Button type="button" onClick={addItem} className="w-full">
             <Plus className="h-4 w-4 mr-2" />
             เพิ่มสินค้า
           </Button>


### PR DESCRIPTION
## Summary
- prevent accidental form submission in `OrderItemsRepeater`
- document why the buttons need explicit `type="button"`

## Testing
- `pnpm test`
- `pnpm eslint`

------
https://chatgpt.com/codex/tasks/task_e_687701ea59a88325a0f16f592599673f