### PR TITLE
Implement mock role-based feature gates

### DIFF
--- a/app/admin/claims/page.tsx
+++ b/app/admin/claims/page.tsx
@@ -10,12 +10,13 @@ import { useAuth } from '@/contexts/auth-context'
 import { mockClaims, updateClaim } from '@/lib/mock-claims'
 import { addAdminLog } from '@/lib/mock-admin-logs'
 import { downloadCSV, downloadPDF } from '@/lib/mock-export'
+import { canAccess } from '@/lib/mock-roles'
 
 export default function AdminClaimsPage() {
   const { user, isAuthenticated } = useAuth()
   const [claims, setClaims] = useState([...mockClaims])
 
-  if (!isAuthenticated || user?.role !== 'admin') {
+  if (!isAuthenticated || !canAccess(user?.role, 'claims')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/admin/customers/[id]/notes/page.tsx
+++ b/app/admin/customers/[id]/notes/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/buttons/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { useAuth } from '@/contexts/auth-context'
 import { loadCustomerNotes, listCustomerNotes, addCustomerNote } from '@/lib/mock-customer-notes'
+import { canAccess } from '@/lib/mock-roles'
 
 export default function CustomerNotesPage({ params }: { params: { id: string } }) {
   const { id } = params
@@ -18,7 +19,7 @@ export default function CustomerNotesPage({ params }: { params: { id: string } }
     setNotes(listCustomerNotes(id, user?.id))
   }, [id, user?.id])
 
-  if (!isAuthenticated || user?.role !== 'admin') {
+  if (!isAuthenticated || !canAccess(user?.role, 'inventory')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p>ไม่มีสิทธิ์เข้าถึง</p>

--- a/app/admin/dev-only/dev/page.tsx
+++ b/app/admin/dev-only/dev/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from "@/contexts/auth-context"
 import { isDevMock } from "@/lib/mock-settings"
+import { canAccess } from "@/lib/mock-roles"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Button } from "@/components/ui/buttons/button"
 import {
@@ -24,7 +25,7 @@ export default function AdminDevPage() {
       </div>
     )
   }
-  if (!isAuthenticated || user?.role !== 'admin') {
+  if (!isAuthenticated || !canAccess(user?.role, 'dev')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p>ไม่มีสิทธิ์เข้าถึง</p>

--- a/app/admin/dev-only/landing/page.tsx
+++ b/app/admin/dev-only/landing/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 import { useAuth } from "@/contexts/auth-context"
+import { canAccess } from "@/lib/mock-roles"
 import { Input } from "@/components/ui/inputs/input"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
@@ -19,12 +20,12 @@ export default function AdminLandingPage() {
     setData(heroBanner)
     if (!isAuthenticated) {
       router.push("/login")
-    } else if (user?.role !== "admin") {
+    } else if (!canAccess(user?.role, 'dev')) {
       router.push("/")
     }
   }, [isAuthenticated, user, router])
 
-  if (!isAuthenticated || user?.role !== "admin") return null
+  if (!isAuthenticated || !canAccess(user?.role, 'dev')) return null
 
   const handleSave = () => {
     setHeroBanner(data)

--- a/app/admin/dev-only/logs/page.tsx
+++ b/app/admin/dev-only/logs/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { useAuth } from '@/contexts/auth-context'
+import { canAccess } from '@/lib/mock-roles'
 import { Button } from '@/components/ui/buttons/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -20,7 +21,7 @@ export default function AdminLogsPage() {
     return true
   })
 
-  if (!isAuthenticated || user?.role !== 'admin') {
+  if (!isAuthenticated || !canAccess(user?.role, 'logs')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -15,6 +15,7 @@ import { AlertTriangle, Package, TrendingDown, TrendingUp, ArrowLeft, Plus, Edit
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useMockNotification } from "@/hooks/use-mock-notification"
+import { canAccess } from "@/lib/mock-roles"
 
 interface StockItem {
   id: string
@@ -115,13 +116,13 @@ export default function InventoryPage() {
       router.push("/login")
       return
     }
-    if (user?.role !== "admin") {
+    if (!canAccess(user?.role, 'inventory')) {
       router.push("/")
       return
     }
   }, [isAuthenticated, user, router])
 
-  if (!isAuthenticated || user?.role !== "admin") {
+  if (!isAuthenticated || !canAccess(user?.role, 'inventory')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/admin/inventory/settings/page.tsx
+++ b/app/admin/inventory/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/contexts/auth-context"
+import { canAccess } from "@/lib/mock-roles"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
@@ -54,13 +55,13 @@ export default function InventorySettingsPage() {
       router.push("/login")
       return
     }
-    if (user?.role !== "admin") {
+    if (!canAccess(user?.role, 'inventorySettings')) {
       router.push("/")
       return
     }
   }, [isAuthenticated, user, router])
 
-  if (!isAuthenticated || user?.role !== "admin") {
+  if (!isAuthenticated || !canAccess(user?.role, 'inventorySettings')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/admin/media/page.tsx
+++ b/app/admin/media/page.tsx
@@ -7,13 +7,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/
 import { Input } from '@/components/ui/inputs/input'
 import { useAuth } from '@/contexts/auth-context'
 import { getMedia } from '@/lib/mock-media'
+import { canAccess } from '@/lib/mock-roles'
 
 export default function AdminMediaPage() {
   const { user, isAuthenticated } = useAuth()
   const [search, setSearch] = useState('')
   const media = getMedia().filter(m => m.url.includes(search))
 
-  if (!isAuthenticated || user?.role !== 'admin') {
+  if (!isAuthenticated || !canAccess(user?.role, 'media')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/admin/orders/manual/page.tsx
+++ b/app/admin/orders/manual/page.tsx
@@ -18,6 +18,7 @@ import {
   getOrderStatusBadgeVariant,
   getOrderStatusText,
 } from "@/lib/order-status"
+import { canAccess } from "@/lib/mock-roles"
 import { orderDb } from "@/lib/order-database"
 import { toast } from "sonner"
 
@@ -31,7 +32,7 @@ export default function ManualOrdersPage() {
   const [selectedOrder, setSelectedOrder] = useState<ManualOrder | null>(null)
 
   useEffect(() => {
-    if (!isLoading && (!isAuthenticated || user?.role !== "admin")) {
+    if (!isLoading && (!isAuthenticated || !canAccess(user?.role, 'inventory'))) {
       router.push("/login")
     }
   }, [isAuthenticated, user, router, isLoading])
@@ -63,7 +64,7 @@ export default function ManualOrdersPage() {
     )
   }
 
-  if (!isAuthenticated || user?.role !== "admin") {
+  if (!isAuthenticated || !canAccess(user?.role, 'inventory')) {
     return null
   }
 

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/inputs/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/modals/dialog"
 import { Plus, Search, Edit, Trash2, ArrowLeft, Eye } from "lucide-react"
+import { canAccess } from "@/lib/mock-roles"
 import Link from "next/link"
 import Image from "next/image"
 import { type Product } from "@/types/product"
@@ -37,7 +38,7 @@ export default function AdminProductsPage() {
     )
   }
 
-  if (user?.role !== "admin") {
+  if (!canAccess(user?.role, 'inventory')) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -31,9 +31,9 @@ export default function LoginPage() {
     try {
       const success = await login(email, password)
       if (success) {
-        // Check if user is admin and redirect accordingly
+        // Redirect based on user role
         const userData = mockUsers.find((u) => u.email === email)
-        if (userData?.role === "admin") {
+        if (userData?.role === "admin" || userData?.role === "staff") {
           router.push("/admin/dashboard")
         } else {
           router.push("/")
@@ -125,6 +125,12 @@ export default function LoginPage() {
             <div className="space-y-1 text-xs text-gray-600">
               <p>
                 <strong>Admin:</strong> admin@sofacover.com / password
+              </p>
+              <p>
+                <strong>Staff:</strong> staff@sofacover.com / password
+              </p>
+              <p>
+                <strong>Limited:</strong> limited@sofacover.com / password
               </p>
               <p>
                 <strong>Customer:</strong> john@example.com / password

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -21,25 +21,28 @@ import {
   unreadCount,
 } from "@/lib/mock-read-status"
 import { useEffect, useState } from "react"
+import { useAuth } from "@/contexts/auth-context"
+import { canAccess } from "@/lib/mock-roles"
 
 const navItems = [
-  { href: "/admin/dashboard", label: "แดชบอร์ด", icon: Home },
-  { href: "/admin/orders", label: "คำสั่งซื้อ", icon: ShoppingCart },
-  { href: "/admin/products", label: "สินค้า", icon: Package },
-  { href: "/admin/inventory", label: "สต็อก", icon: Layers },
-  { href: "/admin/customers", label: "ลูกค้า", icon: Users },
-  { href: "/admin/coupons", label: "คูปอง", icon: Percent },
-  { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText },
-  { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
-  { href: "/admin/chat", label: "แชท", icon: MessageCircle },
-  { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
-  { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List },
-  { href: "/admin/logs", label: "Log", icon: FileText },
+  { href: "/admin/dashboard", label: "แดชบอร์ด", icon: Home, feature: "dashboard" },
+  { href: "/admin/orders", label: "คำสั่งซื้อ", icon: ShoppingCart, feature: "inventory" },
+  { href: "/admin/products", label: "สินค้า", icon: Package, feature: "inventory" },
+  { href: "/admin/inventory", label: "สต็อก", icon: Layers, feature: "inventory" },
+  { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "inventory" },
+  { href: "/admin/coupons", label: "คูปอง", icon: Percent, feature: "inventory" },
+  { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText, feature: "inventory" },
+  { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell, feature: "inventory" },
+  { href: "/admin/chat", label: "แชท", icon: MessageCircle, feature: "chat" },
+  { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText, feature: "logs" },
+  { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List, feature: "logs" },
+  { href: "/admin/logs", label: "Log", icon: FileText, feature: "logs" },
 ]
 
 export default function Sidebar({ className = "" }: { className?: string }) {
   const pathname = usePathname()
   const [count, setCount] = useState(0)
+  const { user } = useAuth()
 
   useEffect(() => {
     loadNotificationStatus()
@@ -52,7 +55,7 @@ export default function Sidebar({ className = "" }: { className?: string }) {
         Admin
       </div>
       <nav className="flex-1 space-y-1 px-2 py-4">
-        {navItems.map(({ href, label, icon: Icon }) => {
+        {navItems.filter(item => canAccess(user?.role, item.feature)).map(({ href, label, icon: Icon }) => {
           const active = pathname === href || pathname.startsWith(`${href}/`)
           const badge = href === "/admin/notifications" ? count : 0
           return (

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -3,11 +3,13 @@
 import { createContext, useContext, useState, type ReactNode } from "react"
 import { mockUsers } from "@/lib/mock-users"
 
+import type { Role } from "@/lib/mock-roles"
+
 interface User {
   id: string
   name: string
   email: string
-  role: "admin" | "customer"
+  role: Role
   avatar?: string
 }
 

--- a/contexts/use-admin-guard.tsx
+++ b/contexts/use-admin-guard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "./auth-context"
+import { canAccess } from "@/lib/mock-roles"
 
 export function useAdminGuard() {
   const { user, isAuthenticated } = useAuth()
@@ -21,11 +22,11 @@ export function useAdminGuard() {
       router.replace("/login")
       return
     }
-    if (user?.role !== "admin") {
+    if (!canAccess(user?.role, 'dashboard')) {
       router.replace("/")
       return
     }
     setLoading(false)
   }, [isAuthenticated, user, router])
-  return { isAdmin: isAuthenticated && user?.role === "admin", loading, conflict }
+  return { isAdmin: isAuthenticated && canAccess(user?.role, 'dashboard'), loading, conflict }
 }

--- a/lib/mock-roles.ts
+++ b/lib/mock-roles.ts
@@ -1,0 +1,13 @@
+export type Role = 'admin' | 'staff' | 'limited' | 'customer'
+
+const roleAccess: Record<Role, string[]> = {
+  admin: ['dev', 'logs', 'inventory', 'inventorySettings', 'claims', 'media', 'dashboard', 'chat'],
+  staff: ['inventory', 'claims', 'media', 'dashboard', 'chat'],
+  limited: ['dashboard', 'chat'],
+  customer: [],
+}
+
+export function canAccess(role: Role | undefined, feature: string): boolean {
+  if (!role) return false
+  return roleAccess[role].includes(feature)
+}

--- a/lib/mock-users.ts
+++ b/lib/mock-users.ts
@@ -13,4 +13,18 @@ export const mockUsers = [
     role: "customer" as const,
     avatar: "/placeholder.svg?height=40&width=40",
   },
+  {
+    id: "3",
+    name: "Staff User",
+    email: "staff@sofacover.com",
+    role: "staff" as const,
+    avatar: "/placeholder.svg?height=40&width=40",
+  },
+  {
+    id: "4",
+    name: "Limited User",
+    email: "limited@sofacover.com",
+    role: "limited" as const,
+    avatar: "/placeholder.svg?height=40&width=40",
+  },
 ]


### PR DESCRIPTION
## Summary
- create `mock-roles.ts` for simple permission checks
- add sample staff and limited users
- gate admin pages using new role checks
- filter sidebar links by role
- document additional login examples

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687774fee37483258946e7fc3ba00e5f