### PR TITLE
Add dashboard report mock pages

### DIFF
--- a/app/dashboard/reports/customers/page.tsx
+++ b/app/dashboard/reports/customers/page.tsx
@@ -1,0 +1,31 @@
+"use client"
+import { useMemo } from 'react'
+import { mockCustomers, getCustomerStats } from '@/lib/mock-customers'
+
+export default function DashboardReportCustomers() {
+  const now = Date.now()
+  const newCustomers = useMemo(() => mockCustomers.filter(c => now - new Date(c.createdAt).getTime() <= 30*24*60*60*1000), [])
+  const top = useMemo(() => {
+    return mockCustomers.map(c => ({ name: c.name, total: getCustomerStats(c.id).totalSpent }))
+      .sort((a,b)=>b.total-a.total)
+      .slice(0,10)
+  }, [])
+  const repeatPercent = useMemo(() => {
+    const repeat = mockCustomers.filter(c => getCustomerStats(c.id).totalOrders > 1).length
+    return mockCustomers.length === 0 ? 0 : Math.round((repeat / mockCustomers.length)*100)
+  }, [])
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">รายงานลูกค้า (mock)</h1>
+      <p className="text-sm text-muted-foreground">ลูกค้าใหม่ {newCustomers.length} ราย</p>
+      <p className="text-sm text-muted-foreground">ซื้อซ้ำ {repeatPercent}%</p>
+      <div>
+        <h2 className="font-semibold mb-2">Top 10</h2>
+        <ul className="list-decimal pl-6 space-y-1">
+          {top.map(t => (<li key={t.name}>{t.name} - ฿{t.total.toLocaleString()}</li>))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/reports/export/page.tsx
+++ b/app/dashboard/reports/export/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { useState } from 'react'
+import { downloadCSV } from '@/lib/mock-export'
+import { getOrdersInRange } from '@/lib/mock-orders'
+
+export default function DashboardReportExport() {
+  const today = new Date().toISOString().slice(0,10)
+  const [start, setStart] = useState(today)
+  const [end, setEnd] = useState(today)
+  const [type, setType] = useState('sales')
+
+  const handleExport = () => {
+    const s = new Date(start)
+    const e = new Date(end + 'T23:59:59')
+    if (type === 'sales') {
+      const data = getOrdersInRange(s,e).map(o=>({id:o.id,date:o.createdAt.slice(0,10),total:o.total}))
+      downloadCSV(data,'sales.csv')
+    } else {
+      downloadCSV([{note:'mock data'}], `${type}.csv`)
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Export รายงาน (mock)</h1>
+      <div className="flex gap-2">
+        <input type="date" className="border rounded p-2" value={start} onChange={e=>setStart(e.target.value)} />
+        <input type="date" className="border rounded p-2" value={end} onChange={e=>setEnd(e.target.value)} />
+        <select className="border rounded p-2" value={type} onChange={e=>setType(e.target.value)}>
+          <option value="sales">ยอดขาย</option>
+          <option value="products">สินค้า</option>
+          <option value="customers">ลูกค้า</option>
+          <option value="staff">พนักงาน</option>
+        </select>
+        <button className="border rounded px-3" onClick={handleExport}>Export CSV</button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export default function DashboardReportsPage() {
+  const items = [
+    { href: '/dashboard/reports/sales', label: 'Sales Summary' },
+    { href: '/dashboard/reports/products', label: 'Product Report' },
+    { href: '/dashboard/reports/customers', label: 'Customer Report' },
+    { href: '/dashboard/reports/staff', label: 'Staff Report' },
+    { href: '/dashboard/reports/export', label: 'Export Report' },
+  ]
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Reports</h1>
+      <ul className="list-disc pl-6 space-y-1">
+        {items.map(i => (
+          <li key={i.href}>
+            <Link className="text-blue-600 underline" href={i.href}>{i.label}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/reports/products/page.tsx
+++ b/app/dashboard/reports/products/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+import { useState, useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { mockOrders } from '@/lib/mock-orders'
+import { mockProducts } from '@/lib/mock-products'
+import { collections } from '@/mock/collections'
+
+export default function DashboardReportProducts() {
+  const categories = Array.from(new Set(mockProducts.map(p => p.category)))
+  const [category, setCategory] = useState<string>('all')
+  const [collection, setCollection] = useState<string>('all')
+
+  const data = useMemo(() => {
+    const counts: Record<string, number> = {}
+    mockOrders.forEach(o => {
+      o.items.forEach(i => {
+        counts[i.productName] = (counts[i.productName] || 0) + i.quantity
+      })
+    })
+    return mockProducts
+      .filter(p => (category === 'all' || p.category === category) && (collection === 'all' || p.collectionId === collection))
+      .map(p => ({ name: p.name, count: counts[p.name] || 0 }))
+      .sort((a,b) => b.count - a.count)
+  }, [category, collection])
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">รายงานสินค้า (mock)</h1>
+      <div className="flex gap-2">
+        <select className="border rounded p-2" value={category} onChange={e=>setCategory(e.target.value)}>
+          <option value="all">ทุกหมวดหมู่</option>
+          {categories.map(c => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <select className="border rounded p-2" value={collection} onChange={e=>setCollection(e.target.value)}>
+          <option value="all">ทุกคอลเลกชัน</option>
+          {collections.map(col => <option key={col.id} value={col.id}>{col.name}</option>)}
+        </select>
+      </div>
+      {data.length > 0 ? (
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" hide />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <p className="text-center text-muted-foreground">ไม่มีข้อมูล</p>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/reports/sales/page.tsx
+++ b/app/dashboard/reports/sales/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useState, useMemo } from 'react'
+import SalesChart from '@/components/dashboard/SalesChart'
+import { mockOrders, getOrdersInRange, getDailySales } from '@/lib/mock-orders'
+import { formatCurrency } from '@/lib/utils'
+
+export default function DashboardReportSales() {
+  const [type, setType] = useState<'day' | 'month' | 'year'>('day')
+
+  const { start, end } = useMemo(() => {
+    const now = new Date()
+    if (type === 'day') {
+      const d = new Date(now.toISOString().slice(0, 10))
+      return { start: d, end: new Date(d.getTime() + 24*60*60*1000 - 1) }
+    }
+    if (type === 'month') {
+      const s = new Date(now.getFullYear(), now.getMonth(), 1)
+      const e = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+      return { start: s, end: e }
+    }
+    const s = new Date(now.getFullYear(), 0, 1)
+    const e = new Date(now.getFullYear(), 11, 31)
+    return { start: s, end: e }
+  }, [type])
+
+  const orders = useMemo(() => getOrdersInRange(start, end), [start, end])
+  const total = useMemo(() => orders.reduce((s, o) => s + o.total, 0), [orders])
+  const chart = useMemo(() => getDailySales(start, end), [start, end])
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สรุปยอดขาย (mock)</h1>
+      <select className="border rounded p-2" value={type} onChange={e=>setType(e.target.value as any)}>
+        <option value="day">วันนี้</option>
+        <option value="month">เดือนนี้</option>
+        <option value="year">ปีนี้</option>
+      </select>
+      <div className="text-sm text-muted-foreground">
+        <p>ออเดอร์ {orders.length} รายการ</p>
+        <p>ยอดรวม {formatCurrency(total)}</p>
+        <p>ส่วนลด 0</p>
+      </div>
+      {chart.length > 0 && <SalesChart data={chart} />}
+    </div>
+  )
+}

--- a/app/dashboard/reports/staff/page.tsx
+++ b/app/dashboard/reports/staff/page.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
+import { staffSummary } from '@/mock/staff'
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658']
+
+export default function DashboardReportStaff() {
+  const data = staffSummary.map(s => ({ name: s.name, value: s.opened }))
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">รายงานพนักงาน (mock)</h1>
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie data={data} dataKey="value" nameKey="name" outerRadius={80} label>
+              {data.map((entry, index) => (
+                <Cell key={`c${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/mock/staff.ts
+++ b/mock/staff.ts
@@ -1,0 +1,12 @@
+export interface StaffSummary {
+  id: string
+  name: string
+  opened: number
+  shipped: number
+}
+
+export const staffSummary: StaffSummary[] = [
+  { id: '1', name: 'Admin A', opened: 12, shipped: 8 },
+  { id: '2', name: 'Admin B', opened: 20, shipped: 15 },
+  { id: '3', name: 'Admin C', opened: 5, shipped: 7 },
+]


### PR DESCRIPTION
## Summary
- create mock data for staff summary
- add dashboard reports index page
- implement sales, product, customer, staff and export report pages using mock data

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687aaaabd1a083258ad86149c0761ce5