### PR TITLE
Create shared admin store

### DIFF
--- a/contexts/admin-collections-context.tsx
+++ b/contexts/admin-collections-context.tsx
@@ -1,47 +1,16 @@
 "use client"
 
-import { createContext, useContext, type ReactNode } from "react"
-import { useLocalStorage } from "@/hooks/use-local-storage"
-import { mockCollections } from "@/lib/mock-collections"
+import { type ReactNode } from "react"
+import { AdminStoreProvider, useAdminStore } from "@/contexts/admin-store-context"
 import type { Collection } from "@/lib/mock-collections"
 
-interface AdminCollectionsContextValue {
-  collections: Collection[]
-  addCollection: (data: Omit<Collection, "id">) => void
-  updateCollection: (id: string, data: Partial<Collection>) => void
-  deleteCollection: (id: string) => void
-}
-
-const AdminCollectionsContext = createContext<AdminCollectionsContextValue | null>(null)
-
 export function AdminCollectionsProvider({ children }: { children: ReactNode }) {
-  const [collections, setCollections] = useLocalStorage<Collection[]>("admin-collections", mockCollections)
-
-  const addCollection = (data: Omit<Collection, "id">) => {
-    const newCollection: Collection = { id: Date.now().toString(), ...data }
-    setCollections((prev) => [...prev, newCollection])
-  }
-
-  const updateCollection = (id: string, data: Partial<Collection>) => {
-    setCollections((prev) => prev.map((c) => (c.id === id ? { ...c, ...data } : c)))
-  }
-
-  const deleteCollection = (id: string) => {
-    setCollections((prev) => prev.filter((c) => c.id !== id))
-  }
-
-  return (
-    <AdminCollectionsContext.Provider
-      value={{ collections, addCollection, updateCollection, deleteCollection }}
-    >
-      {children}
-    </AdminCollectionsContext.Provider>
-  )
+  return <AdminStoreProvider>{children}</AdminStoreProvider>
 }
 
 export function useAdminCollections() {
-  const ctx = useContext(AdminCollectionsContext)
-  if (!ctx) throw new Error("useAdminCollections must be used within AdminCollectionsProvider")
-  return ctx
+  const store = useAdminStore()
+  const { collections, addCollection, updateCollection, deleteCollection } = store
+  return { collections, addCollection, updateCollection, deleteCollection }
 }
 

--- a/contexts/admin-product-groups-context.tsx
+++ b/contexts/admin-product-groups-context.tsx
@@ -1,43 +1,15 @@
 "use client"
 
-import { createContext, useContext, type ReactNode } from 'react'
-import { useLocalStorage } from '@/hooks/use-local-storage'
-import { mockProductGroups, type ProductGroup } from '@/lib/mock-product-groups'
-
-interface AdminProductGroupsContextValue {
-  groups: ProductGroup[]
-  addGroup: (data: Omit<ProductGroup, 'id'>) => void
-  updateGroup: (id: string, data: Partial<ProductGroup>) => void
-  deleteGroup: (id: string) => void
-}
-
-const AdminProductGroupsContext = createContext<AdminProductGroupsContextValue | null>(null)
+import { type ReactNode } from 'react'
+import { AdminStoreProvider, useAdminStore } from '@/contexts/admin-store-context'
+import { type ProductGroup } from '@/lib/mock-product-groups'
 
 export function AdminProductGroupsProvider({ children }: { children: ReactNode }) {
-  const [groups, setGroups] = useLocalStorage<ProductGroup[]>('admin-product-groups', mockProductGroups)
-
-  const addGroup = (data: Omit<ProductGroup, 'id'>) => {
-    const newGroup: ProductGroup = { id: Date.now().toString(), ...data }
-    setGroups(prev => [...prev, newGroup])
-  }
-
-  const updateGroup = (id: string, data: Partial<ProductGroup>) => {
-    setGroups(prev => prev.map(g => (g.id === id ? { ...g, ...data } : g)))
-  }
-
-  const deleteGroup = (id: string) => {
-    setGroups(prev => prev.filter(g => g.id !== id))
-  }
-
-  return (
-    <AdminProductGroupsContext.Provider value={{ groups, addGroup, updateGroup, deleteGroup }}>
-      {children}
-    </AdminProductGroupsContext.Provider>
-  )
+  return <AdminStoreProvider>{children}</AdminStoreProvider>
 }
 
 export function useAdminProductGroups() {
-  const ctx = useContext(AdminProductGroupsContext)
-  if (!ctx) throw new Error('useAdminProductGroups must be used within AdminProductGroupsProvider')
-  return ctx
+  const store = useAdminStore()
+  const { groups, addGroup, updateGroup, deleteGroup } = store
+  return { groups, addGroup, updateGroup, deleteGroup }
 }

--- a/contexts/admin-products-context.tsx
+++ b/contexts/admin-products-context.tsx
@@ -1,55 +1,16 @@
 "use client"
 
-import { createContext, useContext, type ReactNode } from "react"
-import { useLocalStorage } from "@/hooks/use-local-storage"
-import { mockProducts } from "@/lib/mock-products"
+import { type ReactNode } from "react"
+import { AdminStoreProvider, useAdminStore } from "@/contexts/admin-store-context"
 import type { Product } from "@/types/product"
