### PR TITLE
Add pnpm install step before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ includes a button to open Chatwoot in a new browser tab.
 
 ## Testing
 
-Run unit tests with:
+Before running tests, make sure dependencies are installed:
+
+```bash
+pnpm install
+```
+
+Then run unit tests with:
 
 ```bash
 pnpm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
+    "pretest": "pnpm install",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "eslint": "eslint . --ext .js,.jsx,.ts,.tsx,.vue --no-error-on-unmatched-pattern",


### PR DESCRIPTION
## Summary
- mention dependency installation step in `README`
- run `pnpm install` automatically before `pnpm test`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687812df7e648325900a35b7d547c47c