### PR TITLE
Remove chatwoot from vitest exclude

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    exclude: [...configDefaults.exclude, 'chatwoot/**'],
+    exclude: [...configDefaults.exclude],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- drop `chatwoot/**` from vitest exclude list

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6879cdd0861c832585e4acae15c2d3ab