### PR TITLE
Centralize admin navigation config

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/
 import { Skeleton } from "@/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { ShoppingCart, Wallet, Clock, MessageSquare } from "lucide-react"
+import { adminRoutes } from "@/components/admin/admin-nav"
 
 interface OrderData {
   id: string
@@ -59,24 +60,20 @@ export default function AdminDashboard() {
   return (
     <div className="grid min-h-screen md:grid-cols-[220px_1fr]">
       <aside className="border-r bg-gray-50 p-4 space-y-2">
-        <Link href="/admin/fabrics" className="block p-2 hover:underline">
-          ผ้า
-        </Link>
-        <Link href="/admin/orders" className="block p-2 hover:underline">
-          คำสั่งซื้อ
-        </Link>
-        <Link href="/admin/ai-tools" className="block p-2 hover:underline">
-          เครื่องมือ AI
-        </Link>
-        <Link href="/chat" className="block p-2 hover:underline">
-          แชท
-        </Link>
-        <Link href="/admin/feature-map" className="block p-2 hover:underline">
-          แผนที่ฟีเจอร์
-        </Link>
-        <Link href="/admin/menu" className="block p-2 hover:underline">
-          เมนู
-        </Link>
+        {adminRoutes
+          .filter(r => [
+            "/admin/fabrics",
+            "/admin/orders",
+            "/admin/ai-tools",
+            "/chat",
+            "/admin/feature-map",
+            "/admin/menu",
+          ].includes(r.href))
+          .map(({ href, label }) => (
+            <Link key={href} href={href} className="block p-2 hover:underline">
+              {label}
+            </Link>
+          ))}
       </aside>
       <div className="p-4 space-y-6">
         <header className="flex items-center justify-between">
@@ -155,65 +152,35 @@ export default function AdminDashboard() {
           </Card>
           <div className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 gap-2">
             <Button asChild className="w-full">
-              <Link href="/admin/fabrics">ผ้า</Link>
-            </Button>
-            <Button asChild className="w-full">
               <Link href="/admin/bill/create">เปิดบิล</Link>
             </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/collections">คอลเลกชัน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/promo">โปรโมชัน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/ai-tools">เครื่องมือ AI</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/menu">เมนู</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/chat">แชท</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/feature-map">แผนที่ฟีเจอร์</Link>
-            </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/analytics">สถิติ</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/broadcast">บรอดแคสต์</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/claims">เคลม</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/media">มีเดีย</Link>
-              </Button>
-              <Button asChild className="w-full">
-                <Link href="/admin/supply-tracker">ติดตามสต็อก</Link>
-              </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/unpaid">ค้างจ่าย</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/faq">คำถามพบบ่อย</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/feedback">ความคิดเห็น</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/campaign-insight">ข้อมูลแคมเปญ</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/campaigns/summary">สรุปแคมเปญ</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/bills/fast">เปิดบิลด่วน</Link>
-            </Button>
-            <Button asChild className="w-full">
-              <Link href="/admin/users">ผู้ใช้</Link>
-            </Button>
+            {adminRoutes
+              .filter(r => [
+                "/admin/collections",
+                "/admin/promo",
+                "/admin/ai-tools",
+                "/admin/menu",
+                "/chat",
+                "/admin/feature-map",
+                "/admin/analytics",
+                "/admin/broadcast",
+                "/admin/claims",
+                "/admin/media",
+                "/admin/supply-tracker",
+                "/admin/unpaid",
+                "/admin/faq",
+                "/admin/feedback",
+                "/admin/campaign-insight",
+                "/admin/campaigns/summary",
+                "/admin/bills/fast",
+                "/admin/users"
+              ].includes(r.href))
+              .map(({ href, label }) => (
+                <Button asChild key={href} className="w-full">
+                  <Link href={href}>{label}</Link>
+                </Button>
+              ))}
+
           </div>
         </div>
 

--- a/components/admin/QuickActionBar.tsx
+++ b/components/admin/QuickActionBar.tsx
@@ -1,35 +1,28 @@
 "use client"
 
 import Link from "next/link"
-import { Plus, ClipboardList, MessageCircle, Settings, Megaphone, BarChart3 } from "lucide-react"
+import { adminRoutes } from "@/components/admin/admin-nav"
 
 export default function QuickActionBar() {
+  const quickPaths = [
+    "/admin/openbill/quick",
+    "/admin/orders",
+    "/admin/chat",
+    "/admin/broadcast",
+    "/admin/analytics",
+    "/admin/settings",
+  ]
+
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-20 flex justify-around border-t bg-background py-2 md:hidden">
-      <Link href="/admin/openbill/quick" className="flex flex-col items-center text-xs">
-        <Plus className="h-5 w-5" />
-        <span>เปิดบิล</span>
-      </Link>
-      <Link href="/admin/orders" className="flex flex-col items-center text-xs">
-        <ClipboardList className="h-5 w-5" />
-        <span>ออเดอร์</span>
-      </Link>
-      <Link href="/admin/chat" className="flex flex-col items-center text-xs">
-        <MessageCircle className="h-5 w-5" />
-        <span>แชท</span>
-      </Link>
-        <Link href="/admin/broadcast" className="flex flex-col items-center text-xs">
-          <Megaphone className="h-5 w-5" />
-          <span>บรอดแคสต์</span>
-        </Link>
-        <Link href="/admin/analytics" className="flex flex-col items-center text-xs">
-          <BarChart3 className="h-5 w-5" />
-          <span>สถิติ</span>
-        </Link>
-      <Link href="/admin/settings" className="flex flex-col items-center text-xs">
-        <Settings className="h-5 w-5" />
-        <span>ตั้งค่า</span>
-      </Link>
+      {adminRoutes
+        .filter(r => quickPaths.includes(r.href))
+        .map(({ href, label, icon: Icon }) => (
+          <Link key={href} href={href} className="flex flex-col items-center text-xs">
+            {Icon && <Icon className="h-5 w-5" />}
+            <span>{label}</span>
+          </Link>
+        ))}
     </nav>
   )
 }

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
   Bolt,
   UserCog,
 } from "lucide-react"
+import { adminRoutes } from "@/components/admin/admin-nav"
 import clsx from "clsx"
 import { mockNotifications } from "@/lib/mock-notifications"
 import {
@@ -38,34 +39,6 @@ import { useEffect, useState } from "react"
 import { useAuth } from "@/contexts/auth-context"
 import { canAccess } from "@/lib/mock-roles"
 
-const navItems = [
-  { href: "/admin/dashboard", label: "แดชบอร์ด", icon: Home, feature: "dashboard" },
-  { href: "/admin/orders", label: "คำสั่งซื้อ", icon: ShoppingCart, feature: "inventory" },
-  { href: "/admin/products", label: "สินค้า", icon: Package, feature: "inventory" },
-  { href: "/admin/inventory", label: "สต็อก", icon: Layers, feature: "inventory" },
-  { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "inventory" },
-  { href: "/admin/coupons", label: "คูปอง", icon: Percent, feature: "inventory" },
-  { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText, feature: "inventory" },
-  { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell, feature: "inventory" },
-  { href: "/admin/chat", label: "แชท", icon: MessageCircle, feature: "chat" },
-  { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText, feature: "logs" },
-  { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List, feature: "logs" },
-  { href: "/admin/analytics", label: "สถิติ", icon: BarChart3, feature: "analytics" },
-  { href: "/admin/broadcast", label: "บรอดแคสต์", icon: Megaphone, feature: "broadcast" },
-  { href: "/admin/claims", label: "เคลม", icon: ShieldCheck, feature: "claims" },
-  { href: "/admin/collections", label: "คอลเลกชัน", icon: Folder, feature: "collections" },
-  { href: "/admin/media", label: "มีเดีย", icon: Image, feature: "media" },
-  { href: "/admin/reviews", label: "รีวิว", icon: Star, feature: "reviews" },
-  { href: "/admin/supply-tracker", label: "สต็อกภายใน", icon: Boxes, feature: "supply" },
-  { href: "/admin/unpaid", label: "ค้างจ่าย", icon: Wallet, feature: "unpaid" },
-  { href: "/admin/faq", label: "คำถามพบบ่อย", icon: HelpCircle, feature: "faq" },
-  { href: "/admin/feedback", label: "ความคิดเห็น", icon: MailQuestion, feature: "feedback" },
-  { href: "/admin/campaign-insight", label: "ข้อมูลแคมเปญ", icon: Target, feature: "campaigns" },
-  { href: "/admin/campaigns/summary", label: "สรุปแคมเปญ", icon: Flag, feature: "campaigns" },
-  { href: "/admin/bills/fast", label: "เปิดบิลด่วน", icon: Bolt, feature: "fastBills" },
-  { href: "/admin/users", label: "ผู้ใช้", icon: UserCog, feature: "users" },
-  { href: "/admin/logs", label: "บันทึก", icon: FileText, feature: "logs" },
-]
 
 export default function Sidebar({ className = "" }: { className?: string }) {
   const pathname = usePathname()
@@ -83,7 +56,7 @@ export default function Sidebar({ className = "" }: { className?: string }) {
         แอดมิน
       </div>
       <nav className="flex-1 space-y-1 px-2 py-4">
-        {navItems.filter(item => canAccess(user?.role, item.feature)).map(({ href, label, icon: Icon }) => {
+        {adminRoutes.filter(item => canAccess(user?.role, item.feature)).map(({ href, label, icon: Icon }) => {
           const active = pathname === href || pathname.startsWith(`${href}/`)
           const badge = href === "/admin/notifications" ? count : 0
           return (

--- a/components/admin/admin-nav.ts
+++ b/components/admin/admin-nav.ts
@@ -1,0 +1,73 @@
+import {
+  Home,
+  ShoppingCart,
+  Package,
+  Layers,
+  Users,
+  Percent,
+  Bell,
+  MessageCircle,
+  FileText,
+  List,
+  BarChart3,
+  Megaphone,
+  ShieldCheck,
+  Folder,
+  Image,
+  Star,
+  Boxes,
+  Wallet,
+  HelpCircle,
+  MailQuestion,
+  Target,
+  Flag,
+  Bolt,
+  UserCog,
+  Plus,
+  Map,
+  Settings,
+} from "lucide-react"
+
+export interface AdminRoute {
+  href: string
+  label: string
+  icon?: any
+  feature?: string
+  
+}
+
+export const adminRoutes: AdminRoute[] = [
+  { href: "/admin/dashboard", label: "แดชบอร์ด", icon: Home, feature: "dashboard" },
+  { href: "/admin/orders", label: "คำสั่งซื้อ", icon: ShoppingCart, feature: "inventory" },
+  { href: "/admin/products", label: "สินค้า", icon: Package, feature: "inventory" },
+  { href: "/admin/inventory", label: "สต็อก", icon: Layers, feature: "inventory" },
+  { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "inventory" },
+  { href: "/admin/coupons", label: "คูปอง", icon: Percent, feature: "inventory" },
+  { href: "/admin/quotes", label: "ใบเสนอราคา", icon: FileText, feature: "inventory" },
+  { href: "/admin/notifications", label: "แจ้งเตือน", icon: Bell, feature: "inventory" },
+  { href: "/admin/chat", label: "แชท", icon: MessageCircle, feature: "chat" },
+  { href: "/admin/chat-insight", label: "บิลแชท", icon: FileText, feature: "logs" },
+  { href: "/admin/chat-activity", label: "กิจกรรมแชท", icon: List, feature: "logs" },
+  { href: "/admin/analytics", label: "สถิติ", icon: BarChart3, feature: "analytics" },
+  { href: "/admin/broadcast", label: "บรอดแคสต์", icon: Megaphone, feature: "broadcast" },
+  { href: "/admin/claims", label: "เคลม", icon: ShieldCheck, feature: "claims" },
+  { href: "/admin/collections", label: "คอลเลกชัน", icon: Folder, feature: "collections" },
+  { href: "/admin/media", label: "มีเดีย", icon: Image, feature: "media" },
+  { href: "/admin/reviews", label: "รีวิว", icon: Star, feature: "reviews" },
+  { href: "/admin/supply-tracker", label: "สต็อกภายใน", icon: Boxes, feature: "supply" },
+  { href: "/admin/unpaid", label: "ค้างจ่าย", icon: Wallet, feature: "unpaid" },
+  { href: "/admin/faq", label: "คำถามพบบ่อย", icon: HelpCircle, feature: "faq" },
+  { href: "/admin/feedback", label: "ความคิดเห็น", icon: MailQuestion, feature: "feedback" },
+  { href: "/admin/campaign-insight", label: "ข้อมูลแคมเปญ", icon: Target, feature: "campaigns" },
+  { href: "/admin/campaigns/summary", label: "สรุปแคมเปญ", icon: Flag, feature: "campaigns" },
+  { href: "/admin/bills/fast", label: "เปิดบิลด่วน", icon: Bolt, feature: "fastBills" },
+  { href: "/admin/users", label: "ผู้ใช้", icon: UserCog, feature: "users" },
+  { href: "/admin/logs", label: "บันทึก", icon: FileText, feature: "logs" },
+  { href: "/admin/fabrics", label: "ผ้า", icon: Folder },
+  { href: "/admin/ai-tools", label: "เครื่องมือ AI", icon: Bolt },
+  { href: "/chat", label: "แชท", icon: MessageCircle },
+  { href: "/admin/feature-map", label: "แผนที่ฟีเจอร์", icon: Map },
+  { href: "/admin/menu", label: "เมนู", icon: List },
+  { href: "/admin/openbill/quick", label: "เปิดบิล", icon: Plus },
+  { href: "/admin/settings", label: "ตั้งค่า", icon: Settings },
+]


### PR DESCRIPTION
## Summary
- add shared admin route config
- use admin route config in Sidebar and QuickActionBar
- use admin route config in AdminDashboard

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6878daf698708325939b5421c33a4411