### PR TITLE
Add placeholders for chat pages and improve reports

### DIFF
--- a/app/__tests__/reports.test.tsx
+++ b/app/__tests__/reports.test.tsx
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import AdminReportsPage from '../admin/reports/page'
+
+describe('AdminReportsPage', () => {
+  it('should be defined', () => {
+    expect(AdminReportsPage).toBeTruthy()
+  })
+})

--- a/app/admin/chat-activity/page.tsx
+++ b/app/admin/chat-activity/page.tsx
@@ -1,0 +1,7 @@
+import FallbackCenter from "@/components/FallbackCenter"
+
+export default function ChatActivityPage() {
+  return (
+    <FallbackCenter icon="📈" title="Chat Activity ยังไม่พร้อม" subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้" />
+  )
+}

--- a/app/admin/chat-insight/page.tsx
+++ b/app/admin/chat-insight/page.tsx
@@ -1,0 +1,7 @@
+import FallbackCenter from "@/components/FallbackCenter"
+
+export default function ChatInsightPage() {
+  return (
+    <FallbackCenter icon="💬" title="Chat Insight ยังไม่พร้อม" subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้" />
+  )
+}

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,11 +1,64 @@
-import FallbackCenter from "@/components/FallbackCenter"
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { getDailySales } from "@/lib/mock/orders"
 
 export default function AdminReportsPage() {
+  const [daily, setDaily] = useState<{ date: string; total: number }[]>([])
+
+  useEffect(() => {
+    const today = new Date()
+    const past = new Date()
+    past.setDate(today.getDate() - 6)
+    setDaily(getDailySales(past, today))
+  }, [])
+
   return (
-    <FallbackCenter
-      icon="📑"
-      title="Reports ยังไม่พร้อม"
-      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
-    />
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">รายงานสรุป (mock)</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>ยอดขาย 7 วันล่าสุด</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>วันที่</TableHead>
+                  <TableHead className="text-right">ยอดขาย</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {daily.map((d) => (
+                  <TableRow key={d.date}>
+                    <TableCell>{d.date}</TableCell>
+                    <TableCell className="text-right">{d.total.toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {daily.length === 0 && (
+              <p className="text-center py-8 text-gray-500">ไม่มีข้อมูล</p>
+            )}
+          </CardContent>
+        </Card>
+        <Link href="/admin/reports/sales">
+          <Button>ดูรายงานยอดขายแบบละเอียด</Button>
+        </Link>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- add placeholder pages for `/admin/chat-insight` and `/admin/chat-activity`
- expand `/admin/reports` with a mock sales summary table
- stub a simple unit test for the reports page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6878468f2b3c8325beb45c963a879a4d