### PR TITLE
Implement dashboard collection & fabric management

### DIFF
--- a/app/dashboard/collections/[id]/page.tsx
+++ b/app/dashboard/collections/[id]/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useParams } from 'next/navigation'
+import { getCollection, updateCollection } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function EditCollectionPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const collection = getCollection(params.id)
+
+  const [name, setName] = useState(collection?.name || '')
+
+  if (!collection) {
+    return <div className="p-8">ไม่พบคอลเลกชันนี้</div>
+  }
+
+  const handleSave = () => {
+    if (!name.trim()) return
+    updateCollection(collection.id, { name })
+    router.push('/dashboard/collections')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">แก้ไขคอลเลกชัน</h1>
+      <div className="space-y-2 w-64">
+        <Input value={name} onChange={e => setName(e.target.value)} />
+        <Button onClick={handleSave} disabled={!name.trim()}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/collections/new/page.tsx
+++ b/app/dashboard/collections/new/page.tsx
@@ -1,0 +1,27 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { addCollection } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function NewCollectionPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+
+  const handleSave = () => {
+    if (!name.trim()) return
+    addCollection({ name })
+    router.push('/dashboard/collections')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สร้างคอลเลกชันใหม่</h1>
+      <div className="space-y-2 w-64">
+        <Input placeholder="ชื่อคอลเลกชัน" value={name} onChange={e => setName(e.target.value)} />
+        <Button onClick={handleSave} disabled={!name.trim()}>สร้างคอลเลกชัน</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/collections/page.tsx
+++ b/app/dashboard/collections/page.tsx
@@ -1,0 +1,81 @@
+"use client"
+import { useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { collections, softDeleteCollection, reorderCollections } from '@/mock/collections'
+import { fabrics } from '@/mock/fabrics'
+import { Button } from '@/components/ui/buttons/button'
+import ModalWrapper from '@/components/ui/ModalWrapper'
+
+export default function DashboardCollectionsPage() {
+  const [items, setItems] = useState(() => collections.filter(c => !c.isDeleted).sort((a,b) => a.order - b.order))
+  const [preview, setPreview] = useState<string | null>(null)
+  const [dragId, setDragId] = useState<string | null>(null)
+
+  const handleDelete = (id: string) => {
+    softDeleteCollection(id)
+    setItems(collections.filter(c => !c.isDeleted).sort((a,b) => a.order - b.order))
+  }
+
+  const handleDragStart = (id: string) => setDragId(id)
+  const handleDrop = (id: string) => {
+    if (!dragId || dragId === id) return
+    const arr = items.slice()
+    const from = arr.findIndex(c => c.id === dragId)
+    const to = arr.findIndex(c => c.id === id)
+    const [moved] = arr.splice(from,1)
+    arr.splice(to,0,moved)
+    reorderCollections(arr.map(c => c.id))
+    setItems(arr)
+    setDragId(null)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">คอลเลกชัน</h1>
+        <Link href="/dashboard/collections/new"><Button>เพิ่มคอลเลกชัน</Button></Link>
+      </div>
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+        {items.map(col => {
+          const count = fabrics.filter(f => f.collectionId === col.id).length
+          return (
+            <div
+              key={col.id}
+              draggable
+              onDragStart={() => handleDragStart(col.id)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => handleDrop(col.id)}
+              className="border rounded p-4 space-y-2 bg-white"
+            >
+              <h2 className="font-bold">{col.name}</h2>
+              <p className="text-sm text-muted-foreground">{count} ลายผ้า</p>
+              <div className="flex gap-2">
+                <Button size="sm" variant="outline" onClick={() => setPreview(col.id)}>ดูตัวอย่าง</Button>
+                <Link href={`/dashboard/fabrics?collection=${col.id}`} className="flex-1">
+                  <Button size="sm" variant="outline" className="w-full">ดูผ้า</Button>
+                </Link>
+                <Button size="sm" variant="outline" onClick={() => handleDelete(col.id)}>ลบคอลเลกชัน</Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <ModalWrapper open={!!preview} onClose={() => setPreview(null)}>
+        <div className="w-80 space-y-4">
+          {preview && fabrics.filter(f => f.collectionId === preview).length > 0 ? (
+            fabrics
+              .filter(f => f.collectionId === preview)
+              .map(f => (
+                <div key={f.id} className="relative aspect-square w-full border rounded overflow-hidden">
+                  <Image src={f.imageUrl} alt={f.name} fill className="object-cover" />
+                </div>
+              ))
+          ) : (
+            <p>ไม่มีลายผ้าในคอลเลกชันนี้</p>
+          )}
+        </div>
+      </ModalWrapper>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/[id]/page.tsx
+++ b/app/dashboard/fabrics/[id]/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { fabrics, updateFabric } from '@/mock/fabrics'
+import { collections } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function EditFabricPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const fabric = fabrics.find(f => f.id === params.id)
+  const [name, setName] = useState(fabric?.name || '')
+  const [imageUrl, setImageUrl] = useState(fabric?.imageUrl || '')
+  const [collectionId, setCollectionId] = useState(fabric?.collectionId || '')
+
+  if (!fabric) {
+    return <div className="p-8">ไม่พบลายผ้านี้</div>
+  }
+
+  const handleSave = () => {
+    if (!name.trim() || !imageUrl.trim() || !collectionId) return
+    updateFabric(fabric.id, { name, imageUrl, collectionId })
+    router.push('/dashboard/fabrics')
+  }
+
+  const activeCollections = collections.filter(c => !c.isDeleted)
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">แก้ไขผ้า</h1>
+      <div className="space-y-2 w-64">
+        <Input value={name} onChange={e => setName(e.target.value)} />
+        <Input value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <select value={collectionId} onChange={e => setCollectionId(e.target.value)} className="w-full border rounded p-2">
+          <option value="">เลือกคอลเลกชัน</option>
+          {activeCollections.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+        <Button onClick={handleSave} disabled={!name.trim() || !imageUrl.trim() || !collectionId}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/import/page.tsx
+++ b/app/dashboard/fabrics/import/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import JSZip from 'jszip'
+import { addFabric } from '@/mock/fabrics'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function ImportFabricPage() {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [error, setError] = useState('')
+
+  const handleImport = async () => {
+    if (!file) return
+    if (!file.name.endsWith('.zip')) {
+      setError('ไฟล์ต้องเป็น .zip')
+      return
+    }
+    try {
+      const zip = await JSZip.loadAsync(await file.arrayBuffer())
+      const entries = Object.keys(zip.files).filter(n => /\.(jpg|png|webp)$/i.test(n))
+      if (entries.length === 0) {
+        setError('ไม่พบไฟล์ภาพใน zip')
+        return
+      }
+      let i = 1
+      for (const name of entries) {
+        const fabricName = `fabric_${String(i).padStart(3,'0')}`
+        addFabric({ name: fabricName, imageUrl: `/mock/${name}`, collectionId: '' })
+        i++
+      }
+      router.push('/dashboard/fabrics')
+    } catch (e) {
+      setError('เกิดข้อผิดพลาดในการอ่านไฟล์')
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">นำเข้าลายผ้าจาก ZIP</h1>
+      <input type="file" accept=".zip" onChange={e => { setError(''); setFile(e.target.files?.[0] || null) }} />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <Button onClick={handleImport} disabled={!file}>นำเข้า</Button>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/new/page.tsx
+++ b/app/dashboard/fabrics/new/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { addFabric } from '@/mock/fabrics'
+import { collections } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function NewFabricPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [collectionId, setCollectionId] = useState('')
+
+  const handleSave = () => {
+    if (!name.trim() || !imageUrl.trim() || !collectionId) return
+    addFabric({ name, imageUrl, collectionId })
+    router.push('/dashboard/fabrics')
+  }
+
+  const activeCollections = collections.filter(c => !c.isDeleted)
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">เพิ่มผ้าใหม่</h1>
+      <div className="space-y-2 w-64">
+        <Input placeholder="ชื่อผ้า" value={name} onChange={e => setName(e.target.value)} />
+        <Input placeholder="รูป URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <select value={collectionId} onChange={e => setCollectionId(e.target.value)} className="w-full border rounded p-2">
+          <option value="">เลือกคอลเลกชัน</option>
+          {activeCollections.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+        <Button onClick={handleSave} disabled={!name.trim() || !imageUrl.trim() || !collectionId}>เพิ่มผ้า</Button>
+      </div>
+    </div>
+  )
+}

--- a/mock/collections.ts
+++ b/mock/collections.ts
@@ -1,0 +1,44 @@
+export interface Collection {
+  id: string
+  name: string
+  order: number
+  isDeleted?: boolean
+}
+
+export const collections: Collection[] = [
+  { id: 'col-1', name: 'Classic', order: 0 },
+  { id: 'col-2', name: 'Modern', order: 1 },
+]
+
+export function addCollection(data: Omit<Collection, 'id' | 'order' | 'isDeleted'>): Collection {
+  const collection: Collection = {
+    id: `col-${Date.now()}`,
+    order: collections.length,
+    ...data,
+  }
+  collections.push(collection)
+  return collection
+}
+
+export function updateCollection(id: string, data: Partial<Omit<Collection, 'id'>>): Collection | undefined {
+  const col = collections.find(c => c.id === id)
+  if (col) Object.assign(col, data)
+  return col
+}
+
+export function softDeleteCollection(id: string) {
+  const col = collections.find(c => c.id === id)
+  if (col) col.isDeleted = true
+}
+
+export function getCollection(id: string): Collection | undefined {
+  return collections.find(c => c.id === id)
+}
+
+export function reorderCollections(ids: string[]) {
+  ids.forEach((id, index) => {
+    const col = collections.find(c => c.id === id)
+    if (col) col.order = index
+  })
+  collections.sort((a, b) => a.order - b.order)
+}

--- a/mock/fabrics.ts
+++ b/mock/fabrics.ts
@@ -2,6 +2,7 @@ export interface Fabric {
   id: string
   name: string
   imageUrl: string
+  collectionId?: string
 }
 
 export const fabrics: Fabric[] = [
@@ -9,11 +10,13 @@ export const fabrics: Fabric[] = [
     id: 'fab-1',
     name: 'Soft Linen',
     imageUrl: '/images/039.jpg',
+    collectionId: 'col-1',
   },
   {
     id: 'fab-2',
     name: 'Cozy Cotton',
     imageUrl: '/images/041.jpg',
+    collectionId: 'col-2',
   },
 ]
 
@@ -23,7 +26,10 @@ export function addFabric(data: Omit<Fabric, 'id'>): Fabric {
   return fabric
 }
 
-export function updateFabric(id: string, data: Partial<Omit<Fabric, 'id'>>): Fabric | undefined {
+export function updateFabric(
+  id: string,
+  data: Partial<Omit<Fabric, 'id'>>,
+): Fabric | undefined {
   const fabric = fabrics.find(f => f.id === id)
   if (fabric) Object.assign(fabric, data)
   return fabric

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.6.0",
     "input-otp": "1.4.2",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.1.0)
@@ -2035,6 +2038,9 @@ packages:
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -2595,6 +2601,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
@@ -2609,6 +2618,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -2741,6 +2753,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2799,6 +2814,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2812,6 +2830,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3004,6 +3025,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3109,6 +3133,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3208,6 +3235,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3278,6 +3308,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3316,6 +3349,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -3416,6 +3452,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -5583,6 +5622,8 @@ snapshots:
 
   confusing-browser-globals@1.0.11: {}
 
+  core-util-is@1.0.3: {}
+
   crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
@@ -6294,6 +6335,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   immer@10.1.1: {}
 
   import-fresh@3.3.1:
@@ -6304,6 +6347,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   input-otp@1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -6440,6 +6485,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6517,6 +6564,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6531,6 +6585,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -6712,6 +6770,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6797,6 +6857,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -6884,6 +6946,16 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -7000,6 +7072,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -7044,6 +7118,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   sharp@0.33.5:
     dependencies:
@@ -7200,6 +7276,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add mock collections data helper
- extend fabric mock with collectionId
- create dashboard collection list with reorder, delete and preview modal
- add new/edit pages for collections and fabrics
- support fabric import from zip using jszip
- provide form for creating new fabrics

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a56ea67548325b7405fff32a76330