### PR TITLE
Add message helpers

### DIFF
--- a/components/admin/SendToChatModal.tsx
+++ b/components/admin/SendToChatModal.tsx
@@ -1,9 +1,38 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { logEvent } from "@/lib/logs"
+import { getLastCustomerName } from "@/lib/mock-customers"
 
 export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose: () => void }) {
-  const [message, setMessage] = useState(`📦 รายการคำสั่งซื้อ #${orderId}\nยอดรวม: 999 บาท`)
+  const base = `📦 รายการคำสั่งซื้อ #${orderId}\nยอดรวม: 999 บาท`
+  const [message, setMessage] = useState(base)
   const [customer, setCustomer] = useState("ลูกค้า A (Facebook)")
+  const [tone, setTone] = useState("สุภาพ")
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  function applyTone(t: string) {
+    const prefix =
+      t === "สุภาพ" ? "เรียนลูกค้า" : t === "เป็นกันเอง" ? "สวัสดีจ้า" : "ด่วน!"
+    setMessage(`${prefix} ${base}`)
+  }
+
+  function prependLastCustomer() {
+    const name = getLastCustomerName()
+    if (name) setMessage((msg) => `${name} ${msg}`)
+  }
+
+  function insertEmoji(emoji: string) {
+    if (!textareaRef.current) return
+    const el = textareaRef.current
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    const newText = message.slice(0, start) + emoji + message.slice(end)
+    setMessage(newText)
+    requestAnimationFrame(() => {
+      el.selectionStart = el.selectionEnd = start + emoji.length
+      el.focus()
+    })
+  }
+
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
@@ -18,11 +47,37 @@ export function SendToChatModal({ orderId, onClose }: { orderId: string; onClose
           <option>ลูกค้า B (Inbox)</option>
           <option>ลูกค้า C (โทรศัพท์)</option>
         </select>
+        <select
+          className="w-full border p-2 rounded"
+          value={tone}
+          onChange={(e) => {
+            setTone(e.target.value)
+            applyTone(e.target.value)
+          }}
+        >
+          <option>สุภาพ</option>
+          <option>เป็นกันเอง</option>
+          <option>เร่งยอด</option>
+        </select>
+        <button
+          className="text-sm underline text-left"
+          onClick={prependLastCustomer}
+        >
+          ใส่ชื่ออัตโนมัติ
+        </button>
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          ref={textareaRef}
           className="w-full h-32 border p-2 rounded"
         />
+        <div className="flex gap-2 md:hidden">
+          {['❤️', '✅', '🙏', '🧵'].map((e) => (
+            <button key={e} onClick={() => insertEmoji(e)} className="text-xl">
+              {e}
+            </button>
+          ))}
+        </div>
         <div className="flex justify-end gap-2">
           <button className="text-gray-500" onClick={onClose}>ยกเลิก</button>
           <button

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -188,3 +188,8 @@ export function checkCustomerInfo(id: string): string | null {
   if (!customer.phone) missing.push("เบอร์โทร")
   return missing.length > 0 ? `ข้อมูลลูกค้าไม่ครบ (${missing.join(", ")})` : null
 }
+
+export function getLastCustomerName(): string | null {
+  const last = mockCustomers[mockCustomers.length - 1]
+  return last ? last.name : null
+}


### PR DESCRIPTION
## Summary
- expose `getLastCustomerName` helper
- add auto name, tone selector, emoji buttons in SendToChatModal

## Testing
- `pnpm eslint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68780d495f288325a5291abb02f43448