### PR TITLE
Add simplified admin mobile pages

### DIFF
--- a/app/admin/dashboard-mobile/page.tsx
+++ b/app/admin/dashboard-mobile/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link"
+import { Card, CardContent } from "@/components/ui/cards/card"
+import { Button } from "@/components/ui/buttons/button"
+import {
+  ClipboardList,
+  FileText,
+  MessageCircle,
+  LineChart,
+} from "lucide-react"
+
+const stats = [
+  { label: "Today's Orders", value: 12 },
+  { label: "Pending Bills", value: 5 },
+  { label: "New Chats", value: 3 },
+  { label: "Total Sales", value: "฿25,000" },
+]
+
+const actions = [
+  { href: "/admin/orders", label: "ออเดอร์", icon: ClipboardList },
+  { href: "/admin/bills", label: "บิล", icon: FileText },
+  { href: "/admin/chat", label: "แชท", icon: MessageCircle },
+  { href: "/admin/reports", label: "รายงาน", icon: LineChart },
+]
+
+export default function AdminDashboardMobile() {
+  return (
+    <div className="space-y-6 p-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {stats.map(({ label, value }) => (
+          <Card key={label}>
+            <CardContent className="p-4 text-center space-y-1">
+              <p className="text-sm text-gray-600">{label}</p>
+              <p className="text-xl font-bold">{value}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        {actions.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={label}
+            href={href}
+            className="flex flex-col items-center justify-center rounded-lg bg-blue-50 p-4 text-sm hover:bg-blue-100"
+          >
+            <Icon className="mb-2 h-6 w-6" />
+            <span>{label}</span>
+          </Link>
+        ))}
+      </div>
+
+      <div className="text-center">
+        <p className="text-lg font-semibold">สู้ ๆ นะวันนี้!</p>
+      </div>
+
+      <div className="text-center">
+        <Link href="/admin/menu">
+          <Button variant="outline">ไปยังเมนูหลัก</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/menu/page.tsx
+++ b/app/admin/menu/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link"
+import { Bot, MessageCircle, Package, ShoppingCart, Settings } from "lucide-react"
+
+const sections = [
+  {
+    title: "สินค้า",
+    items: [
+      { href: "/admin/products", label: "รายการสินค้า", icon: Package },
+      { href: "/admin/products/new", label: "เพิ่มสินค้า", icon: ShoppingCart },
+    ],
+  },
+  {
+    title: "คำสั่งซื้อ",
+    items: [
+      { href: "/admin/orders", label: "ออเดอร์ทั้งหมด", icon: ShoppingCart },
+      { href: "/admin/bills", label: "บิลค้างชำระ", icon: Package },
+    ],
+  },
+  {
+    title: "แชท",
+    items: [
+      { href: "/admin/chat", label: "พูดคุยกับลูกค้า", icon: MessageCircle },
+    ],
+  },
+  {
+    title: "เอไอ",
+    items: [
+      { href: "/admin/ai", label: "ผู้ช่วย AI", icon: Bot },
+    ],
+  },
+  {
+    title: "ตั้งค่า",
+    items: [
+      { href: "/admin/settings", label: "ตั้งค่าระบบ", icon: Settings },
+    ],
+  },
+]
+
+export default function AdminMenuPage() {
+  return (
+    <div className="space-y-8 p-4">
+      {sections.map((section) => (
+        <div key={section.title} className="space-y-2">
+          <h2 className="text-lg font-bold">{section.title}</h2>
+          <div className="grid grid-cols-3 gap-4">
+            {section.items.map(({ href, label, icon: Icon }) => (
+              <Link
+                key={label}
+                href={href}
+                className="flex flex-col items-center rounded-lg bg-blue-50 p-4 text-center text-sm hover:bg-blue-100"
+              >
+                <Icon className="mb-2 h-6 w-6" />
+                <span>{label}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/admin/dashboard-mobile` with summary cards and quick actions
- add `/admin/menu` with Thai-labelled navigation grid

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68781d493d7c83259e62e6ca707cf87e