### PR TITLE
Implement fabric management pages

### DIFF
--- a/app/dashboard/fabrics/[id]/page.tsx
+++ b/app/dashboard/fabrics/[id]/page.tsx
@@ -1,44 +1,36 @@
 "use client"
-import { useState } from 'react'
-import { useRouter, useParams } from 'next/navigation'
-import { fabrics, updateFabric } from '@/mock/fabrics'
-import { collections } from '@/mock/collections'
+import { useParams, useRouter } from 'next/navigation'
+import Image from 'next/image'
+import { fabrics } from '@/mock/fabrics'
 import { Button } from '@/components/ui/buttons/button'
-import { Input } from '@/components/ui/inputs/input'
 
-export default function EditFabricPage() {
-  const params = useParams<{ id: string }>()
+export default function FabricDetailPage() {
+  const { id } = useParams<{ id: string }>()
   const router = useRouter()
-  const fabric = fabrics.find(f => f.id === params.id)
-  const [name, setName] = useState(fabric?.name || '')
-  const [imageUrl, setImageUrl] = useState(fabric?.imageUrl || '')
-  const [collectionId, setCollectionId] = useState(fabric?.collectionId || '')
+  const fabric = fabrics.find(f => f.id === id)
 
-  if (!fabric) {
-    return <div className="p-8">ไม่พบลายผ้านี้</div>
-  }
-
-  const handleSave = () => {
-    if (!name.trim() || !imageUrl.trim() || !collectionId) return
-    updateFabric(fabric.id, { name, imageUrl, collectionId })
-    router.push('/dashboard/fabrics')
-  }
-
-  const activeCollections = collections.filter(c => !c.isDeleted)
+  if (!fabric) return <div className="p-8">กำลังโหลด...</div>
 
   return (
     <div className="container mx-auto py-8 space-y-4">
-      <h1 className="text-2xl font-bold">แก้ไขผ้า</h1>
-      <div className="space-y-2 w-64">
-        <Input value={name} onChange={e => setName(e.target.value)} />
-        <Input value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
-        <select value={collectionId} onChange={e => setCollectionId(e.target.value)} className="w-full border rounded p-2">
-          <option value="">เลือกคอลเลกชัน</option>
-          {activeCollections.map(c => (
-            <option key={c.id} value={c.id}>{c.name}</option>
-          ))}
-        </select>
-        <Button onClick={handleSave} disabled={!name.trim() || !imageUrl.trim() || !collectionId}>บันทึก</Button>
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={() => router.back()}>กลับ</Button>
+        <Button onClick={() => router.push(`/dashboard/fabrics/edit/${id}`)}>แก้ไข</Button>
+      </div>
+      <div className="space-y-2">
+        <div className="relative w-64 h-64">
+          <Image src={fabric.imageUrl} alt={fabric.name} fill className="object-cover rounded" />
+        </div>
+        <h1 className="text-xl font-bold">{fabric.name}</h1>
+        {fabric.variants?.length ? (
+          <ul className="list-disc pl-4 text-sm">
+            {fabric.variants.map((v, i) => (
+              <li key={i}>{v.color} - {v.size}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">ไม่มีตัวเลือก</p>
+        )}
       </div>
     </div>
   )

--- a/app/dashboard/fabrics/add/page.tsx
+++ b/app/dashboard/fabrics/add/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { addFabric } from '@/mock/fabrics'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+interface Variant { color: string; size: string }
+
+export default function AddFabricWithVariantsPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [variants, setVariants] = useState<Variant[]>([])
+  const [color, setColor] = useState('')
+  const [size, setSize] = useState('')
+  const [error, setError] = useState('')
+
+  const addVariant = () => {
+    if (!color.trim() || !size.trim()) {
+      setError('กรอกสีและขนาดให้ครบ')
+      return
+    }
+    setVariants([...variants, { color: color.trim(), size: size.trim() }])
+    setColor('')
+    setSize('')
+    setError('')
+  }
+
+  const handleSave = () => {
+    if (!name.trim() || !imageUrl.trim() || variants.length === 0) {
+      setError('กรอกข้อมูลให้ครบ')
+      return
+    }
+    addFabric({ name, imageUrl, variants })
+    router.push('/dashboard/fabrics')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">เพิ่มผ้าพร้อมตัวเลือก</h1>
+      <div className="space-y-2 w-72">
+        <Input placeholder="ชื่อผ้า" value={name} onChange={e => setName(e.target.value)} />
+        <Input placeholder="รูป URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <div className="flex gap-2">
+          <Input placeholder="สี" value={color} onChange={e => setColor(e.target.value)} />
+          <Input placeholder="ขนาด" value={size} onChange={e => setSize(e.target.value)} />
+          <Button variant="outline" onClick={addVariant}>เพิ่ม</Button>
+        </div>
+        {variants.length > 0 && (
+          <ul className="text-sm list-disc pl-4">
+            {variants.map((v, i) => (
+              <li key={i}>{v.color} - {v.size}</li>
+            ))}
+          </ul>
+        )}
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <Button onClick={handleSave}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/edit/[id]/page.tsx
+++ b/app/dashboard/fabrics/edit/[id]/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { fabrics, updateFabric } from '@/mock/fabrics'
+import { collections } from '@/mock/collections'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+
+export default function EditFabricPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const fabric = fabrics.find(f => f.id === params.id)
+  const [name, setName] = useState(fabric?.name || '')
+  const [imageUrl, setImageUrl] = useState(fabric?.imageUrl || '')
+  const [collectionId, setCollectionId] = useState(fabric?.collectionId || '')
+
+  if (!fabric) {
+    return <div className="p-8">ไม่พบลายผ้านี้</div>
+  }
+
+  const handleSave = () => {
+    if (!name.trim() || !imageUrl.trim() || !collectionId) return
+    updateFabric(fabric.id, { name, imageUrl, collectionId })
+    router.push('/dashboard/fabrics')
+  }
+
+  const activeCollections = collections.filter(c => !c.isDeleted)
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">แก้ไขผ้า</h1>
+      <div className="space-y-2 w-64">
+        <Input value={name} onChange={e => setName(e.target.value)} />
+        <Input value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+        <select value={collectionId} onChange={e => setCollectionId(e.target.value)} className="w-full border rounded p-2">
+          <option value="">เลือกคอลเลกชัน</option>
+          {activeCollections.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+        <Button onClick={handleSave} disabled={!name.trim() || !imageUrl.trim() || !collectionId}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/filter/page.tsx
+++ b/app/dashboard/fabrics/filter/page.tsx
@@ -1,0 +1,38 @@
+"use client"
+import { useState } from 'react'
+import FabricCard from '@/components/fabric/FabricCard'
+import { fabrics } from '@/mock/fabrics'
+import { Checkbox } from '@/components/ui/checkbox'
+
+const colors = ['แดง', 'เขียว', 'น้ำเงิน']
+
+export default function FilterFabricByColorPage() {
+  const [selected, setSelected] = useState<string[]>([])
+
+  const toggle = (c: string) => {
+    setSelected(prev => prev.includes(c) ? prev.filter(i => i !== c) : [...prev, c])
+  }
+
+  const filtered = selected.length === 0 ? fabrics : fabrics.filter(f =>
+    f.variants?.some(v => selected.includes(v.color))
+  )
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">กรองผ้าตามสี</h1>
+      <div className="flex gap-4">
+        {colors.map(c => (
+          <label key={c} className="flex items-center gap-1 text-sm">
+            <Checkbox checked={selected.includes(c)} onCheckedChange={() => toggle(c)} />
+            {c}
+          </label>
+        ))}
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {filtered.map(f => (
+          <FabricCard key={f.id} fabric={f} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/fabrics/gallery/page.tsx
+++ b/app/dashboard/fabrics/gallery/page.tsx
@@ -1,0 +1,25 @@
+"use client"
+import { useState, useEffect } from 'react'
+import FabricCard from '@/components/fabric/FabricCard'
+import { fabrics } from '@/mock/fabrics'
+
+export default function FabricGalleryPage() {
+  const [items, setItems] = useState<typeof fabrics | null>(null)
+
+  useEffect(() => {
+    setItems([...fabrics])
+  }, [])
+
+  if (!items) return <div className="p-8">กำลังโหลด...</div>
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Gallery ลายผ้า</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {items.map(f => (
+          <FabricCard key={f.id} fabric={f} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/mock/fabrics.ts
+++ b/mock/fabrics.ts
@@ -1,8 +1,14 @@
+export interface FabricVariant {
+  color: string
+  size: string
+}
+
 export interface Fabric {
   id: string
   name: string
   imageUrl: string
   collectionId?: string
+  variants?: FabricVariant[]
 }
 
 export const fabrics: Fabric[] = [
@@ -11,12 +17,20 @@ export const fabrics: Fabric[] = [
     name: 'Soft Linen',
     imageUrl: '/images/039.jpg',
     collectionId: 'col-1',
+    variants: [
+      { color: 'แดง', size: 'S' },
+      { color: 'เขียว', size: 'M' },
+    ],
   },
   {
     id: 'fab-2',
     name: 'Cozy Cotton',
     imageUrl: '/images/041.jpg',
     collectionId: 'col-2',
+    variants: [
+      { color: 'น้ำเงิน', size: 'L' },
+      { color: 'แดง', size: 'XL' },
+    ],
   },
 ]
 


### PR DESCRIPTION
## Summary
- add variant support in mock fabrics
- implement add page for fabrics with variants
- add fabric detail page with edit link
- move edit fabric page under /edit
- add color filter and gallery views

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa697d0e883258d78456a643c2788