-import { addAdminLog } from "@/lib/mock-admin-logs"
-
-interface AdminProductsContextValue {
-  products: Product[]
-  addProduct: (data: Omit<Product, "id">) => void
-  updateProduct: (id: string, data: Partial<Product>) => void
-  deleteProduct: (id: string) => void
-}
-
-const AdminProductsContext = createContext<AdminProductsContextValue | null>(null)
 
 export function AdminProductsProvider({ children }: { children: ReactNode }) {
-  const [products, setProducts] = useLocalStorage<Product[]>("admin-products", mockProducts)
-
-  const addProduct = (data: Omit<Product, "id">) => {
-    const newProduct: Product = {
-      id: Date.now().toString(),
-      status: "active",
-      ...data,
-    }
-    setProducts((prev) => [...prev, newProduct])
-    addAdminLog(`add product ${newProduct.id}`, 'mockAdminId')
-  }
-
-  const updateProduct = (id: string, data: Partial<Product>) => {
-    setProducts((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)))
-    addAdminLog(`update product ${id}`, 'mockAdminId')
-  }
-
-  const deleteProduct = (id: string) => {
-    setProducts((prev) => prev.filter((p) => p.id !== id))
-    addAdminLog(`delete product ${id}`, 'mockAdminId')
-  }
-
-  return (
-    <AdminProductsContext.Provider
-      value={{ products, addProduct, updateProduct, deleteProduct }}
-    >
-      {children}
-    </AdminProductsContext.Provider>
-  )
+  return <AdminStoreProvider>{children}</AdminStoreProvider>
 }
 
 export function useAdminProducts() {
-  const ctx = useContext(AdminProductsContext)
-  if (!ctx) throw new Error("useAdminProducts must be used within AdminProductsProvider")
-  return ctx
+  const store = useAdminStore()
+  const { products, addProduct, updateProduct, deleteProduct } = store
+  return { products, addProduct, updateProduct, deleteProduct }
 }
 

--- a/contexts/admin-store-context.tsx
+++ b/contexts/admin-store-context.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+import { mockProducts } from "@/lib/mock-products"
+import { mockCollections, type Collection } from "@/lib/mock-collections"
+import { mockProductGroups, type ProductGroup } from "@/lib/mock-product-groups"
+import type { Product } from "@/types/product"
+import { addAdminLog } from "@/lib/mock-admin-logs"
+
+interface AdminStoreState {
+  products: Product[]
+  collections: Collection[]
+  groups: ProductGroup[]
+}
+
+interface AdminStore extends AdminStoreState {
+  addProduct: (data: Omit<Product, "id">) => void
+  updateProduct: (id: string, data: Partial<Product>) => void
+  deleteProduct: (id: string) => void
+  addCollection: (data: Omit<Collection, "id">) => void
+  updateCollection: (id: string, data: Partial<Collection>) => void
+  deleteCollection: (id: string) => void
+  addGroup: (data: Omit<ProductGroup, "id">) => void
+  updateGroup: (id: string, data: Partial<ProductGroup>) => void
+  deleteGroup: (id: string) => void
+}
+
+const AdminStoreContext = createContext<AdminStore | null>(null)
+
+const DEFAULT_STATE: AdminStoreState = {
+  products: mockProducts,
+  collections: mockCollections,
+  groups: mockProductGroups,
+}
+
+export function AdminStoreProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useLocalStorage<AdminStoreState>(
+    "admin-store",
+    DEFAULT_STATE
+  )
+
+  const addProduct = (data: Omit<Product, "id">) => {
+    const newProduct: Product = {
+      id: Date.now().toString(),
+      status: "active",
+      ...data,
+    }
+    setState((prev) => ({ ...prev, products: [...prev.products, newProduct] }))
+    addAdminLog(`add product ${newProduct.id}`, "mockAdminId")
+  }
+
+  const updateProduct = (id: string, data: Partial<Product>) => {
+    setState((prev) => ({
+      ...prev,
+      products: prev.products.map((p) => (p.id === id ? { ...p, ...data } : p)),
+    }))
+    addAdminLog(`update product ${id}`, "mockAdminId")
+  }
+
+  const deleteProduct = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      products: prev.products.filter((p) => p.id !== id),
+    }))
+    addAdminLog(`delete product ${id}`, "mockAdminId")
+  }
+
+  const addCollection = (data: Omit<Collection, "id">) => {
+    const newCollection: Collection = { id: Date.now().toString(), ...data }
+    setState((prev) => ({
+      ...prev,
+      collections: [...prev.collections, newCollection],
+    }))
+  }
+
+  const updateCollection = (id: string, data: Partial<Collection>) => {
+    setState((prev) => ({
+      ...prev,
+      collections: prev.collections.map((c) =>
+        c.id === id ? { ...c, ...data } : c
+      ),
+    }))
+  }
+
+  const deleteCollection = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      collections: prev.collections.filter((c) => c.id !== id),
+    }))
+  }
+
+  const addGroup = (data: Omit<ProductGroup, "id">) => {
+    const newGroup: ProductGroup = { id: Date.now().toString(), ...data }
+    setState((prev) => ({ ...prev, groups: [...prev.groups, newGroup] }))
+  }
+
+  const updateGroup = (id: string, data: Partial<ProductGroup>) => {
+    setState((prev) => ({
+      ...prev,
+      groups: prev.groups.map((g) => (g.id === id ? { ...g, ...data } : g)),
+    }))
+  }
+
+  const deleteGroup = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      groups: prev.groups.filter((g) => g.id !== id),
+    }))
+  }
+
+  return (
+    <AdminStoreContext.Provider
+      value={{
+        ...state,
+        addProduct,
+        updateProduct,
+        deleteProduct,
+        addCollection,
+        updateCollection,
+        deleteCollection,
+        addGroup,
+        updateGroup,
+        deleteGroup,
+      }}
+    >
+      {children}
+    </AdminStoreContext.Provider>
+  )
+}
+
+export function useAdminStore() {
+  const ctx = useContext(AdminStoreContext)
+  if (!ctx) throw new Error("useAdminStore must be used within AdminStoreProvider")
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add `admin-store-context` that manages collections, products and groups in one place
- refactor existing admin context files to use the shared store instead of their own local storage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687942b6816c8325811ee118bac0105d