### PR TITLE
Implement sidebar integration and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Real data is fetched from Supabase when the following variables are provided:
 
 If these variables are absent, the app falls back to built-in mock data.
 
+The notification service uses additional variables:
+
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` – SMTP settings for email
+- `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER` – Twilio SMS credentials
+- `LINE_NOTIFY_TOKEN` – token for sending Line notifications
+
 ## Chatwoot
 
 The store now uses [Chatwoot](https://www.chatwoot.com/) for the customer chat

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,5 +1,4 @@
 "use client"
-// TODO: Ready for UX-001 integration – Sidebar logic isolated and modular
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
@@ -46,8 +45,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-const SIDEBAR_WIDTH = "16rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH = "17rem"
+const SIDEBAR_WIDTH_MOBILE = "19rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 
 type SidebarContext = {
@@ -209,7 +208,7 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear",
+            "duration-300 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-in-out",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -219,7 +218,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex",
+            "duration-300 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-in-out md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/contexts/__tests__/wishlist-context.test.tsx
+++ b/contexts/__tests__/wishlist-context.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { WishlistProvider, useWishlist } from '../wishlist-context'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <WishlistProvider>{children}</WishlistProvider>
+}
+
+describe('WishlistProvider', () => {
+  beforeEach(() => {
+    (globalThis as any).React = React
+    localStorage.clear()
+  })
+
+  it('toggles items in wishlist', () => {
+    const { result } = renderHook(() => useWishlist(), { wrapper })
+    act(() => result.current.toggleWishlist('a'))
+    expect(result.current.wishlist).toContain('a')
+    expect(JSON.parse(localStorage.getItem('wishlist') || '[]')).toContain('a')
+    act(() => result.current.toggleWishlist('a'))
+    expect(result.current.wishlist).not.toContain('a')
+  })
+})

--- a/hooks/__tests__/use-local-storage.test.ts
+++ b/hooks/__tests__/use-local-storage.test.ts
@@ -1,0 +1,23 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLocalStorage } from '../use-local-storage'
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('reads initial value from localStorage', () => {
+    localStorage.setItem('key', JSON.stringify('stored'))
+    const { result } = renderHook(() => useLocalStorage('key', 'fallback'))
+    expect(result.current[0]).toBe('stored')
+  })
+
+  it('writes updates to localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('key', ''))
+    act(() => {
+      result.current[1]('hello')
+    })
+    expect(localStorage.getItem('key')).toBe(JSON.stringify('hello'))
+  })
+})

--- a/lib/notification-service.ts
+++ b/lib/notification-service.ts
@@ -3,6 +3,22 @@ import { mockCustomers } from "./mock-customers"
 import { mockOrders } from "./mock-orders"
 import type { Customer } from "./mock-customers"
 
+function warnMissing(varName: string) {
+  if (!process.env[varName]) {
+    console.warn(`Environment variable ${varName} is not set.`)
+    return true
+  }
+  return false
+}
+
+// Validate notification related environment variables
+warnMissing("SMTP_USER")
+warnMissing("SMTP_PASS")
+warnMissing("TWILIO_ACCOUNT_SID")
+warnMissing("TWILIO_AUTH_TOKEN")
+warnMissing("TWILIO_FROM_NUMBER")
+warnMissing("LINE_NOTIFY_TOKEN")
+
 // Types
 export interface NotificationTemplate {
   id: string

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -7,6 +7,10 @@ let client: SupabaseClient | null = null
 
 if (supabaseUrl && supabaseAnonKey) {
   client = createClient(supabaseUrl, supabaseAnonKey)
+} else {
+  console.warn(
+    'Supabase environment variables are not set; falling back to mock data.'
+  )
 }
 
 export const supabase = client


### PR DESCRIPTION
## Summary
- tweak sidebar dimensions and transitions for UX-001
- warn when Supabase or notification service env vars are missing
- document notification env vars in README
- add unit tests for `useLocalStorage` hook and wishlist context

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687a98694ed88325a81427fc1ade49c2