### PR TITLE
Add emotion banner to mobile admin

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -5,18 +5,26 @@ import { useAdminGuard } from "@/contexts/use-admin-guard"
 import Sidebar from "@/components/admin/Sidebar"
 import Topbar from "@/components/admin/Topbar"
 import { Sheet, SheetContent } from "@/components/ui/modals/sheet"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { AdminProductsProvider } from "@/contexts/admin-products-context"
 import { AdminCollectionsProvider } from "@/contexts/admin-collections-context"
 import { AdminToast } from "@/components/admin/AdminToast"
 import QuickActionBar from "@/components/admin/QuickActionBar"
 import ErrorBoundary from "@/components/ErrorBoundary"
+import EmotionBanner from "@/components/admin/EmotionBanner"
+import { loadMockPreferences, mockPreferences } from "@/lib/mock-preferences"
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const { loading, isAdmin, conflict } = useAdminGuard()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const isMobile = useIsMobile()
+  const [showEmotion, setShowEmotion] = useState(mockPreferences.showEmotion)
+
+  useEffect(() => {
+    loadMockPreferences()
+    setShowEmotion(mockPreferences.showEmotion)
+  }, [])
 
   if (loading) {
     return (
@@ -56,6 +64,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             )}
             <div className="flex flex-1 flex-col">
               <Topbar onMenuClick={() => setSidebarOpen(true)} />
+              {isMobile && showEmotion && <EmotionBanner />}
               <main className="flex-1 p-4 pb-20 md:pb-4">{children}</main>
               <AdminToast />
               <QuickActionBar />

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   loadMockPreferences,
   mockPreferences,
   setShowIds,
+  setShowEmotion,
 } from "@/lib/mock-preferences";
 import { clearMockData, downloadMockMappingPlan } from "@/lib/mock-tools";
 import {
@@ -47,6 +48,7 @@ export default function SettingsPage() {
   const [reviewRemind, setReviewRemind] = useState(reviewReminder);
   const [archiveOld, setArchiveOld] = useState(autoArchive);
   const [showIds, setShowIdsState] = useState(mockPreferences.showIds);
+  const [showEmotion, setShowEmotionState] = useState(mockPreferences.showEmotion);
 
   useEffect(() => {
     loadAutoMessage();
@@ -63,6 +65,7 @@ export default function SettingsPage() {
     setArchiveOld(autoArchive);
     setReviewRemind(reviewReminder);
     setShowIdsState(mockPreferences.showIds);
+    setShowEmotionState(mockPreferences.showEmotion);
     if (!isAuthenticated) {
       router.push("/login");
     } else if (user?.role !== "admin") {
@@ -80,6 +83,7 @@ export default function SettingsPage() {
     setAutoArchive(archiveOld);
     setReviewReminder(reviewRemind);
     setShowIds(showIds);
+    setShowEmotion(showEmotion);
     alert("บันทึกข้อความแล้ว");
   };
 
@@ -190,6 +194,14 @@ export default function SettingsPage() {
             <CardTitle>ทดลอง</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="show-emotion"
+                checked={showEmotion}
+                onCheckedChange={(v) => setShowEmotionState(Boolean(v))}
+              />
+              <Label htmlFor="show-emotion">แสดงข้อความกำลังใจ</Label>
+            </div>
             <div className="flex items-center space-x-2">
               <Checkbox
                 id="show-ids"

--- a/components/admin/EmotionBanner.tsx
+++ b/components/admin/EmotionBanner.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { useState } from "react"
+import { getEmotionForDay } from "@/lib/mock-emotions"
+
+export default function EmotionBanner() {
+  const [index, setIndex] = useState(new Date().getDay())
+  const emotion = getEmotionForDay(index)
+
+  return (
+    <div className="mb-4 flex w-full items-center rounded-lg bg-gradient-to-r from-pink-100 via-yellow-50 to-yellow-100 p-3 text-sm">
+      <span className="mr-2 text-xl">{emotion.emoji}</span>
+      <span className="flex-1">{emotion.text}</span>
+      <button className="text-xs underline" onClick={() => setIndex((index + 1) % 7)}>
+        เปลี่ยนข้อความกำลังใจ
+      </button>
+    </div>
+  )
+}

--- a/lib/mock-emotions.ts
+++ b/lib/mock-emotions.ts
@@ -1,0 +1,18 @@
+export interface EmotionMessage {
+  emoji: string
+  text: string
+}
+
+const messages: Partial<Record<number, EmotionMessage>> = {
+  1: { emoji: "☕", text: "ยอดเบานะวันนี้ แวะกาแฟก่อนมั้ยคะ ☕" },
+  5: { emoji: "💰", text: "สิ้นเดือนแล้ว ลุยปิดยอดให้สุด 💰" },
+}
+
+export const fallbackEmotion: EmotionMessage = {
+  emoji: "💖",
+  text: "วันนี้ไม่มีคำพูดพิเศษนะคะ แต่แอดมินก็เก่งที่สุดแล้วค่ะ 💖",
+}
+
+export function getEmotionForDay(day: number = new Date().getDay()): EmotionMessage {
+  return messages[day] ?? fallbackEmotion
+}

--- a/lib/mock-preferences.ts
+++ b/lib/mock-preferences.ts
@@ -1,10 +1,11 @@
 export interface MockPreferences {
   showIds: boolean
+  showEmotion: boolean
 }
 
 const STORAGE_KEY = 'mockPreferences'
 
-export let mockPreferences: MockPreferences = { showIds: false }
+export let mockPreferences: MockPreferences = { showIds: false, showEmotion: true }
 
 export function loadMockPreferences() {
   if (typeof window !== 'undefined') {
@@ -22,4 +23,8 @@ export function setMockPreferences(val: MockPreferences) {
 
 export function setShowIds(show: boolean) {
   setMockPreferences({ ...mockPreferences, showIds: show })
+}
+
+export function setShowEmotion(show: boolean) {
+  setMockPreferences({ ...mockPreferences, showEmotion: show })
 }


### PR DESCRIPTION
## Summary
- rotate emotion messages by weekday with fallback
- allow toggling emotion banner visibility in preferences
- show banner in admin layout when enabled
- add manual rotation button

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f93df5a0832588fb2167c4306ac6