### PR TITLE
Add admin inactivity reminder

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -55,6 +55,10 @@ import {
   ResponsiveContainer,
 } from "recharts"
 import { toast } from "sonner"
+import {
+  shouldRemindAdmin,
+  recordAdminActivity,
+} from "@/lib/admin-reminder"
 
 export default function AdminDashboard() {
   const [stats, setStats] = useState<DashboardStats | null>(null)
@@ -83,6 +87,10 @@ export default function AdminDashboard() {
       )
       if (overdue) toast.warning("มีบิลค้างชำระเกิน 3 วัน")
     }
+    if (shouldRemindAdmin()) {
+      toast.warning("ไม่มีการอัปเดตข้อมูลเกิน 5 วัน")
+    }
+    recordAdminActivity()
   }, [])
 
   useEffect(() => {

--- a/lib/admin-reminder.ts
+++ b/lib/admin-reminder.ts
@@ -1,0 +1,15 @@
+export const ADMIN_LAST_ACTIVE_KEY = 'adminLastActive'
+
+export function recordAdminActivity() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(ADMIN_LAST_ACTIVE_KEY, Date.now().toString())
+  }
+}
+
+export function shouldRemindAdmin(): boolean {
+  if (typeof window === 'undefined') return false
+  const last = localStorage.getItem(ADMIN_LAST_ACTIVE_KEY)
+  if (!last) return true
+  const lastTime = parseInt(last, 10)
+  return Date.now() - lastTime > 5 * 24 * 60 * 60 * 1000
+}


### PR DESCRIPTION
## Summary
- warn admins if no updates for more than 5 days
- store last activity in `localStorage`

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_68779726c2d48325888b2a1ec38f2624