### PR TITLE
Implement customer data validator

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -12,7 +12,7 @@ import { Search, ArrowLeft, Eye, FileText, Edit, Copy, ExternalLink } from "luci
 import Link from "next/link"
 import { toast } from "sonner"
 import { mockOrders, setPackingStatus, setOrderStatus } from "@/lib/mock-orders"
-import { mockCustomers } from "@/lib/mock-customers"
+import { mockCustomers, checkCustomerInfo } from "@/lib/mock-customers"
 import { createBill, confirmBill, mockBills } from "@/lib/mock-bills"
 import { downloadCSV, downloadPDF } from "@/lib/mock-export"
 import type { Order, OrderStatus, PackingStatus } from "@/types/order"
@@ -74,6 +74,12 @@ export default function AdminOrdersPage() {
   }
 
   const handleCreateBill = (orderId: string) => {
+    const order = orders.find((o) => o.id === orderId)
+    const warning = order ? checkCustomerInfo(order.customerId) : "ยังไม่สามารถตรวจสอบข้อมูลได้"
+    if (warning) {
+      toast.warning(warning)
+      return
+    }
     const bill = createBill(orderId)
     setBills([...mockBills])
     toast.success(`สร้างบิล ${bill.id}`)
@@ -81,6 +87,12 @@ export default function AdminOrdersPage() {
   }
 
   const handlePrebookBill = (orderId: string) => {
+    const order = orders.find((o) => o.id === orderId)
+    const warning = order ? checkCustomerInfo(order.customerId) : "ยังไม่สามารถตรวจสอบข้อมูลได้"
+    if (warning) {
+      toast.warning(warning)
+      return
+    }
     const due = window.prompt("กำหนดวันครบชำระ YYYY-MM-DD") || undefined
     const bill = createBill(orderId, "pending", due)
     setBills([...mockBills])

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -178,3 +178,13 @@ export function setCustomerMuted(id: string, muted: boolean) {
   if (!customer) return
   customer.muted = muted
 }
+
+export function checkCustomerInfo(id: string): string | null {
+  const customer = mockCustomers.find((c) => c.id === id)
+  if (!customer) return "ยังไม่สามารถตรวจสอบข้อมูลได้"
+  const missing: string[] = []
+  if (!customer.name) missing.push("ชื่อ")
+  if (!customer.address) missing.push("ที่อยู่")
+  if (!customer.phone) missing.push("เบอร์โทร")
+  return missing.length > 0 ? `ข้อมูลลูกค้าไม่ครบ (${missing.join(", ")})` : null
+}


### PR DESCRIPTION
## Summary
- add `checkCustomerInfo` helper in mock customers
- warn before creating bills if customer info is incomplete

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687772847b108325b8a080085137b37d