### PR TITLE
Add dashboard settings pages

### DIFF
--- a/app/dashboard/settings/admins/add/page.tsx
+++ b/app/dashboard/settings/admins/add/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/inputs/input";
+import { Button } from "@/components/ui/buttons/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { loadAdminUsers, addAdmin } from "@/lib/mock-admin-users";
+
+export default function AddAdminPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [perm, setPerm] = useState({ read: true, write: false, manage: false });
+
+  useEffect(() => {
+    loadAdminUsers();
+  }, []);
+
+  const handleSave = () => {
+    if (!name || !email) {
+      alert("กรุณากรอกข้อมูลให้ครบ");
+      return;
+    }
+    addAdmin({ name, email, permissions: perm });
+    alert("บันทึกแล้ว");
+    router.push("/dashboard/settings/admins");
+  };
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">เพิ่มแอดมิน</h1>
+      <Input placeholder="ชื่อ" value={name} onChange={(e) => setName(e.target.value)} />
+      <Input placeholder="อีเมล" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <div className="space-y-2">
+        <div className="flex items-center space-x-2">
+          <Checkbox id="read" checked={perm.read} onCheckedChange={(v) => setPerm({ ...perm, read: Boolean(v) })} />
+          <Label htmlFor="read">อ่าน</Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox id="write" checked={perm.write} onCheckedChange={(v) => setPerm({ ...perm, write: Boolean(v) })} />
+          <Label htmlFor="write">เขียน</Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox id="manage" checked={perm.manage} onCheckedChange={(v) => setPerm({ ...perm, manage: Boolean(v) })} />
+          <Label htmlFor="manage">จัดการ</Label>
+        </div>
+      </div>
+      <Button onClick={handleSave}>เพิ่ม</Button>
+    </div>
+  );
+}

