### PR TITLE
Unify mock fabrics naming

### DIFF
--- a/app/admin/analytics/favorites/page.tsx
+++ b/app/admin/analytics/favorites/page.tsx
@@ -5,11 +5,11 @@ import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/buttons/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { useLocalStorage } from '@/hooks/use-local-storage'
-import { mockFabrics } from '@/lib/mock-fabrics'
+import { fabrics } from '@/lib/mock-fabrics'
 
 export default function AdminFavoritesAnalytics() {
   const [counts] = useLocalStorage<Record<string, number>>('favorite-counts', {})
-  const ranking = [...mockFabrics].map((f) => ({
+  const ranking = [...fabrics].map((f) => ({
     ...f,
     count: counts[f.slug] || 0,
   })).sort((a, b) => b.count - a.count)

--- a/app/admin/fabrics/page.tsx
+++ b/app/admin/fabrics/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { useAuth } from "@/contexts/auth-context"
 import { supabase } from "@/lib/supabase"
-import { getFabrics as fetchMockFabrics } from "@/lib/mock-fabrics"
+import { getFabrics } from "@/lib/mock-fabrics"
 import EmptyState from "@/components/EmptyState"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AvailabilityTag } from "@/components/AvailabilityTag"
@@ -103,7 +103,7 @@ export default function AdminFabricsPage() {
   useEffect(() => {
     const fetchFabrics = async () => {
       setLoading(true)
-      const data = await fetchMockFabrics()
+      const data = await getFabrics()
       const { data: collectionsData } = await supabase
         ?.from("collections")
         .select("id, name")

--- a/app/bookmarks/all/page.tsx
+++ b/app/bookmarks/all/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { Navbar } from '@/components/navbar'
 import { Footer } from '@/components/footer'
 import { mockBookmarks, Bookmark } from '@/lib/mock-bookmark'
-import { mockFabrics } from '@/lib/mock-fabrics'
+import { fabrics } from '@/lib/mock-fabrics'
 import { mockOrders } from '@/lib/mock-orders'
 
 interface BookmarkView {
@@ -19,7 +19,7 @@ export default function AllBookmarksPage() {
   const items: BookmarkView[] = mockBookmarks
     .map((b) => {
       if (b.type === 'fabric') {
-        const f = mockFabrics.find((f) => f.slug === b.ref)
+        const f = fabrics.find((f) => f.slug === b.ref)
         return f
           ? {
               href: `/fabrics/${f.slug}`,

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -12,7 +12,7 @@ import {
 import { supabase } from "@/lib/supabase"
 import { getCollections } from "@/lib/mock-collections"
 import { WishlistButton } from "@/components/WishlistButton"
-import { mockFabrics } from "@/lib/mock-fabrics"
+import { fabrics } from "@/lib/mock-fabrics"
 import { FabricsList } from "@/components/FabricsList"
 import { CopyPageLinkButton } from "@/components/CopyPageLinkButton"
 import { CollectionStickyBar } from "@/components/CollectionStickyBar"
@@ -53,11 +53,11 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
     }
   }
 
-  const fabrics = mockFabrics.filter((f) => f.collectionSlug === data.slug)
+  const filtered = fabrics.filter((f) => f.collectionSlug === data.slug)
   const reviews = mockFabricReviews.filter((r) =>
-    fabrics.some((f) => f.id === r.fabricId),
+    filtered.some((f) => f.id === r.fabricId),
   )
-  const subtitle = `มีทั้งหมด ${fabrics.length} ลายผ้าในกลุ่มนี้`
+  const subtitle = `มีทั้งหมด ${filtered.length} ลายผ้าในกลุ่มนี้`
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -8,7 +8,7 @@ import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/buttons/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/modals/dialog"
 import { useCompare } from "@/contexts/compare-context"
-import { mockFabrics } from "@/lib/mock-fabrics"
+import { fabrics } from "@/lib/mock-fabrics"
 
 interface Fabric {
   id: string
@@ -26,7 +26,7 @@ export default function ComparePage() {
 
   useEffect(() => {
     setFabrics(
-      mockFabrics
+      fabrics
         .filter((f) => items.includes(f.slug))
         .map((f) => ({ ...f }))
     )

--- a/app/dashboard/fabrics/page.tsx
+++ b/app/dashboard/fabrics/page.tsx
@@ -3,16 +3,16 @@ import { useState } from 'react'
 import FabricCard from '@/components/fabric/FabricCard'
 import AddNewFabricButton from '@/components/fabric/AddNewFabricButton'
 import EmptyState from '@/components/ui/EmptyState'
-import { fabrics as mockFabrics, Fabric } from '@/mock/fabrics'
+import { fabrics, Fabric } from '@/mock/fabrics'
 
 export default function DashboardFabricsPage() {
-  const [items, setItems] = useState<Fabric[]>([...mockFabrics])
+  const [items, setItems] = useState<Fabric[]>([...fabrics])
 
   return (
     <div className="container mx-auto py-8 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">ลายผ้า</h1>
-        <AddNewFabricButton onAdd={() => setItems([...mockFabrics])} />
+        <AddNewFabricButton onAdd={() => setItems([...fabrics])} />
       </div>
       {items.length > 0 ? (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
@@ -20,15 +20,15 @@ export default function DashboardFabricsPage() {
             <FabricCard
               key={fabric.id}
               fabric={fabric}
-              onUpdated={() => setItems([...mockFabrics])}
-              onDelete={() => setItems([...mockFabrics])}
+              onUpdated={() => setItems([...fabrics])}
+              onDelete={() => setItems([...fabrics])}
             />
           ))}
         </div>
       ) : (
         <EmptyState
           title="ยังไม่มีลายผ้าในระบบ"
-          action={<AddNewFabricButton onAdd={() => setItems([...mockFabrics])} />}
+          action={<AddNewFabricButton onAdd={() => setItems([...fabrics])} />}
         />
       )}
     </div>

--- a/app/fabrics/[slug]/page.tsx
+++ b/app/fabrics/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { WishlistButton } from "@/components/WishlistButton"
 import { FavoriteButton } from "@/components/FavoriteButton"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
-import { mockFabrics } from "@/lib/mock-fabrics"
+import { fabrics } from "@/lib/mock-fabrics"
 import { notFound } from "next/navigation"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 import { MessageSquare, Share2, Receipt } from "lucide-react"
@@ -30,7 +30,7 @@ interface Fabric {
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
   if (!supabase) {
-    const fabric = mockFabrics.find((f) => f.slug === params.slug)
+    const fabric = fabrics.find((f) => f.slug === params.slug)
     if (!fabric) return {}
     const title = `${fabric.name} | SofaCover Pro`
     const description = `รายละเอียดลายผ้า ${fabric.name}`
@@ -66,7 +66,7 @@ export default async function FabricDetailPage({ params }: { params: { slug: str
   let collection: { name: string; slug: string } | null = null
 
   if (!supabase) {
-    const f = mockFabrics.find((fab) => fab.slug === params.slug)
+    const f = fabrics.find((fab) => fab.slug === params.slug)
     if (!f) {
       notFound()
     }

--- a/app/fabrics/page.tsx
+++ b/app/fabrics/page.tsx
@@ -3,7 +3,7 @@ import { Footer } from "@/components/footer"
 import { FabricsList } from "@/components/FabricsList"
 import type { Metadata } from "next"
 import { supabase } from "@/lib/supabase"
-import { mockFabrics } from "@/lib/mock-fabrics"
+import { fabrics } from "@/lib/mock-fabrics"
 import { AnalyticsTracker } from "@/components/analytics-tracker"
 
 export const metadata: Metadata = {
@@ -21,9 +21,9 @@ interface Fabric {
 }
 
 export default async function FabricsPage() {
-  let fabrics: Fabric[] = []
+  let items: Fabric[] = []
   if (!supabase) {
-    fabrics = mockFabrics.map((f) => ({
+    items = fabrics.map((f) => ({
       id: f.id,
       slug: f.slug,
       name: f.name,
@@ -44,7 +44,7 @@ export default async function FabricsPage() {
         </div>
       )
     }
-    fabrics = data as Fabric[]
+    items = data as Fabric[]
   }
 
   return (
@@ -52,7 +52,7 @@ export default async function FabricsPage() {
       <Navbar />
       <div className="container mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">แกลเลอรี่ลายผ้า</h1>
-        <FabricsList fabrics={fabrics} />
+        <FabricsList fabrics={items} />
       </div>
       <Footer />
       <AnalyticsTracker event="ViewContent" />

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -5,11 +5,11 @@ import Link from 'next/link'
 import { Navbar } from '@/components/navbar'
 import { Footer } from '@/components/footer'
 import { useFavorites } from '@/contexts/favorites-context'
-import { mockFabrics } from '@/lib/mock-fabrics'
+import { fabrics } from '@/lib/mock-fabrics'
 
 export default function FavoritesPage() {
   const { favorites } = useFavorites()
-  const items = mockFabrics.filter(f => favorites.includes(f.slug))
+  const items = fabrics.filter(f => favorites.includes(f.slug))
 
   return (
     <div className="min-h-screen">

--- a/app/sofa-covers/page.tsx
+++ b/app/sofa-covers/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { Navbar } from '@/components/navbar'
 import { Footer } from '@/components/footer'
 
-const mockFabrics = [
+const fabrics = [
   { id: 1, name: 'สีเทาเข้ม', image: '/images/fabrics/dark-gray.jpg' },
   { id: 2, name: 'สีเบจ', image: '/images/fabrics/beige.jpg' },
   { id: 3, name: 'ลายสก็อต', image: '/images/fabrics/scott.jpg' },
@@ -33,9 +33,9 @@ export default function SofaCoversPage() {
           เลือกผ้าคลุมโซฟาที่เหมาะกับบ้านคุณ ทั้งผ้ายืดหยุ่น กันน้ำ และลายยอดนิยม
         </p>
 
-        {mockFabrics.length > 0 ? (
+        {fabrics.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-            {mockFabrics.map((fabric) => (
+            {fabrics.map((fabric) => (
               <div key={fabric.id} className="border rounded-xl p-4 shadow">
                 <Image
                   src={fabric.image}

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { useWishlist } from "@/contexts/wishlist-context"
-import { mockFabrics } from "@/lib/mock-fabrics"
+import { fabrics } from "@/lib/mock-fabrics"
 import { mockCollections } from "@/lib/mock-collections"
 
 export default function WishlistPage() {
@@ -13,10 +13,10 @@ export default function WishlistPage() {
 
   const items = wishlist
     .map((slug) =>
-      mockFabrics.find((f) => f.slug === slug) ||
+      fabrics.find((f) => f.slug === slug) ||
       mockCollections.find((c) => c.slug === slug),
     )
-    .filter(Boolean) as (typeof mockFabrics[number] | typeof mockCollections[number])[]
+    .filter(Boolean) as (typeof fabrics[number] | typeof mockCollections[number])[]
 
   return (
     <div className="min-h-screen">

--- a/components/FabricSuggestions.tsx
+++ b/components/FabricSuggestions.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { mockFabrics } from '@/lib/mock-fabrics'
+import { fabrics } from '@/lib/mock-fabrics'
 import { mockFabricSimilarity } from '@/lib/mock-fabric-similarity'
 import { recordFabricClick, getFabricPreference } from '@/lib/mock-user-preference'
 
@@ -12,15 +12,15 @@ interface Props {
 }
 
 export function FabricSuggestions({ slug }: Props) {
-  const [items, setItems] = useState<typeof mockFabrics>([])
+  const [items, setItems] = useState<typeof fabrics>([])
 
   useEffect(() => {
     recordFabricClick(slug)
     const prefs = getFabricPreference()
     const similar = mockFabricSimilarity[slug] || []
-    const fabrics = mockFabrics.filter((f) => similar.includes(f.slug))
-    fabrics.sort((a, b) => (prefs[b.slug] || 0) - (prefs[a.slug] || 0))
-    setItems(fabrics.slice(0, 4))
+    const list = fabrics.filter((f) => similar.includes(f.slug))
+    list.sort((a, b) => (prefs[b.slug] || 0) - (prefs[a.slug] || 0))
+    setItems(list.slice(0, 4))
   }, [slug])
 
   if (items.length === 0) return null

--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -93,9 +93,9 @@ describe('getFabrics', () => {
     const from = vi.fn().mockReturnValue({ select })
     vi.doMock('../supabase', () => ({ supabase: { from } }))
 
-    const { getFabrics, mockFabrics } = await import('../mock-fabrics')
+    const { getFabrics, fabrics } = await import('../mock-fabrics')
     const result = await getFabrics()
 
-    expect(result).toEqual(mockFabrics)
+    expect(result).toEqual(fabrics)
   })
 })

--- a/lib/get-fabric-ranking.ts
+++ b/lib/get-fabric-ranking.ts
@@ -1,5 +1,5 @@
 import { mockOrders } from './mock-orders'
-import { mockFabrics } from './mock-fabrics'
+import { fabrics } from './mock-fabrics'
 
 export interface FabricRanking { slug: string; name: string; image: string; count: number }
 
@@ -8,11 +8,11 @@ export function getFabricRanking(): FabricRanking[] {
   mockOrders.forEach(o => {
     o.items.forEach(it => {
       const idx = parseInt(it.productId, 10) - 1
-      const fab = mockFabrics[idx]
+      const fab = fabrics[idx]
       if (fab) counts[fab.slug] = (counts[fab.slug] || 0) + it.quantity
     })
   })
-  const list = mockFabrics.map(f => ({ slug: f.slug, name: f.name, image: f.images[0], count: counts[f.slug] || 0 }))
+  const list = fabrics.map(f => ({ slug: f.slug, name: f.name, image: f.images[0], count: counts[f.slug] || 0 }))
   list.sort((a, b) => b.count - a.count)
   return list.slice(0, 10)
 }

--- a/lib/mock-fabrics.ts
+++ b/lib/mock-fabrics.ts
@@ -12,7 +12,7 @@ export interface Fabric {
   availability: "available" | "out" | "discontinued"
 }
 
-export const mockFabrics: Fabric[] = [
+export const fabrics: Fabric[] = [
   {
     id: 'f01',
     name: 'Soft Linen',
@@ -72,12 +72,12 @@ export const mockFabrics: Fabric[] = [
 
 export async function getFabrics() {
   if (!supabase) {
-    return Promise.resolve(mockFabrics)
+    return Promise.resolve(fabrics)
   }
   const { data, error } = await supabase.from('fabrics').select('*')
   if (error || !data) {
     console.error('Supabase fetch fabrics error', error)
-    return mockFabrics
+    return fabrics
   }
   return data as Fabric[]
 }

--- a/lib/mock-tools.ts
+++ b/lib/mock-tools.ts
@@ -1,12 +1,12 @@
 import { mockProducts } from './mock-products'
 import { mockBills } from './bills'
-import { mockFabrics } from './mock-fabrics'
+import { fabrics } from './mock-fabrics'
 import { downloadJSON } from './mock-export'
 
 export function clearMockData() {
   mockProducts.splice(0, mockProducts.length)
   mockBills.splice(0, mockBills.length)
-  mockFabrics.splice(0, mockFabrics.length)
+  fabrics.splice(0, fabrics.length)
 }
 
 export interface MappingEntry {
@@ -18,7 +18,7 @@ export function getMockMappingPlan(): MappingEntry[] {
   return [
     ...mockBills.map((b) => ({ mockID: b.id, supaID: null })),
     ...mockProducts.map((p) => ({ mockID: p.id, supaID: null })),
-    ...mockFabrics.map((f) => ({ mockID: f.id, supaID: null })),
+    ...fabrics.map((f) => ({ mockID: f.id, supaID: null })),
   ]
 }
 


### PR DESCRIPTION
## Summary
- rename `mockFabrics` export to `fabrics`
- update all imports and references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a897df7f883259023d3bbe5269b59