### PR TITLE
Add tooltip seen state

### DIFF
--- a/components/MobileMainMenuGrid.tsx
+++ b/components/MobileMainMenuGrid.tsx
@@ -1,6 +1,26 @@
 "use client"
 import Link from "next/link"
-import { ShoppingCart, ImageIcon, ScrollText, MessageCircle, Book, Percent, LayoutGrid } from "lucide-react"
+import { useEffect, useState } from "react"
+import {
+  ShoppingCart,
+  ImageIcon,
+  ScrollText,
+  MessageCircle,
+  Book,
+  Percent,
+  LayoutGrid,
+} from "lucide-react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  loadTooltipSeenState,
+  markTooltipSeen,
+  tooltipSeenState,
+} from "@/lib/mock-tooltip-seen"
 
 const menu = [
   { href: "/quick-bill", label: "เปิดบิลเร็ว", icon: ShoppingCart },
@@ -13,14 +33,51 @@ const menu = [
 ]
 
 export default function MobileMainMenuGrid() {
+  const [seen, setSeen] = useState<Record<string, boolean>>(tooltipSeenState)
+  const [open, setOpen] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadTooltipSeenState()
+    setSeen({ ...tooltipSeenState })
+  }, [])
+
+  const handleClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    label: string,
+  ) => {
+    if (!seen[label]) {
+      e.preventDefault()
+      setOpen(label)
+      markTooltipSeen(label)
+      setSeen((s) => ({ ...s, [label]: true }))
+    }
+  }
+
   return (
-    <div className="grid grid-cols-3 gap-4 text-center">
-      {menu.map(({ href, label, icon: Icon }) => (
-        <Link key={label} href={href} className="bg-blue-50 rounded-lg p-4 flex flex-col items-center text-sm hover:bg-blue-100">
-          <Icon className="w-6 h-6 mb-2" />
-          <span>{label}</span>
-        </Link>
-      ))}
-    </div>
+    <TooltipProvider delayDuration={0}>
+      <div className="grid grid-cols-3 gap-4 text-center">
+        {menu.map(({ href, label, icon: Icon }) => (
+          <Tooltip
+            key={label}
+            open={!seen[label] && open === label}
+            onOpenChange={(o) => {
+              if (!o && open === label) setOpen(null)
+            }}
+          >
+            <TooltipTrigger asChild>
+              <Link
+                href={href}
+                className="bg-blue-50 rounded-lg p-4 flex flex-col items-center text-sm hover:bg-blue-100"
+                onClick={(e) => handleClick(e, label)}
+              >
+                <Icon className="w-6 h-6 mb-2" />
+                <span>{label}</span>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Tap again to open</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
   )
 }

--- a/lib/mock-tooltip-seen.ts
+++ b/lib/mock-tooltip-seen.ts
@@ -1,0 +1,23 @@
+export type TooltipSeenState = Record<string, boolean>
+
+const STORAGE_KEY = 'tooltipSeenState'
+
+export let tooltipSeenState: TooltipSeenState = {}
+
+export function loadTooltipSeenState() {
+  if (typeof window !== 'undefined') {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) tooltipSeenState = JSON.parse(raw) as TooltipSeenState
+  }
+}
+
+export function markTooltipSeen(id: string) {
+  tooltipSeenState[id] = true
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tooltipSeenState))
+  }
+}
+
+export function hasSeenTooltip(id: string): boolean {
+  return !!tooltipSeenState[id]
+}


### PR DESCRIPTION
## Summary
- track tooltip usage in mock localStorage
- show tooltip on first tap in mobile menu

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68780c1852108325a91b8d442e20f6a2