### PR TITLE
Add component sandbox preview page

### DIFF
--- a/app/dev/component-test/page.tsx
+++ b/app/dev/component-test/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useState } from "react"
+import { mockComponents } from "@/mock/mock-components"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+
+export default function ComponentTestPage() {
+  const [name, setName] = useState(mockComponents[0].name)
+  const selected = mockComponents.find((c) => c.name === name)!
+  const Comp = selected.Component
+
+  return (
+    <div className="min-h-screen p-4 space-y-4">
+      <select
+        className="border rounded p-2"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      >
+        {mockComponents.map((c) => (
+          <option key={c.name} value={c.name}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      <Card>
+        <CardHeader>
+          <CardTitle>Sandbox Preview</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Comp {...selected.props} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/mock/mock-components.ts
+++ b/mock/mock-components.ts
@@ -1,0 +1,29 @@
+import type { ComponentType } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { Badge } from "@/components/ui/badge"
+import BillPreview from "@/components/BillPreview"
+import { mockOrders } from "@/lib/mock-orders"
+
+export interface MockComponent {
+  name: string
+  Component: ComponentType<any>
+  props?: Record<string, any>
+}
+
+export const mockComponents: MockComponent[] = [
+  {
+    name: "Button",
+    Component: Button,
+    props: { children: "ตัวอย่างปุ่ม" },
+  },
+  {
+    name: "Badge",
+    Component: Badge,
+    props: { children: "ตัวอย่าง Badge" },
+  },
+  {
+    name: "BillPreview",
+    Component: BillPreview,
+    props: { order: mockOrders[0] },
+  },
+]


### PR DESCRIPTION
## Summary
- add `mock/mock-components.ts` for quick component examples
- create `/dev/component-test` page to preview mocked components

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687777fc77c08325b4057524d74a9515