### PR TITLE
Add chat quick templates and emoji picker

### DIFF
--- a/components/EmojiPicker.tsx
+++ b/components/EmojiPicker.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {
+  const emojis = ['😀', '😂', '😍', '👍', '🙏', '🎉']
+
+  if (emojis.length === 0) {
+    return <div className="text-sm text-gray-500">ไม่สามารถแสดง emoji ได้</div>
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 p-2 border rounded">
+      {emojis.map((e) => (
+        <button
+          key={e}
+          type="button"
+          onClick={() => onSelect(e)}
+          className="text-xl hover:opacity-75"
+        >
+          {e}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/admin/SendToChatModal.tsx
+++ b/components/admin/SendToChatModal.tsx
@@ -1,9 +1,14 @@
-import { useState } from "react"
-import { logEvent } from "@/lib/logs"
+import { useEffect, useState } from 'react'
+import { logEvent } from '@/lib/logs'
+import { chatTemplates, loadChatTemplates } from '@/lib/mock-chat-templates'
+import { EmojiPicker } from '@/components/EmojiPicker'
 
 export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose: () => void }) {
   const [message, setMessage] = useState(`📦 รายการคำสั่งซื้อ #${orderId}\nยอดรวม: 999 บาท`)
   const [customer, setCustomer] = useState("ลูกค้า A (Facebook)")
+  useEffect(() => {
+    loadChatTemplates()
+  }, [])
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -23,6 +28,19 @@ export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose
           onChange={(e) => setMessage(e.target.value)}
           className="w-full h-32 border p-2 rounded"
         />
+        <EmojiPicker onSelect={(e) => setMessage((m) => m + e)} />
+        <div className="flex flex-wrap gap-2">
+          {chatTemplates.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setMessage(t.text)}
+              className="px-2 py-1 text-sm border rounded hover:bg-gray-100"
+            >
+              {t.name}
+            </button>
+          ))}
+        </div>
         <div className="flex justify-end gap-2">
           <button className="text-gray-500" onClick={onClose}>ยกเลิก</button>
           <button

--- a/lib/mock-chat-templates.ts
+++ b/lib/mock-chat-templates.ts
@@ -7,6 +7,17 @@ export interface ChatTemplate {
 export let chatTemplates: ChatTemplate[] = [
   { id: 'bill_created', name: 'สร้างบิล', text: 'เราได้ออกบิลใหม่ให้คุณแล้วค่ะ' },
   { id: 'status_paid', name: 'ยืนยันการชำระ', text: 'ออเดอร์ของคุณชำระเรียบร้อยแล้วค่ะ' },
+  {
+    id: 'tracking',
+    name: 'ติดตามพัสดุ',
+    text: 'พัสดุของคุณกำลังจัดส่ง สามารถติดตามได้ที่ลิงก์นี้ค่ะ',
+  },
+  {
+    id: 'shipping_no',
+    name: 'แจ้งเลขพัสดุ',
+    text: 'เลขพัสดุของคุณคือ XXXX ค่ะ',
+  },
+  { id: 'thank_you', name: 'ขอบคุณ', text: 'ขอบคุณที่ใช้บริการนะคะ' },
 ]
 
 export function loadChatTemplates() {


### PR DESCRIPTION
## Summary
- extend chat templates list
- add reusable mock EmojiPicker component
- show quick template buttons and emoji picker in SendToChatModal

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68776d7bc6b08325962b3f2f024f19da