### PR TITLE
Fix about theme crash

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/cards/card"
 import { Badge } from "@/components/ui/badge"
 import { Star, Users, Award, Heart, Shield, Truck } from "lucide-react"
 import Image from "next/image"
+import AboutClient from "@/components/AboutClient"
 
 export default function AboutPage() {
   const stats = [
@@ -55,6 +56,7 @@ export default function AboutPage() {
   return (
     <div className="min-h-screen">
       <Navbar />
+      <AboutClient />
 
       {/* Hero Section */}
       <section className="relative py-20 bg-gradient-to-r from-blue-600 to-purple-600 text-white">

--- a/components/AboutClient.tsx
+++ b/components/AboutClient.tsx
@@ -1,0 +1,7 @@
+"use client"
+import { useTheme } from "next-themes"
+
+export default function AboutClient() {
+  const { theme } = useTheme()
+  return <div>Current theme: {theme}</div>
+}


### PR DESCRIPTION
## Summary
- add `AboutClient` component that uses `useTheme`
- render `AboutClient` inside About page instead of calling `useTheme` in the server component

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6878b05af0e0832593ae62db7cf9d29f