### PR TITLE
Add dashboard orders page with filters and mobile cards

### DIFF
--- a/app/dashboard/orders/page.tsx
+++ b/app/dashboard/orders/page.tsx
@@ -1,0 +1,103 @@
+"use client"
+import { useState } from 'react'
+import Link from 'next/link'
+import { orders as mockOrders, SimpleOrder } from '@/mock/orders'
+import OrderCard from '@/components/order/OrderCard'
+import EmptyState from '@/components/EmptyState'
+import { Input } from '@/components/ui/inputs/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function DashboardOrdersPage() {
+  const [orders, setOrders] = useState<SimpleOrder[]>([...mockOrders])
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [search, setSearch] = useState('')
+
+  const filtered = orders.filter(o => {
+    const matchStatus = statusFilter === 'all' || o.status === statusFilter
+    const term = search.toLowerCase()
+    const matchSearch = o.id.toLowerCase().includes(term) || o.customer.toLowerCase().includes(term)
+    return matchStatus && matchSearch
+  })
+
+  const handleCancel = (id: string) => {
+    if (confirm('ยืนยันยกเลิกคำสั่งซื้อ?')) {
+      setOrders(prev => prev.map(o => (o.id === id ? { ...o, status: 'Cancelled' } : o)))
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">คำสั่งซื้อ</h1>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div className="flex gap-2">
+          <select
+            className="border rounded-md p-2"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            <option value="Pending">Pending</option>
+            <option value="Paid">Paid</option>
+            <option value="Cancelled">Cancelled</option>
+          </select>
+          <Input
+            placeholder="ค้นหา..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {filtered.length > 0 ? (
+        <>
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>รหัส</TableHead>
+                  <TableHead>ลูกค้า</TableHead>
+                  <TableHead>สถานะ</TableHead>
+                  <TableHead>ยอดรวม</TableHead>
+                  <TableHead className="text-right">การจัดการ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((order) => (
+                  <TableRow key={order.id}>
+                    <TableCell>{order.id}</TableCell>
+                    <TableCell>{order.customer}</TableCell>
+                    <TableCell>{order.status}</TableCell>
+                    <TableCell>฿{order.total.toLocaleString()}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <Link href={`/dashboard/orders/${order.id}`}>
+                          <Button variant="outline" size="sm">ดู</Button>
+                        </Link>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleCancel(order.id)}
+                        >
+                          ยกเลิก
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="md:hidden space-y-4">
+            {filtered.map((order) => (
+              <OrderCard key={order.id} order={order} onCancel={handleCancel} />
+            ))}
+          </div>
+        </>
+      ) : (
+        <EmptyState title="ยังไม่มีคำสั่งซื้อในระบบ" />
+      )}
+    </div>
+  )
+}

--- a/components/order/OrderCard.tsx
+++ b/components/order/OrderCard.tsx
@@ -1,0 +1,32 @@
+"use client"
+import Link from 'next/link'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import type { SimpleOrder } from '@/mock/orders'
+
+export default function OrderCard({ order, onCancel }: { order: SimpleOrder; onCancel?: (id: string) => void }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">คำสั่งซื้อ {order.id}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <p>ลูกค้า: {order.customer}</p>
+        <p>สถานะ: {order.status}</p>
+        <p>ยอดรวม: ฿{order.total.toLocaleString()}</p>
+        <div className="flex gap-2 pt-2">
+          <Link href={`/dashboard/orders/${order.id}`}>
+            <Button variant="outline" size="sm">ดู</Button>
+          </Link>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onCancel?.(order.id)}
+          >
+            ยกเลิก
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/mock/orders.ts
+++ b/mock/orders.ts
@@ -1,0 +1,12 @@
+export interface SimpleOrder {
+  id: string
+  customer: string
+  status: 'Pending' | 'Paid' | 'Cancelled'
+  total: number
+}
+
+export const orders: SimpleOrder[] = [
+  { id: 'ORD-001', customer: 'John Doe', status: 'Paid', total: 2990 },
+  { id: 'ORD-002', customer: 'Jane Smith', status: 'Pending', total: 3980 },
+  { id: 'ORD-003', customer: 'Bob Johnson', status: 'Cancelled', total: 1500 },
+]


### PR DESCRIPTION
## Summary
- create mock order list
- add OrderCard component for mobile layout
- build `/dashboard/orders` with filters, search and actions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a318ed8888325b4bf78955954d2eb