### PR TITLE
Add mock shipping management pages

### DIFF
--- a/app/dashboard/shipping/page.tsx
+++ b/app/dashboard/shipping/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState } from "react"
+import { shippingOrders } from "@/mock/shipping"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import EmptyState from "@/components/EmptyState"
+
+export default function ShippingListPage() {
+  const [status, setStatus] = useState("all")
+
+  const filtered = shippingOrders.filter(o => status === "all" || o.status === status)
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">รายการจัดส่ง</h1>
+      <select value={status} onChange={e=>setStatus(e.target.value)} className="border rounded p-2">
+        <option value="all">ทั้งหมด</option>
+        <option value="รอพิมพ์">รอพิมพ์</option>
+        <option value="ส่งแล้ว">ส่งแล้ว</option>
+        <option value="ตีกลับ">ตีกลับ</option>
+      </select>
+      {filtered.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>ชื่อ</TableHead>
+              <TableHead>สถานะ</TableHead>
+              <TableHead>Tracking</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map(o => (
+              <TableRow key={o.id}>
+                <TableCell>{o.id}</TableCell>
+                <TableCell>{o.name}</TableCell>
+                <TableCell>{o.status}</TableCell>
+                <TableCell>{o.tracking || '-'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <EmptyState title="ไม่มีข้อมูล" />
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/shipping/print/page.tsx
+++ b/app/dashboard/shipping/print/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState } from "react"
+import { shippingOrders } from "@/mock/shipping"
+import { Button } from "@/components/ui/buttons/button"
+
+export default function PrintShippingLabelPage() {
+  const [selected, setSelected] = useState<string[]>([])
+
+  const toggle = (id: string) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id],
+    )
+  }
+
+  const toPrint = shippingOrders.filter(o => selected.includes(o.id))
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">พิมพ์ใบจ่าหน้า</h1>
+      <div className="space-y-2">
+        {shippingOrders.map(o => (
+          <label key={o.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={selected.includes(o.id)}
+              onChange={() => toggle(o.id)}
+            />
+            {o.id} – {o.name}
+          </label>
+        ))}
+      </div>
+      {toPrint.length > 0 && (
+        <Button onClick={() => window.print()}>พิมพ์</Button>
+      )}
+      <div className="print:block hidden">
+        {toPrint.map(o => (
+          <div key={o.id} className="mb-4 border p-4 w-80">
+            <p className="font-semibold">{o.name}</p>
+            <p className="text-sm whitespace-pre-line">{o.address}</p>
+            <p className="text-sm">โทร {o.phone}</p>
+            <p className="text-sm">Tracking: {o.tracking || '-'}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/shipping/provider/page.tsx
+++ b/app/dashboard/shipping/provider/page.tsx
@@ -1,0 +1,23 @@
+"use client"
+import { useState, useEffect } from "react"
+import { setShippingProvider, getShippingProvider } from "@/mock/shipping"
+
+export default function ShippingProviderPage() {
+  const [provider, setProvider] = useState(getShippingProvider())
+
+  useEffect(() => {
+    setShippingProvider(provider)
+  }, [provider])
+
+  return (
+    <div className="container mx-auto max-w-md space-y-4 py-8">
+      <h1 className="text-2xl font-bold">เลือกผู้ให้บริการขนส่ง</h1>
+      <select value={provider} onChange={e=>setProvider(e.target.value as any)} className="border rounded p-2 w-full">
+        <option value="Kerry">Kerry</option>
+        <option value="Flash">Flash</option>
+        <option value="ปณ.">ปณ.</option>
+      </select>
+      <p className="text-sm text-muted-foreground">เลือกเพื่อบันทึกในเซสชัน mock เท่านั้น</p>
+    </div>
+  )
+}

--- a/app/dashboard/shipping/status/page.tsx
+++ b/app/dashboard/shipping/status/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+import { shippingOrders } from "@/mock/shipping"
+import { CheckCircle, Truck } from "lucide-react"
+
+const statusMap: Record<string, { icon: any; color: string }> = {
+  "กำลังจัดส่ง": { icon: Truck, color: "text-orange-600" },
+  "ถึงแล้ว": { icon: CheckCircle, color: "text-green-600" },
+}
+
+export default function DeliveryStatusPage() {
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">สถานะการจัดส่ง</h1>
+      <div className="space-y-2">
+        {shippingOrders.map(o => {
+          const Info = statusMap[o.deliveryStatus]
+          const Icon = Info.icon
+          return (
+            <div key={o.id} className="flex items-center gap-2">
+              <Icon className={`h-5 w-5 ${Info.color}`} />
+              <span>{o.id} – {o.deliveryStatus}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/shipping/tracking/page.tsx
+++ b/app/dashboard/shipping/tracking/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { useState } from "react"
+import { shippingOrders, addTrackingNumber } from "@/mock/shipping"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { CopyToClipboardButton } from "@/components/CopyToClipboardButton"
+
+export default function AddTrackingPage() {
+  const [orderId, setOrderId] = useState(shippingOrders[0]?.id || "")
+  const [tracking, setTracking] = useState("")
+  const [added, setAdded] = useState<string | null>(null)
+
+  const handleAdd = () => {
+    const order = addTrackingNumber(orderId, tracking)
+    if (order) {
+      setAdded(order.tracking)
+      setTracking("")
+    }
+  }
+
+  return (
+    <div className="container mx-auto max-w-md space-y-4 py-8">
+      <h1 className="text-2xl font-bold">เพิ่มเลขพัสดุ</h1>
+      <select value={orderId} onChange={e=>setOrderId(e.target.value)} className="border rounded p-2 w-full">
+        {shippingOrders.map(o=> (
+          <option key={o.id} value={o.id}>{o.id} - {o.name}</option>
+        ))}
+      </select>
+      <Input placeholder="Tracking number" value={tracking} onChange={e=>setTracking(e.target.value)} />
+      <Button onClick={handleAdd}>บันทึก</Button>
+      {added && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{added}</span>
+          <CopyToClipboardButton text={added} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/mock/shipping.ts
+++ b/mock/shipping.ts
@@ -1,0 +1,64 @@
+export interface ShippingOrder {
+  id: string
+  name: string
+  address: string
+  phone: string
+  tracking: string
+  status: 'รอพิมพ์' | 'ส่งแล้ว' | 'ตีกลับ'
+  deliveryStatus: 'กำลังจัดส่ง' | 'ถึงแล้ว'
+}
+
+export const shippingOrders: ShippingOrder[] = [
+  {
+    id: 'SHIP-001',
+    name: 'John Doe',
+    address: '123 ถนนสุขุมวิท, กรุงเทพฯ 10110',
+    phone: '081-234-5678',
+    tracking: 'TH1234567890',
+    status: 'ส่งแล้ว',
+    deliveryStatus: 'ถึงแล้ว',
+  },
+  {
+    id: 'SHIP-002',
+    name: 'Jane Smith',
+    address: '456 ถนนพหลโยธิน, กรุงเทพฯ 10400',
+    phone: '082-345-6789',
+    tracking: '',
+    status: 'รอพิมพ์',
+    deliveryStatus: 'กำลังจัดส่ง',
+  },
+  {
+    id: 'SHIP-003',
+    name: 'Bob Johnson',
+    address: '789 ถนนเจริญกรุง, กรุงเทพฯ 10500',
+    phone: '083-456-7890',
+    tracking: 'TH5555555555',
+    status: 'ตีกลับ',
+    deliveryStatus: 'กำลังจัดส่ง',
+  },
+]
+
+export function addTrackingNumber(id: string, tracking: string): ShippingOrder | undefined {
+  const order = shippingOrders.find(o => o.id === id)
+  if (order) {
+    order.tracking = tracking
+    if (order.status === 'รอพิมพ์') order.status = 'ส่งแล้ว'
+  }
+  return order
+}
+
+export function getShippingOrder(id: string) {
+  return shippingOrders.find(o => o.id === id)
+}
+
+export type ShippingProvider = 'Kerry' | 'Flash' | 'ปณ.'
+
+let provider: ShippingProvider = 'Kerry'
+
+export function setShippingProvider(p: ShippingProvider) {
+  provider = p
+}
+
+export function getShippingProvider() {
+  return provider
+}


### PR DESCRIPTION
## Summary
- add mock shipping data helper
- list shipping orders with filter
- assign tracking number with copy button
- print shipping labels for selected orders
- choose a mock shipping provider
- show delivery status with icons

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687aaa94a92483259b303582fa31ae32