### PR TITLE
Unify bill routes

### DIFF
--- a/app/b/[id]/page.tsx
+++ b/app/b/[id]/page.tsx
@@ -1,19 +1,5 @@
-import QRCode from "react-qr-code"
-import { mockOrders } from "@/lib/mock-orders"
+import { redirect } from "next/navigation"
 
 export default function BillPage({ params }: { params: { id: string } }) {
-  const order = mockOrders.find(o => o.id === params.id)
-  if (!order) return <div className="p-4 text-red-500">ไม่พบคำสั่งซื้อ</div>
-
-  const billUrl = `https://elfcover.vercel.app/b/${order.id}`
-
-  return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-bold">บิลคำสั่งซื้อ #{order.id}</h1>
-      <p>ยอดรวม: <strong>{order.total} บาท</strong></p>
-      <QRCode value={billUrl} />
-      <p className="text-sm text-gray-400">ลูกค้าสามารถสแกน QR หรือกดลิงก์ด้านล่าง</p>
-      <a href={billUrl} className="underline text-blue-600">{billUrl}</a>
-    </div>
-  )
+  redirect(`/bill/${params.id}`)
 }

--- a/app/chat-bill/[id]/page.tsx
+++ b/app/chat-bill/[id]/page.tsx
@@ -1,52 +1,5 @@
-"use client"
-import { useEffect, useState } from 'react'
-import { getChatBill, loadChatBills } from '@/lib/mock-chat-bills'
-import { Navbar } from '@/components/navbar'
-import { Footer } from '@/components/footer'
-import { useParams } from 'next/navigation'
+import { redirect } from 'next/navigation'
 
-export default function ChatBillPage() {
-  const params = useParams<{ id: string }>()
-  const id = params.id
-  const [bill, setBill] = useState(() => getChatBill(id))
-  useEffect(() => {
-    loadChatBills()
-    setBill(getChatBill(id))
-  }, [id])
-
-  if (!bill) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p>ไม่พบบิลนี้</p>
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex flex-col min-h-screen">
-      <Navbar />
-      <div className="flex-1 container mx-auto px-4 py-8 space-y-6">
-        <h1 className="text-2xl font-bold text-center">
-          บิลสำหรับคุณ {bill.fbName} จากแชทเพจ
-        </h1>
-        <div className="border rounded-lg p-4 space-y-2 max-w-xl mx-auto">
-          {bill.items.map((it) => (
-            <div key={it.productId} className="flex justify-between">
-              <span>{it.name}</span>
-              <span>฿{it.price.toLocaleString()}</span>
-            </div>
-          ))}
-          <div className="flex justify-between border-t pt-2 font-semibold">
-            <span>ส่วนลด</span>
-            <span>-฿{bill.discount.toLocaleString()}</span>
-          </div>
-          <div className="flex justify-between font-bold">
-            <span>ยอดรวม</span>
-            <span>฿{bill.total.toLocaleString()}</span>
-          </div>
-        </div>
-      </div>
-      <Footer />
-    </div>
-  )
+export default function ChatBillPage({ params }: { params: { id: string } }) {
+  redirect(`/bill/${params.id}`)
 }

--- a/app/public/bill/[publicLink]/page.tsx
+++ b/app/public/bill/[publicLink]/page.tsx
@@ -131,6 +131,14 @@ export default function PublicBillPage({ params }: PublicBillPageProps) {
             <BillPreview order={mappedOrder} />
           </CardContent>
         </Card>
+        <p className="text-center mt-4">
+          <Link
+            href={`/bill/${mappedOrder.id}`}
+            className="text-primary underline"
+          >
+            เปิดบิลแบบเต็ม
+          </Link>
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- consolidate `/bill/[id]` as main bill route
- redirect legacy `/b/[id]` and `/chat-bill/[id]` paths
- show simple order and chat bill layouts inside `/bill/[id]`
- link public bill page to full bill view

## Testing
- `pnpm eslint`

------
https://chatgpt.com/codex/tasks/task_e_68791f2e4d1083258b9179fe30eb9cf2