### PR TITLE
Add fallback utilities

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,86 +1,23 @@
 "use client"
 
 import Link from "next/link"
+import { Search } from "lucide-react"
 import { Button } from "@/components/ui/buttons/button"
-import { Home, Search, ArrowLeft } from "lucide-react"
-import { addChatActivity, loadChatActivity } from "@/lib/mock-chat-activity"
-import { useAuth } from "@/contexts/auth-context"
+import EmptyState from "@/components/ui/EmptyState"
 
 export default function NotFound() {
-  const { user, guestId } = useAuth()
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50">
-      <div className="text-center space-y-8 px-4">
-        {/* 404 Illustration */}
-        <div className="relative">
-          <div className="text-9xl font-bold text-gray-200 select-none">404</div>
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="w-32 h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center">
-              <Search className="h-16 w-16 text-white" />
-            </div>
-          </div>
-        </div>
-
-        {/* Error Message */}
-        <div className="space-y-4">
-          <h1 className="text-4xl font-bold text-gray-900">ไม่พบหน้าที่คุณค้นหา</h1>
-          <p className="text-xl text-gray-600 max-w-md mx-auto">ขออภัย หน้าที่คุณกำลังมองหาอาจถูกย้าย ลบ หรือไม่มีอยู่จริง</p>
-        </div>
-
-        {/* Action Buttons */}
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Button
-            onClick={() => {
-              if (typeof window !== "undefined") {
-                window.history.back()
-              }
-            }}
-            variant="outline"
-            size="lg"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            กลับหน้าก่อนหน้า
-          </Button>
-
+    <div className="min-h-screen flex items-center justify-center">
+      <EmptyState
+        icon={<Search className="h-10 w-10 text-muted-foreground" />}
+        title="ไม่พบหน้าที่คุณค้นหา"
+        description="ขออภัย หน้าที่คุณเปิดอาจถูกย้ายหรือลบไปแล้ว"
+        action={
           <Link href="/">
-            <Button size="lg">
-              <Home className="mr-2 h-4 w-4" />
-              กลับหน้าแรก
-            </Button>
+            <Button>กลับหน้าแรก</Button>
           </Link>
-        </div>
-
-        {/* Quick Links */}
-        <div className="pt-8 border-t border-gray-200">
-          <p className="text-gray-600 mb-4">หรือลองดูหน้าเหล่านี้:</p>
-          <div className="flex flex-wrap gap-2 justify-center">
-            <Link href="/products">
-              <Button variant="ghost" size="sm">
-                สินค้าทั้งหมด
-              </Button>
-            </Link>
-            <Link href="/about">
-              <Button variant="ghost" size="sm">
-                เกี่ยวกับเรา
-              </Button>
-            </Link>
-            <Link href="/contact">
-              <Button variant="ghost" size="sm">
-                ติดต่อเรา
-              </Button>
-            </Link>
-            <Link
-              href="/chat"
-              onClick={() => {
-                loadChatActivity()
-                addChatActivity(user?.id || guestId!, "open_chat")
-              }}
-            >
-              <Button variant="ghost" size="sm">แชทสด</Button>
-            </Link>
-          </div>
-        </div>
-      </div>
+        }
+      />
     </div>
   )
 }

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,5 +1,8 @@
 "use client"
 import React from "react"
+import EmptyState from "./ui/EmptyState"
+import { Button } from "@/components/ui/buttons/button"
+import { AlertTriangle } from "lucide-react"
 
 export default class ErrorBoundary extends React.Component<{
   children: React.ReactNode
@@ -25,15 +28,12 @@ export default class ErrorBoundary extends React.Component<{
     if ((this.state as any).hasError) {
       return (
         <div className="min-h-screen flex items-center justify-center">
-          <div className="text-center space-y-2">
-            <p>เกิดปัญหาชั่วคราว</p>
-            <button
-              className="px-4 py-2 rounded bg-primary text-white"
-              onClick={this.handleRefresh}
-            >
-              Refresh
-            </button>
-          </div>
+          <EmptyState
+            icon={<AlertTriangle className="h-8 w-8 text-red-600" />}
+            title="เกิดปัญหาชั่วคราว"
+            description="โปรดลองรีเฟรชหน้านี้"
+            action={<Button onClick={this.handleRefresh}>Refresh</Button>}
+          />
         </div>
       )
     }

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+export interface EmptyStateProps {
+  icon?: ReactNode
+  title?: ReactNode
+  description?: ReactNode
+  action?: ReactNode
+  className?: string
+}
+
+export default function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center text-center space-y-4 py-8", className)}>
+      {icon && <div className="text-5xl">{icon}</div>}
+      {title && <h2 className="text-lg font-semibold">{title}</h2>}
+      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      {action}
+    </div>
+  )
+}

--- a/components/ui/LoadingSpinner.tsx
+++ b/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils"
+
+export default function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent",
+        className,
+      )}
+    />
+  )
+}

--- a/components/ui/UnderConstruction.tsx
+++ b/components/ui/UnderConstruction.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link"
+import { Construction } from "lucide-react"
+import { Button } from "@/components/ui/buttons/button"
+import EmptyState from "./EmptyState"
+
+interface UnderConstructionProps {
+  message?: string
+  backHref?: string
+}
+
+export default function UnderConstruction({
+  message = "หน้านี้อยู่ระหว่างการพัฒนา",
+  backHref = "/",
+}: UnderConstructionProps) {
+  return (
+    <EmptyState
+      icon={<Construction className="h-10 w-10 text-yellow-600" />}
+      title="อยู่ระหว่างการพัฒนา"
+      description={message}
+      action={
+        <Link href={backHref}>
+          <Button>กลับหน้าแรก</Button>
+        </Link>
+      }
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- update custom 404 page
- refactor `ErrorBoundary` to use new fallback component
- add reusable `EmptyState` component
- add `LoadingSpinner` util
- add `UnderConstruction` notice

## Testing
- `pnpm test` *(fails: require() of ES module not supported)*

------
https://chatgpt.com/codex/tasks/task_e_687a2272d6a483259755fc6c7f5335d4