--- a/app/dashboard/settings/admins/edit/[id]/page.tsx
+++ b/app/dashboard/settings/admins/edit/[id]/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/inputs/input";
+import { Button } from "@/components/ui/buttons/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  loadAdminUsers,
+  getAdminById,
+  updateAdmin,
+} from "@/lib/mock-admin-users";
+
+export default function EditAdminPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { id } = params;
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [perm, setPerm] = useState({ read: true, write: false, manage: false });
+
+  useEffect(() => {
+    loadAdminUsers();
+    const admin = getAdminById(id);
+    if (admin) {
+      setName(admin.name);
+      setEmail(admin.email);
+      setPerm(admin.permissions);
+    }
+  }, [id]);
+
+  const handleSave = () => {
+    updateAdmin(id, { name, email, permissions: perm });
+    alert("บันทึกแล้ว");
+    router.push("/dashboard/settings/admins");
+  };
+
+  const handleReset = () => {
+    alert("ส่งลิงก์รีเซ็ตรหัสแล้ว");
+  };
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">แก้ไขแอดมิน</h1>
+      <Input placeholder="ชื่อ" value={name} onChange={(e) => setName(e.target.value)} />
+      <Input placeholder="อีเมล" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <div className="space-y-2">
+        <div className="flex items-center space-x-2">
+          <Checkbox id="read" checked={perm.read} onCheckedChange={(v) => setPerm({ ...perm, read: Boolean(v) })} />
+          <Label htmlFor="read">อ่าน</Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox id="write" checked={perm.write} onCheckedChange={(v) => setPerm({ ...perm, write: Boolean(v) })} />
+          <Label htmlFor="write">เขียน</Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox id="manage" checked={perm.manage} onCheckedChange={(v) => setPerm({ ...perm, manage: Boolean(v) })} />
+          <Label htmlFor="manage">จัดการ</Label>
+        </div>
+      </div>
+      <div className="space-x-2">
+        <Button onClick={handleSave}>บันทึก</Button>
+        <Button variant="outline" onClick={handleReset}>รีเซ็ตรหัสผ่าน</Button>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/settings/admins/page.tsx
+++ b/app/dashboard/settings/admins/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/buttons/button";
+import {
+  loadAdminUsers,
+  adminUsers,
+  removeAdmin,
+} from "@/lib/mock-admin-users";
+
+function permLabel(p: { read: boolean; write: boolean; manage: boolean }) {
+  const arr = [] as string[];
+  if (p.manage) arr.push("จัดการ");
+  if (p.write) arr.push("เขียน");
+  if (p.read) arr.push("อ่าน");
+  return arr.join(", ");
+}
+
+export default function AdminsPage() {
+  const [list, setList] = useState(adminUsers);
+  useEffect(() => {
+    loadAdminUsers();
+    setList([...adminUsers]);
+  }, []);
+
+  const handleDelete = (id: string) => {
+    if (confirm("ลบผู้ใช้นี้?")) {
+      removeAdmin(id);
+      setList([...adminUsers]);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">รายชื่อแอดมิน</h1>
+        <Link href="/dashboard/settings/admins/add">
+          <Button>เพิ่มแอดมิน</Button>
+        </Link>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">ชื่อ</th>
+            <th className="p-2 text-left">อีเมล</th>
+            <th className="p-2 text-left">สิทธิ์</th>
+            <th className="p-2 text-right">จัดการ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((a) => (
+            <tr key={a.id} className="border-b hover:bg-muted/50">
+              <td className="p-2">{a.name}</td>
+              <td className="p-2">{a.email}</td>
+              <td className="p-2">{permLabel(a.permissions)}</td>
+              <td className="space-x-2 p-2 text-right">
+                <Link href={`/dashboard/settings/admins/edit/${a.id}`}>
+                  <Button size="sm" variant="outline">
+                    แก้ไข
+                  </Button>
+                </Link>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(a.id)}
+                >
+                  ลบ
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/dashboard/settings/general/page.tsx
+++ b/app/dashboard/settings/general/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/inputs/input";
+import { Button } from "@/components/ui/buttons/button";
+import {
+  loadGeneralSettings,
+  generalSettings,
+  setGeneralSettings,
+} from "@/lib/mock-general-settings";
+
+export default function GeneralSettingsPage() {
+  const [name, setName] = useState(generalSettings.storeName);
+  const [logo, setLogo] = useState(generalSettings.logoUrl);
+  const [lang, setLang] = useState(generalSettings.language);
+
+  useEffect(() => {
+    loadGeneralSettings();
+    setName(generalSettings.storeName);
+    setLogo(generalSettings.logoUrl);
+    setLang(generalSettings.language);
+  }, []);
+
+  const handleSave = () => {
+    try {
+      setGeneralSettings({ storeName: name, logoUrl: logo, language: lang });
+      alert("บันทึกแล้ว");
+    } catch (err) {
+      alert("เกิดข้อผิดพลาด");
+    }
+  };
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">ตั้งค่าทั่วไป</h1>
+      <Input
+        placeholder="ชื่อร้าน"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Input
+        placeholder="โลโก้ URL"
+        value={logo}
+        onChange={(e) => setLogo(e.target.value)}
+      />
+      <select
+        value={lang}
+        onChange={(e) => setLang(e.target.value)}
+        className="w-full rounded border p-2"
+      >
+        <option value="th">ไทย</option>
+        <option value="en">English</option>
+      </select>
+      <Button onClick={handleSave}>บันทึก</Button>
+    </div>
+  );
+}

--- a/app/dashboard/settings/permissions/page.tsx
+++ b/app/dashboard/settings/permissions/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/buttons/button";
+import { downloadCSV } from "@/lib/mock-export";
+import { loadAdminUsers, adminUsers } from "@/lib/mock-admin-users";
+
+export default function PermissionsPage() {
+  const [list, setList] = useState(adminUsers);
+  useEffect(() => {
+    loadAdminUsers();
+    setList([...adminUsers]);
+  }, []);
+
+  const rows = list.map((a) => ({
+    name: a.name,
+    email: a.email,
+    read: a.permissions.read ? "yes" : "",
+    write: a.permissions.write ? "yes" : "",
+    manage: a.permissions.manage ? "yes" : "",
+  }));
+
+  const handleExport = () => downloadCSV(rows, "permissions.csv");
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ภาพรวมสิทธิ์</h1>
+        <Button variant="outline" onClick={handleExport}>
+          Export CSV
+        </Button>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">ชื่อ</th>
+            <th className="p-2 text-left">อีเมล</th>
+            <th className="p-2 text-center">อ่าน</th>
+            <th className="p-2 text-center">เขียน</th>
+            <th className="p-2 text-center">จัดการ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((a) => (
+            <tr key={a.id} className="border-b hover:bg-muted/50">
+              <td className="p-2">{a.name}</td>
+              <td className="p-2">{a.email}</td>
+              <td className="p-2 text-center">{a.permissions.read ? "✓" : ""}</td>
+              <td className="p-2 text-center">{a.permissions.write ? "✓" : ""}</td>
+              <td className="p-2 text-center">{a.permissions.manage ? "✓" : ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/mock-admin-users.ts
+++ b/lib/mock-admin-users.ts
@@ -1,0 +1,61 @@
+export interface AdminUser {
+  id: string
+  name: string
+  email: string
+  permissions: {
+    read: boolean
+    write: boolean
+    manage: boolean
+  }
+}
+
+const STORAGE_KEY = 'adminUsers'
+
+export let adminUsers: AdminUser[] = [
+  {
+    id: '1',
+    name: 'Super Admin',
+    email: 'root@sofacover.com',
+    permissions: { read: true, write: true, manage: true },
+  },
+]
+
+export function loadAdminUsers() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) adminUsers = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(adminUsers))
+  }
+}
+
+export function addAdmin(data: Omit<AdminUser, 'id'>): AdminUser {
+  const user: AdminUser = { id: Date.now().toString(), ...data }
+  adminUsers.push(user)
+  save()
+  return user
+}
+
+export function getAdminById(id: string) {
+  return adminUsers.find((a) => a.id === id)
+}
+
+export function updateAdmin(id: string, data: Partial<Omit<AdminUser, 'id'>>) {
+  const admin = adminUsers.find((a) => a.id === id)
+  if (!admin) return
+  Object.assign(admin, data)
+  save()
+  return admin
+}
+
+export function removeAdmin(id: string) {
+  const idx = adminUsers.findIndex((a) => a.id === id)
+  if (idx !== -1) {
+    adminUsers.splice(idx, 1)
+    save()
+  }
+}

--- a/lib/mock-general-settings.ts
+++ b/lib/mock-general-settings.ts
@@ -1,0 +1,27 @@
+export interface GeneralSettings {
+  storeName: string
+  logoUrl: string
+  language: string
+}
+
+const STORAGE_KEY = 'generalSettings'
+
+export let generalSettings: GeneralSettings = {
+  storeName: 'SofaCover Pro',
+  logoUrl: '/logo.png',
+  language: 'th',
+}
+
+export function loadGeneralSettings() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) generalSettings = JSON.parse(stored)
+  }
+}
+
+export function setGeneralSettings(val: GeneralSettings) {
+  generalSettings = val
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
+  }
+}


### PR DESCRIPTION
## Summary
- implement mock general settings data
- implement mock admin users list
- add dashboard settings pages for general options, admin CRUD, and permissions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687aae164fd08325bd033b4b07bc0231