### PR TITLE
Add chat priority queue page

### DIFF
--- a/app/admin/chat-priority/page.tsx
+++ b/app/admin/chat-priority/page.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { Conversation } from '@/types/conversation'
+import { loadConversations, listConversations } from '@/lib/mock-conversations'
+
+export default function ChatPriorityPage() {
+  const [convos, setConvos] = useState<Conversation[]>([])
+
+  useEffect(() => {
+    loadConversations()
+    setConvos([...listConversations()])
+  }, [])
+
+  const now = Date.now()
+  const items = convos
+    .map((c) => {
+      let urgency = 0
+      let status: string | null = null
+      if (c.tags.includes('สำคัญ')) {
+        urgency = 2
+        status = 'แชทสำคัญ'
+      }
+      if (now - new Date(c.updatedAt).getTime() > 24 * 60 * 60 * 1000) {
+        if (urgency < 1) urgency = 1
+        status = status || 'ค้างเกิน 1 วัน'
+      }
+      return { ...c, urgency, status }
+    })
+    .filter((c) => c.status)
+    .sort((a, b) => b.urgency - a.urgency)
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">คิวแชท</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>แชทค้างนาน</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ลูกค้า</TableHead>
+                  <TableHead>ข้อความล่าสุด</TableHead>
+                  <TableHead>สถานะ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((c) => (
+                  <TableRow key={c.id} className={c.urgency === 2 ? 'bg-red-50' : ''}>
+                    <TableCell>{c.customerName}</TableCell>
+                    <TableCell>{c.lastMessage}</TableCell>
+                    <TableCell className="flex items-center gap-1">
+                      {c.status}
+                      {c.urgency === 2 && <AlertCircle className="h-4 w-4 text-red-600" />}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {items.length === 0 && (
+              <p className="text-center py-8 text-gray-500">ไม่มีแชทค้างนาน</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   MessageCircle,
   FileText,
   List,
+  AlertCircle,
 } from "lucide-react"
 import clsx from "clsx"
 import { mockNotifications } from "@/lib/mock-notifications"
@@ -32,6 +33,7 @@ const navItems = [
   { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText },
   { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell },
   { href: "/admin/chat", label: "แชท", icon: MessageCircle },
+  { href: "/admin/chat-priority", label: "คิวแชท", icon: AlertCircle },
   { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText },
   { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List },
   { href: "/admin/logs", label: "Log", icon: FileText },

--- a/lib/mock-conversations.ts
+++ b/lib/mock-conversations.ts
@@ -7,14 +7,14 @@ export let conversations: Conversation[] = [
     customerName: 'John Doe',
     lastMessage: 'สอบถามราคาเบาะโซฟา',
     tags: ['ถามราคา'],
-    updatedAt: new Date().toISOString(),
+    updatedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
     id: 'conv-002',
     customerId: '3',
     customerName: 'Jane Smith',
     lastMessage: 'จะโอนพรุ่งนี้',
-    tags: ['รอโอน'],
+    tags: ['รอโอน', 'สำคัญ'],
     updatedAt: new Date().toISOString(),
   },
 ]


### PR DESCRIPTION
## Summary
- mock conversations: mark older and important chats
- sidebar: link to new chat priority queue page
- implement chat priority queue page with urgency sorting and fallback

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687777f0550c8325823fe8dc1982c61c