### PR TITLE
Add env example and README setup step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_CHATWOOT_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 !chatwoot/.env.example
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Continue building your app on:
 
 ## Environment Variables
 
+Before starting the app, copy the example environment file and fill in your own values:
+
+```bash
+cp .env.example .env
+```
+
 Real data is fetched from Supabase when the following variables are provided:
 
 - `NEXT_PUBLIC_SUPABASE_URL` – your Supabase project URL


### PR DESCRIPTION
## Summary
- add `.env.example` with Supabase and Chatwoot placeholders
- allow `.env.example` via `.gitignore`
- document copying env file in README

## Testing
- `pnpm test`
- `pnpm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_6879bcc422f88325be9b7f280b61bdef