### PR TITLE
Add mount pulse animation to wishlist button

### DIFF
--- a/components/WishlistButton.tsx
+++ b/components/WishlistButton.tsx
@@ -2,15 +2,28 @@
 
 import { Heart } from "lucide-react"
 import { useWishlist } from "@/contexts/wishlist-context"
+import { useEffect, useState } from "react"
+import { cn } from "@/lib/utils"
 
 export function WishlistButton({ slug }: { slug: string }) {
   const { wishlist, toggleWishlist } = useWishlist()
   const active = wishlist.includes(slug)
+  const [animate, setAnimate] = useState(false)
+
+  useEffect(() => {
+    setAnimate(true)
+    const timer = setTimeout(() => setAnimate(false), 1000)
+    return () => clearTimeout(timer)
+  }, [])
 
   return (
     <button onClick={() => toggleWishlist(slug)} aria-label="toggle wishlist">
       <Heart
-        className={`h-6 w-6 ${active ? "text-red-500" : "text-gray-500"}`}
+        className={cn(
+          "h-6 w-6",
+          active ? "text-red-500" : "text-gray-500",
+          animate && "animate-[pulse_1s_ease-in-out]"
+        )}
         fill={active ? "currentColor" : "none"}
       />
     </button>


### PR DESCRIPTION
## Summary
- animate the WishlistButton with a single pulse on mount

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68781033a47883258632ee32cf5b0276