### PR TITLE
Implement dashboard tools and enable lint

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,95 @@
+"use client"
+import { useState, useMemo } from 'react'
+import SalesChart from '@/components/dashboard/SalesChart'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { mockOrders } from '@/lib/mock-orders'
+import { mockBills } from '@/mock/bills'
+import { getMockNow } from '@/lib/mock-date'
+
+export default function AnalyticsPage() {
+  const [range, setRange] = useState<'1' | '7' | '30'>('7')
+  const now = getMockNow()
+
+  const billsInRange = useMemo(() => {
+    const days = Number(range)
+    return mockBills.filter(b => {
+      const diff = now.getTime() - new Date(b.createdAt).getTime()
+      return diff <= days * 24 * 60 * 60 * 1000
+    })
+  }, [range, now])
+
+  const dailyData = useMemo(() => {
+    const days = Number(range)
+    return Array.from({ length: days }).map((_, i) => {
+      const d = new Date(now)
+      d.setDate(d.getDate() - (days - 1 - i))
+      const total = billsInRange
+        .filter(b => new Date(b.createdAt).toDateString() === d.toDateString())
+        .reduce((s, b) =>
+          s + b.items.reduce((t, it) => t + it.price * it.quantity, 0) + b.shipping,
+        0)
+      return {
+        name: d.toLocaleDateString('th-TH', { month: 'short', day: 'numeric' }),
+        total,
+      }
+    })
+  }, [billsInRange, range, now])
+
+  const salesToday = billsInRange
+    .filter(b => new Date(b.createdAt).toDateString() === now.toDateString())
+    .reduce((s, b) => s + b.items.reduce((t, it) => t + it.price * it.quantity, 0) + b.shipping, 0)
+
+  const salesMonth = billsInRange
+    .filter(b => b.createdAt.slice(0,7) === now.toISOString().slice(0,7))
+    .reduce((s, b) => s + b.items.reduce((t, it) => t + it.price * it.quantity, 0) + b.shipping, 0)
+
+  const paidOrders = mockOrders.filter(o => o.status === 'paid')
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">สถิติยอดขาย</h1>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>วันนี้</CardTitle>
+          </CardHeader>
+          <CardContent>
+            ฿{salesToday.toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>เดือนนี้</CardTitle>
+          </CardHeader>
+          <CardContent>
+            ฿{salesMonth.toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>ชำระแล้ว</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {paidOrders.length}/{mockOrders.length} ออเดอร์
+          </CardContent>
+        </Card>
+      </div>
+      <div className="space-y-2">
+        <div className="flex justify-end">
+          <Select value={range} onValueChange={setRange}>
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1">วันนี้</SelectItem>
+              <SelectItem value="7">7 วัน</SelectItem>
+              <SelectItem value="30">30 วัน</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <SalesChart data={dailyData} />
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/collections/import/page.tsx
+++ b/app/dashboard/collections/import/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import JSZip from 'jszip'
+import { collections, addCollection } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+
+interface Preview { name: string }
+
+export default function ImportCollectionsPage() {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [error, setError] = useState('')
+  const [preview, setPreview] = useState<Preview[]>([])
+
+  const handleRead = async () => {
+    if (!file) return
+    if (!file.name.endsWith('.zip')) {
+      setError('ไฟล์ต้องเป็น .zip')
+      return
+    }
+    try {
+      const zip = await JSZip.loadAsync(await file.arrayBuffer())
+      const names = new Set<string>()
+      Object.values(zip.files).forEach(f => {
+        const [dir] = f.name.split('/')
+        if (dir) names.add(dir)
+      })
+      const arr = Array.from(names)
+      if (arr.length === 0) {
+        setError('ไม่พบข้อมูลใน zip')
+        return
+      }
+      setPreview(arr.map((n, i) => ({ name: n || `collection_${String(i+1).padStart(3,'0')}` })))
+    } catch {
+      setError('อ่านไฟล์ไม่สำเร็จ')
+    }
+  }
+
+  const handleSave = () => {
+    preview.forEach(p => addCollection({ name: p.name }))
+    router.push('/dashboard/collections')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">นำเข้าคอลเลกชัน</h1>
+      <input type="file" accept=".zip" onChange={e => { setError(''); setPreview([]); setFile(e.target.files?.[0] || null) }} />
+      <Button onClick={handleRead} disabled={!file}>อ่านไฟล์</Button>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {preview.length > 0 && (
+        <div className="space-y-2">
+          <ul className="list-disc pl-5">
+            {preview.map(p => <li key={p.name}>{p.name}</li>)}
+          </ul>
+          <Button onClick={handleSave}>บันทึก</Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/batch-edit/page.tsx
+++ b/app/dashboard/fabrics/batch-edit/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { fabrics as mockFabrics, updateFabric } from '@/mock/fabrics'
+import { collections } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Checkbox } from '@/components/ui/checkbox'
+
+export default function BatchEditFabricsPage() {
+  const router = useRouter()
+  const [selected, setSelected] = useState<string[]>([])
+  const [collectionId, setCollectionId] = useState('')
+
+  const handleToggle = (id: string, checked: boolean) => {
+    setSelected(prev => checked ? [...prev, id] : prev.filter(i => i !== id))
+  }
+
+  const handleSave = () => {
+    selected.forEach(id => updateFabric(id, { collectionId }))
+    router.push('/dashboard/fabrics')
+  }
+
+  const activeCollections = collections.filter(c => !c.isDeleted)
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">แก้ไขหลายรายการ</h1>
+      <div className="grid gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {mockFabrics.map(f => (
+          <label key={f.id} className="flex items-center space-x-2 border p-2 rounded">
+            <Checkbox checked={selected.includes(f.id)} onCheckedChange={c => handleToggle(f.id, !!c)} />
+            <span>{f.name}</span>
+          </label>
+        ))}
+      </div>
+      <div className="space-y-2 w-64">
+        <select value={collectionId} onChange={e => setCollectionId(e.target.value)} className="w-full border rounded p-2">
+          <option value="">เลือกคอลเลกชัน</option>
+          {activeCollections.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+        <Button onClick={handleSave} disabled={selected.length === 0 || !collectionId}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/tools/quick-status/page.tsx
+++ b/app/dashboard/tools/quick-status/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+import Link from 'next/link'
+import { mockOrders } from '@/lib/mock-orders'
+import { mockBills } from '@/mock/bills'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function QuickStatusPage() {
+  const latestOrder = mockOrders[0]
+  const latestBill = mockBills[0]
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สถานะด่วน</h1>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card className="text-sm">
+          <CardHeader>
+            <CardTitle>ออเดอร์ล่าสุด</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {latestOrder ? (
+              <div className="space-y-1">
+                <div>{latestOrder.id}</div>
+                <div>{latestOrder.customerName}</div>
+                <div>฿{latestOrder.total.toLocaleString()}</div>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">ไม่มีข้อมูล</p>
+            )}
+          </CardContent>
+        </Card>
+        <Card className="text-sm">
+          <CardHeader>
+            <CardTitle>บิลล่าสุด</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {latestBill ? (
+              <div className="space-y-1">
+                <div>{latestBill.id}</div>
+                <div>{latestBill.customer}</div>
+                <div>{latestBill.status}</div>
+              </div>
+            ) : (
+              <p className="text-muted-foreground">ไม่มีข้อมูล</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <div className="flex gap-2">
+        <Link href="/dashboard/fabrics"><Button size="sm">Fabrics</Button></Link>
+        <Link href="/dashboard/orders"><Button size="sm">Orders</Button></Link>
+        <Link href="/dashboard/bill/BILL-001"><Button size="sm">Bills</Button></Link>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/SalesChart.tsx
+++ b/components/dashboard/SalesChart.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts'
+import { Card, CardContent } from '@/components/ui/cards/card'
+import FallbackCenter from '@/components/FallbackCenter'
+
+interface SalesChartProps {
+  data: { name: string; total: number }[]
+}
+
+export default function SalesChart({ data }: SalesChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center h-40">
+          <FallbackCenter title="ไม่มีข้อมูลในช่วงเวลานี้" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  try {
+    return (
+      <Card>
+        <CardContent className="h-40">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ left: 0, right: 0 }}>
+              <XAxis dataKey="name" />
+              <YAxis hide />
+              <Tooltip />
+              <Bar dataKey="total" fill="#0ea5e9" name="ยอดขาย" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    )
+  } catch {
+    return null
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ const compat = new FlatCompat({ baseDirectory: import.meta.dirname })
 
 export default [
   {
-    ignores: ['**'],
+    ignores: ['node_modules/**', 'dist/**', '.next/**'],
   },
   ...compat.extends('airbnb-base'),
   ...compat.extends('plugin:react/recommended'),


### PR DESCRIPTION
## Summary
- enable eslint by removing global ignore
- add reusable `SalesChart` component
- build analytics dashboard with sales summary
- add fabrics batch edit page
- support importing collections from zip
- add quick status page with latest order and bill

## Testing
- `pnpm run eslint` *(fails: many lint errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a651e8f3083259076364b1071ec0c