### PR TITLE
Add mock integration and order tracking pages

### DIFF
--- a/app/dashboard/integrations/facebook/page.tsx
+++ b/app/dashboard/integrations/facebook/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+
+export default function FacebookIntegrationPage() {
+  const [pageId, setPageId] = useState("")
+  const [token, setToken] = useState("")
+
+  const handleConnect = () => {
+    alert("เชื่อมต่อ Facebook Page สำเร็จ (mock)")
+  }
+
+  const handleTest = () => {
+    alert(`ส่งข้อความทดสอบไปยัง ${pageId} (mock)`)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Facebook Page Chat</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>เชื่อมต่อเพจ</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            value={pageId}
+            onChange={e => setPageId(e.target.value)}
+            placeholder="Page ID"
+          />
+          <Input
+            value={token}
+            onChange={e => setToken(e.target.value)}
+            placeholder="Access Token"
+          />
+          <div className="flex space-x-2">
+            <Button onClick={handleConnect}>เชื่อมต่อ</Button>
+            <Button variant="outline" onClick={handleTest}>ทดสอบส่งข้อความ</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/integrations/lineoa/page.tsx
+++ b/app/dashboard/integrations/lineoa/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { Switch } from "@/components/ui/switch"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+
+export default function LineOAIntegrationPage() {
+  const [token, setToken] = useState("")
+  const [enabled, setEnabled] = useState(false)
+
+  const handleTest = () => {
+    alert("ส่ง broadcast ทดสอบ (mock)")
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">LINE OA</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>ตั้งค่า</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <Switch id="enabled" checked={enabled} onCheckedChange={v => setEnabled(Boolean(v))} />
+            <label htmlFor="enabled">เปิดใช้ในระบบ</label>
+          </div>
+          <Input
+            value={token}
+            onChange={e => setToken(e.target.value)}
+            placeholder="LINE OA Token"
+          />
+          <Button onClick={handleTest}>ทดสอบ broadcast</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/settings/email/page.tsx
+++ b/app/dashboard/settings/email/page.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+
+export default function EmailSettingsPage() {
+  const [primary, setPrimary] = useState("")
+  const [notifyOrder, setNotifyOrder] = useState(true)
+  const [notifyTransfer, setNotifyTransfer] = useState(true)
+  const [notifyOut, setNotifyOut] = useState(false)
+
+  const save = () => {
+    alert("บันทึกการตั้งค่าแล้ว (mock)")
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Email Notifications</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>การแจ้งเตือน</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <Switch id="o" checked={notifyOrder} onCheckedChange={v => setNotifyOrder(Boolean(v))} />
+            <label htmlFor="o">อีเมลแจ้งสั่งซื้อ</label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch id="p" checked={notifyTransfer} onCheckedChange={v => setNotifyTransfer(Boolean(v))} />
+            <label htmlFor="p">แจ้งโอนเงิน</label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch id="out" checked={notifyOut} onCheckedChange={v => setNotifyOut(Boolean(v))} />
+            <label htmlFor="out">สินค้าใกล้หมด</label>
+          </div>
+          <Input
+            value={primary}
+            onChange={e => setPrimary(e.target.value)}
+            placeholder="อีเมลหลักของร้าน"
+          />
+          <Button onClick={save}>บันทึก</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/store/thankyou/page.tsx
+++ b/app/store/thankyou/page.tsx
@@ -1,0 +1,19 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import Link from "next/link"
+import { Button } from "@/components/ui/buttons/button"
+
+export default function ThankYouPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 flex flex-col items-center justify-center space-y-4 p-8">
+        <h1 className="text-2xl font-bold text-center">ขอบคุณสำหรับการสั่งซื้อ</h1>
+        <Link href="/store/track-order">
+          <Button>ติดตามสถานะออเดอร์</Button>
+        </Link>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/store/track-order/page.tsx
+++ b/app/store/track-order/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useState } from "react"
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { orders } from "@/mock/orders"
+
+export default function TrackOrderPage() {
+  const [orderId, setOrderId] = useState("")
+  const [status, setStatus] = useState<string | null>(null)
+  const [notFound, setNotFound] = useState(false)
+
+  const search = () => {
+    const o = orders.find(o => o.id === orderId.trim())
+    if (o) {
+      setStatus(o.status)
+      setNotFound(false)
+    } else {
+      setStatus(null)
+      setNotFound(true)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>ติดตามออเดอร์</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              value={orderId}
+              onChange={e => setOrderId(e.target.value)}
+              placeholder="หมายเลขออเดอร์"
+            />
+            <Button onClick={search}>ค้นหา</Button>
+            {status && <p>สถานะ: {status}</p>}
+            {notFound && <p>ไม่พบออเดอร์</p>}
+          </CardContent>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Facebook Page mock integration
- add LINE OA mock integration
- add email notification settings
- show thank you screen after checkout
- allow users to check mock order status

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_687aae8d854c8325807af7139c8d11e6