### PR TITLE
Remove dashboard button grid

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -57,28 +57,7 @@ export default function AdminDashboard() {
   )
 
   return (
-    <div className="grid min-h-screen md:grid-cols-[220px_1fr]">
-      <aside className="border-r bg-gray-50 p-4 space-y-2">
-        <Link href="/admin/fabrics" className="block p-2 hover:underline">
-          ผ้า
-        </Link>
-        <Link href="/admin/orders" className="block p-2 hover:underline">
-          คำสั่งซื้อ
-        </Link>
-        <Link href="/admin/ai-tools" className="block p-2 hover:underline">
-          เครื่องมือ AI
-        </Link>
-        <Link href="/chat" className="block p-2 hover:underline">
-          แชท
-        </Link>
-        <Link href="/admin/feature-map" className="block p-2 hover:underline">
-          แผนที่ฟีเจอร์
-        </Link>
-        <Link href="/admin/menu" className="block p-2 hover:underline">
-          เมนู
-        </Link>
-      </aside>
-      <div className="p-4 space-y-6">
+    <div className="space-y-6">
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">แดชบอร์ดแอดมินหลัก</h1>
           <Button asChild>
@@ -153,68 +132,6 @@ export default function AdminDashboard() {
               </ul>
             </CardContent>
           </Card>
-          <div className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 gap-2">
-            <Button asChild className="w-full">
-              <Link href="/admin/fabrics">ผ้า</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/bill/create">เปิดบิล</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/collections">คอลเลกชัน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/promo">โปรโมชัน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/ai-tools">เครื่องมือ AI</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/menu">เมนู</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/chat">แชท</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/feature-map">แผนที่ฟีเจอร์</Link>
-            </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/analytics">สถิติ</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/broadcast">บรอดแคสต์</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/claims">เคลม</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/media">มีเดีย</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/supply-tracker">ติดตามสต็อก</Link>
-              </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/unpaid">ค้างจ่าย</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/faq">คำถามพบบ่อย</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/feedback">ความคิดเห็น</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/campaign-insight">ข้อมูลแคมเปญ</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/campaigns/summary">สรุปแคมเปญ</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/bills/fast">เปิดบิลด่วน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/users">ผู้ใช้</Link>
-            </Button>
-          </div>
         </div>
 
         {debug && (
@@ -224,7 +141,6 @@ export default function AdminDashboard() {
             <p>ยังไม่เชื่อม</p>
           </div>
         )}
-      </div>
-    </div>
-  )
-}
+        </div>
+      )
+  }


### PR DESCRIPTION
## Summary
- remove custom sidebar and button grid from admin dashboard
- rely on layout Sidebar/QuickActionBar navigation

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6878d989a0708325a9b660cc2cf564f6