### PR TITLE
Implement dashboard fabrics management

### DIFF
--- a/app/dashboard/fabrics/page.tsx
+++ b/app/dashboard/fabrics/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+import { useState } from 'react'
+import FabricCard from '@/components/fabric/FabricCard'
+import AddNewFabricButton from '@/components/fabric/AddNewFabricButton'
+import EmptyState from '@/components/EmptyState'
+import { fabrics as mockFabrics, Fabric } from '@/mock/fabrics'
+
+export default function DashboardFabricsPage() {
+  const [items, setItems] = useState<Fabric[]>([...mockFabrics])
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ลายผ้า</h1>
+        <AddNewFabricButton onAdd={() => setItems([...mockFabrics])} />
+      </div>
+      {items.length > 0 ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {items.map((fabric) => (
+            <FabricCard key={fabric.id} fabric={fabric} onUpdated={() => setItems([...mockFabrics])} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState title="ยังไม่มีลายผ้าในระบบ" />
+      )}
+    </div>
+  )
+}

--- a/components/fabric/AddNewFabricButton.tsx
+++ b/components/fabric/AddNewFabricButton.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import type { Fabric } from '@/mock/fabrics'
+import { addFabric } from '@/mock/fabrics'
+
+export default function AddNewFabricButton({ onAdd }: { onAdd?: (fabric: Fabric) => void }) {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+
+  const handleSubmit = () => {
+    if (!name.trim()) return
+    const fabric = addFabric({ name, imageUrl })
+    setName('')
+    setImageUrl('')
+    setOpen(false)
+    onAdd?.(fabric)
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>เพิ่มลายผ้าใหม่</Button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-80 space-y-4 rounded bg-white p-4">
+            <h2 className="text-lg font-bold">เพิ่มลายผ้าใหม่</h2>
+            <Input placeholder="ชื่อผ้า" value={name} onChange={e => setName(e.target.value)} />
+            <Input placeholder="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setOpen(false)}>ยกเลิก</Button>
+              <Button onClick={handleSubmit} disabled={!name.trim()}>บันทึก</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/fabric/EditFabricModal.tsx
+++ b/components/fabric/EditFabricModal.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import type { Fabric } from '@/mock/fabrics'
+import { updateFabric } from '@/mock/fabrics'
+
+interface Props {
+  fabric: Fabric
+  open: boolean
+  onClose: () => void
+  onUpdated?: (fabric: Fabric) => void
+}
+
+export default function EditFabricModal({ fabric, open, onClose, onUpdated }: Props) {
+  const [name, setName] = useState(fabric.name)
+  const [imageUrl, setImageUrl] = useState(fabric.imageUrl)
+
+  useEffect(() => {
+    if (open) {
+      setName(fabric.name)
+      setImageUrl(fabric.imageUrl)
+    }
+  }, [open, fabric])
+
+  const handleSave = () => {
+    const updated = updateFabric(fabric.id, { name, imageUrl })
+    if (updated) onUpdated?.(updated)
+    onClose()
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-80 space-y-4 rounded bg-white p-4">
+        <h2 className="text-lg font-bold">แก้ไขลายผ้า</h2>
+        <Input placeholder="ชื่อผ้า" value={name} onChange={e => setName(e.target.value)} />
+        <Input placeholder="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>ยกเลิก</Button>
+          <Button onClick={handleSave}>บันทึก</Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/fabric/FabricCard.tsx
+++ b/components/fabric/FabricCard.tsx
@@ -1,0 +1,33 @@
+"use client"
+import Image from 'next/image'
+import { useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { Edit } from 'lucide-react'
+import EditFabricModal from './EditFabricModal'
+import type { Fabric } from '@/mock/fabrics'
+
+export default function FabricCard({ fabric, onUpdated }: { fabric: Fabric; onUpdated?: (fabric: Fabric) => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="border rounded overflow-hidden bg-white">
+      <div className="relative aspect-square">
+        <Image src={fabric.imageUrl} alt={fabric.name} fill className="object-cover" />
+      </div>
+      <div className="flex items-center justify-between p-2 text-sm">
+        <span className="font-medium">{fabric.name}</span>
+        <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+          <Edit className="w-4 h-4" />
+        </Button>
+      </div>
+      <EditFabricModal
+        fabric={fabric}
+        open={open}
+        onClose={() => setOpen(false)}
+        onUpdated={(f) => {
+          setOpen(false)
+          onUpdated?.(f)
+        }}
+      />
+    </div>
+  )
+}

--- a/mock/fabrics.ts
+++ b/mock/fabrics.ts
@@ -1,0 +1,30 @@
+export interface Fabric {
+  id: string
+  name: string
+  imageUrl: string
+}
+
+export const fabrics: Fabric[] = [
+  {
+    id: 'fab-1',
+    name: 'Soft Linen',
+    imageUrl: '/images/039.jpg',
+  },
+  {
+    id: 'fab-2',
+    name: 'Cozy Cotton',
+    imageUrl: '/images/041.jpg',
+  },
+]
+
+export function addFabric(data: Omit<Fabric, 'id'>): Fabric {
+  const fabric: Fabric = { id: `fab-${Date.now()}`, ...data }
+  fabrics.unshift(fabric)
+  return fabric
+}
+
+export function updateFabric(id: string, data: Partial<Omit<Fabric, 'id'>>): Fabric | undefined {
+  const fabric = fabrics.find(f => f.id === id)
+  if (fabric) Object.assign(fabric, data)
+  return fabric
+}


### PR DESCRIPTION
## Summary
- mock fabric data state
- add dashboard fabrics page
- add button for creating new fabrics
- enable editing fabrics via modal
- show each fabric with `FabricCard`

## Testing
- `npm test`
- `npm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_687a2b46d47c832589e40a2413e8cc90