### PR TITLE
Add mobile home UI mock

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { ReviewImagesProvider } from "@/contexts/review-images-context"
 import { FavoritesProvider } from "@/contexts/favorites-context"
 import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-context"
 import { validateMockData } from "@/lib/mock-validator"
+import RedirectMobileHome from "@/components/RedirectMobileHome"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -38,6 +39,7 @@ export default function RootLayout({
                 <FavoritesProvider>
                   <AdminProductGroupsProvider>
                     <ReviewImagesProvider>
+                      <RedirectMobileHome />
                       {children}
                       <Toaster />
                     </ReviewImagesProvider>

--- a/app/mobile-home/page.tsx
+++ b/app/mobile-home/page.tsx
@@ -1,0 +1,23 @@
+"use client"
+import EmotionBanner from "@/components/EmotionBanner"
+import WalkthroughModal from "@/components/WalkthroughModal"
+import FallbackCenter from "@/components/FallbackCenter"
+
+let MenuGrid: React.ComponentType | null = null
+try {
+  MenuGrid = require("@/components/MobileMainMenuGrid").default
+} catch {
+  MenuGrid = null
+}
+
+const mockUser = { hasSeenIntro: false }
+
+export default function MobileHomePage() {
+  return (
+    <div className="space-y-4 py-4">
+      <EmotionBanner />
+      {!mockUser.hasSeenIntro && <WalkthroughModal />}
+      {MenuGrid ? <MenuGrid /> : <FallbackCenter title="โหลดเมนูไม่สำเร็จ ลองรีเฟรช" />}
+    </div>
+  )
+}

--- a/components/EmotionBanner.tsx
+++ b/components/EmotionBanner.tsx
@@ -1,0 +1,13 @@
+"use client"
+import { useState } from "react"
+
+const mockEmotion = "สดใส"
+
+export default function EmotionBanner() {
+  const [emotion] = useState(mockEmotion)
+  return (
+    <div className="bg-pink-50 text-pink-800 text-center p-2 rounded-md">
+      วันนี้คุณรู้สึก {emotion}
+    </div>
+  )
+}

--- a/components/MobileMainMenuGrid.tsx
+++ b/components/MobileMainMenuGrid.tsx
@@ -1,0 +1,26 @@
+"use client"
+import Link from "next/link"
+import { ShoppingCart, ImageIcon, ScrollText, MessageCircle, Book, Percent, LayoutGrid } from "lucide-react"
+
+const menu = [
+  { href: "/quick-bill", label: "เปิดบิลเร็ว", icon: ShoppingCart },
+  { href: "/fabrics", label: "ลายผ้า", icon: ImageIcon },
+  { href: "/orders/latest", label: "บิลล่าสุด", icon: ScrollText },
+  { href: "/chat", label: "คุยกับลูกค้า", icon: MessageCircle },
+  { href: "/catalog", label: "แคตตาล็อก", icon: Book },
+  { href: "/promos", label: "โปรโมชัน", icon: Percent },
+  { href: "/tools", label: "อื่น ๆ", icon: LayoutGrid },
+]
+
+export default function MobileMainMenuGrid() {
+  return (
+    <div className="grid grid-cols-3 gap-4 text-center">
+      {menu.map(({ href, label, icon: Icon }) => (
+        <Link key={label} href={href} className="bg-blue-50 rounded-lg p-4 flex flex-col items-center text-sm hover:bg-blue-100">
+          <Icon className="w-6 h-6 mb-2" />
+          <span>{label}</span>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/components/RedirectMobileHome.tsx
+++ b/components/RedirectMobileHome.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+export default function RedirectMobileHome() {
+  const isMobile = useIsMobile()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (isMobile && pathname === "/") {
+      router.replace("/mobile-home")
+    }
+  }, [isMobile, pathname, router])
+
+  return null
+}

--- a/components/WalkthroughModal.tsx
+++ b/components/WalkthroughModal.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { useState } from "react"
+import { Button } from "@/components/ui/buttons/button"
+
+const steps = [
+  "กด \"เปิดบิลเร็ว\" เพื่อเริ่มสร้างบิล",
+  "เลือกเมนู \"ลายผ้า\" เพื่อดูแบบทั้งหมด",
+  "ดูเมนู \"บิลล่าสุด\" เพื่อติดตามคำสั่งซื้อ",
+  "ใช้เมนู \"คุยกับลูกค้า\" เพื่อเปิดแชท"
+]
+
+export default function WalkthroughModal() {
+  const [step, setStep] = useState(0)
+  if (step >= steps.length) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded shadow w-72 space-y-4 text-center">
+        <p>{steps[step]}</p>
+        <Button onClick={() => setStep(step + 1)}>
+          {step === steps.length - 1 ? "ปิด" : "ถัดไป"}
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add mobile-only EmotionBanner, WalkthroughModal and menu grid
- redirect mobile devices from `/` to `/mobile-home`
- mount new mobile home page and components

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f67722108325a9e31d3f56c6e413