### PR TITLE
Add analytics dashboard page

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,72 @@
+"use client"
+import { useMemo, useState } from "react"
+import SalesChart from "@/components/dashboard/SalesChart"
+import { orders as ordersMock } from "@/mock/orders"
+import { mockBills as billsMock } from "@/mock/bills"
+import { formatCurrency } from "@/lib/utils"
+
+export default function DashboardAnalyticsPage() {
+  const [range, setRange] = useState(7)
+  const paidOrders = ordersMock.filter(o => o.status === "Paid").length
+  const totalOrders = ordersMock.length
+
+  const salesToday = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10)
+    return billsMock
+      .filter(b => b.status === "paid" && b.createdAt.slice(0, 10) === today)
+      .reduce((s, b) => s + b.items.reduce((n, i) => n + i.price * i.quantity, 0) + b.shipping, 0)
+  }, [])
+
+  const salesMonth = useMemo(() => {
+    const month = new Date().toISOString().slice(0, 7)
+    return billsMock
+      .filter(b => b.status === "paid" && b.createdAt.slice(0, 7) === month)
+      .reduce((s, b) => s + b.items.reduce((n, i) => n + i.price * i.quantity, 0) + b.shipping, 0)
+  }, [])
+
+  const chartData = useMemo(() => {
+    const now = new Date()
+    const start = new Date()
+    start.setDate(now.getDate() - range + 1)
+    const days: { date: string; total: number }[] = []
+    for (let d = new Date(start); d <= now; d.setDate(d.getDate() + 1)) {
+      const dateStr = d.toISOString().slice(5, 10)
+      const total = billsMock
+        .filter(b => b.status === "paid" && b.createdAt.slice(0, 10) === d.toISOString().slice(0, 10))
+        .reduce((s, b) => s + b.items.reduce((n, i) => n + i.price * i.quantity, 0) + b.shipping, 0)
+      days.push({ date: dateStr, total })
+    }
+    return days
+  }, [range])
+
+  if (ordersMock.length === 0 && billsMock.length === 0) {
+    return (
+      <div className="container mx-auto py-8">
+        <p className="text-center text-muted-foreground">ไม่มีข้อมูลในช่วงเวลานี้</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">สถิติ</h1>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm">ชำระเงินแล้ว {paidOrders} / {totalOrders} คำสั่งซื้อ</p>
+        <select
+          className="rounded-md border p-2"
+          value={range}
+          onChange={e => setRange(parseInt(e.target.value))}
+        >
+          <option value={1}>วันนี้</option>
+          <option value={7}>7 วัน</option>
+          <option value={30}>30 วัน</option>
+        </select>
+      </div>
+      <div className="text-sm text-muted-foreground">
+        <p>ยอดขายวันนี้: {formatCurrency(salesToday)}</p>
+        <p>ยอดขายเดือนนี้: {formatCurrency(salesMonth)}</p>
+      </div>
+      {chartData.length > 0 && <SalesChart data={chartData} />}
+    </div>
+  )
+}

--- a/components/dashboard/SalesChart.tsx
+++ b/components/dashboard/SalesChart.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import React from "react"
+
+class ChartBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  state = { hasError: false }
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+  render() {
+    if (this.state.hasError) return null
+    return this.props.children
+  }
+}
+
+export default function SalesChart({ data }: { data: { date: string; total: number }[] }) {
+  if (!data.length) return null
+  return (
+    <ChartBoundary>
+      <ChartContainer
+        className="h-60 w-full"
+        config={{ sales: { color: "hsl(221, 83%, 53%)" } }}
+      >
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Line type="monotone" dataKey="total" stroke="var(--color-sales)" />
+        </LineChart>
+      </ChartContainer>
+    </ChartBoundary>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `SalesChart` reusable component for analytics
- add dashboard analytics page with mock sales data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a6674b9508325a5a8b7a4cbf14239