### PR TITLE
Add mock checkout success flow

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+import Link from "next/link";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/buttons/button";
+
+export default function CheckoutSuccess() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="space-y-6 text-center">
+          <h1 className="text-2xl font-bold">ขอบคุณสำหรับการสั่งซื้อ!</h1>
+          <Link href="/orders">
+            <Button>ดูคำสั่งซื้อทั้งหมด</Button>
+          </Link>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support selecting delivery methods on checkout
- handle missing checkout fields with alert
- store selected delivery method to mock order and redirect to `/checkout/success`
- show delivery fee in price breakdown
- create checkout success page with link to all orders

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6877dd1af2608325a038a751c1197e17