### PR TITLE
Redirect mobile users to default menu

### DIFF
--- a/components/RedirectMobileHome.tsx
+++ b/components/RedirectMobileHome.tsx
@@ -9,7 +9,7 @@ export default function RedirectMobileHome() {
   const router = useRouter()
 
   useEffect(() => {
-    if (isMobile && pathname === "/") {
+    if ((isMobile === true || isMobile === undefined) && pathname === "/") {
       router.replace("/mobile-home")
     }
   }, [isMobile, pathname, router])

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -17,5 +17,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }


### PR DESCRIPTION
## Summary
- adjust `useIsMobile` to return `undefined` initially
- redirect to `/mobile-home` when device is mobile or unknown

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68780628cb548325ac67104d9442328c