### PR TITLE
Secure mobile admin route

### DIFF
--- a/app/mobile-home/page.tsx
+++ b/app/mobile-home/page.tsx
@@ -2,6 +2,7 @@
 import EmotionBanner from "@/components/EmotionBanner"
 import WalkthroughModal from "@/components/WalkthroughModal"
 import FallbackCenter from "@/components/FallbackCenter"
+import { useAdminGuard } from "@/contexts/use-admin-guard"
 
 let MenuGrid: React.ComponentType | null = null
 try {
@@ -10,13 +11,37 @@ try {
   MenuGrid = null
 }
 
-const mockUser = { hasSeenIntro: false }
 
 export default function MobileHomePage() {
+  const { loading, isAdmin, conflict } = useAdminGuard()
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p>กำลังตรวจสอบสิทธิ์...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (conflict) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>session conflict detected</p>
+      </div>
+    )
+  }
+
+  if (!isAdmin) {
+    return null
+  }
+
   return (
     <div className="space-y-4 py-4">
       <EmotionBanner />
-      {!mockUser.hasSeenIntro && <WalkthroughModal />}
+      <WalkthroughModal />
       {MenuGrid ? <MenuGrid /> : <FallbackCenter title="โหลดเมนูไม่สำเร็จ ลองรีเฟรช" />}
     </div>
   )

--- a/components/RedirectMobileHome.tsx
+++ b/components/RedirectMobileHome.tsx
@@ -2,17 +2,19 @@
 import { useEffect } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useAuth } from "@/contexts/auth-context"
 
 export default function RedirectMobileHome() {
   const isMobile = useIsMobile()
+  const { isAuthenticated } = useAuth()
   const pathname = usePathname()
   const router = useRouter()
 
   useEffect(() => {
-    if (isMobile && pathname === "/") {
+    if (isMobile && pathname === "/" && isAuthenticated) {
       router.replace("/mobile-home")
     }
-  }, [isMobile, pathname, router])
+  }, [isMobile, isAuthenticated, pathname, router])
 
   return null
 }


### PR DESCRIPTION
## Summary
- gate `/mobile-home` behind admin auth
- only redirect to mobile home when logged in

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68796c0212b883258aeb9ae09711819d