### PR TITLE
Add stock pages

### DIFF
--- a/app/dashboard/settings/stock-alert/page.tsx
+++ b/app/dashboard/settings/stock-alert/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { getStockAlert, loadStockAlert, setStockAlert } from '@/lib/mock-stock-settings'
+import { Input } from '@/components/ui/inputs/input'
+import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function StockAlertSettingsPage() {
+  const [enabled, setEnabled] = useState(true)
+  const [threshold, setThreshold] = useState(5)
+
+  useEffect(() => {
+    loadStockAlert()
+    const s = getStockAlert()
+    setEnabled(s.enabled)
+    setThreshold(s.threshold)
+  }, [])
+
+  const handleSave = () => {
+    setStockAlert({ enabled, threshold })
+    alert('saved')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4 max-w-md">
+      <h1 className="text-2xl font-bold">ตั้งค่าเตือนสต๊อกต่ำ</h1>
+      <div className="flex items-center justify-between">
+        <span>เปิดการเตือน</span>
+        <Switch checked={enabled} onCheckedChange={setEnabled} />
+      </div>
+      <Input type="number" value={threshold} onChange={e=>setThreshold(Number(e.target.value))} placeholder="น้อยกว่า..." />
+      <Button onClick={handleSave}>บันทึก</Button>
+    </div>
+  )
+}

--- a/app/dashboard/stock/edit/page.tsx
+++ b/app/dashboard/stock/edit/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { mockStock } from '@/lib/mock-stock'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import { Select, SelectTrigger, SelectContent, SelectItem } from '@/components/ui/select'
+
+export default function EditStockPage() {
+  const router = useRouter()
+  const [id, setId] = useState(mockStock[0]?.id || '')
+  const [qty, setQty] = useState(0)
+  const [reason, setReason] = useState('คืนของ')
+
+  const handleSubmit = () => {
+    const item = mockStock.find(s => s.id === id)
+    if (item) item.currentStock += qty
+    alert('บันทึกแล้ว')
+    router.push('/dashboard/stock')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ปรับสต๊อกสินค้า</h1>
+      <div className="space-y-2 max-w-sm">
+        <Select value={id} onValueChange={setId}>
+          <SelectTrigger>สินค้า</SelectTrigger>
+          <SelectContent>
+            {mockStock.map(i => (
+              <SelectItem key={i.id} value={i.id}>{i.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input type="number" value={qty} onChange={e=>setQty(Number(e.target.value))} placeholder="จำนวน (+/-)" />
+        <Select value={reason} onValueChange={setReason}>
+          <SelectTrigger>เหตุผล</SelectTrigger>
+          <SelectContent>
+            <SelectItem value="คืนของ">คืนของ</SelectItem>
+            <SelectItem value="ซื้อเพิ่ม">ซื้อเพิ่ม</SelectItem>
+            <SelectItem value="เสียหาย">เสียหาย</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={handleSubmit}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/stock/export/page.tsx
+++ b/app/dashboard/stock/export/page.tsx
@@ -1,0 +1,34 @@
+"use client"
+import { useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { Select, SelectTrigger, SelectContent, SelectItem } from '@/components/ui/select'
+import { downloadExcel } from '@/lib/mock-export'
+import { mockStock } from '@/lib/mock-stock'
+
+export default function ExportStockPage() {
+  const categories = Array.from(new Set(mockStock.map(i => i.category)))
+  const [cat, setCat] = useState('all')
+
+  const handleExport = () => {
+    const rows = cat === 'all' ? mockStock : mockStock.filter(i => i.category === cat)
+    downloadExcel(rows, 'stock.xlsx')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ส่งออกสต๊อก</h1>
+      <div className="flex gap-2 max-w-sm">
+        <Select value={cat} onValueChange={setCat}>
+          <SelectTrigger className="w-32">{cat === 'all' ? 'ทุกหมวด' : cat}</SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">ทุกหมวด</SelectItem>
+            {categories.map(c => (
+              <SelectItem key={c} value={c}>{c}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button onClick={handleExport}>ดาวน์โหลด</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/stock/import/page.tsx
+++ b/app/dashboard/stock/import/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/buttons/button'
+import { mockStock, StockItem } from '@/lib/mock-stock'
+
+export default function ImportStockPage() {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [rows, setRows] = useState<StockItem[]>([])
+
+  const handleRead = async () => {
+    if (!file) return
+    const XLSX = await import('xlsx')
+    const buf = await file.arrayBuffer()
+    const wb = XLSX.read(buf, { type: 'array' })
+    const ws = wb.Sheets[wb.SheetNames[0]]
+    const data: StockItem[] = XLSX.utils.sheet_to_json(ws)
+    setRows(data)
+  }
+
+  const handleSave = () => {
+    rows.forEach(r => mockStock.push(r))
+    alert('imported')
+    router.push('/dashboard/stock')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">นำเข้าสต๊อกจาก Excel</h1>
+      <input type="file" accept=".xlsx" onChange={e=>setFile(e.target.files?.[0]||null)} />
+      <Button onClick={handleRead} disabled={!file}>preview</Button>
+      {rows.length > 0 && (
+        <div>
+          <p>พบ {rows.length} รายการ</p>
+          <Button onClick={handleSave}>บันทึก</Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/stock/page.tsx
+++ b/app/dashboard/stock/page.tsx
@@ -1,0 +1,68 @@
+"use client"
+import { useState } from 'react'
+import { mockStock, StockItem } from '@/lib/mock-stock'
+import { Select, SelectTrigger, SelectContent, SelectItem } from '@/components/ui/select'
+import { Input } from '@/components/ui/inputs/input'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { StockAlertSetting, getStockAlert, loadStockAlert } from '@/lib/mock-stock-settings'
+
+export default function StockOverviewPage() {
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState('all')
+  const [items, setItems] = useState<StockItem[]>([...mockStock])
+  const [setting, setSetting] = useState<StockAlertSetting>(() => {
+    loadStockAlert()
+    return getStockAlert()
+  })
+
+  const filtered = items.filter(i => {
+    const matchName = i.name.toLowerCase().includes(query.toLowerCase())
+    const matchCat = category === 'all' || i.category === category
+    return matchName && matchCat
+  })
+
+  const rowStyle = (stock: number) => {
+    if (stock === 0) return 'bg-red-50'
+    if (stock < setting.threshold) return 'bg-orange-50'
+    if (stock >= 10) return 'bg-green-50'
+    return ''
+  }
+
+  const categories = Array.from(new Set(mockStock.map(i => i.category)))
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">สต๊อกสินค้า</h1>
+      <div className="flex gap-2">
+        <Input placeholder="ค้นหา" value={query} onChange={e=>setQuery(e.target.value)} />
+        <Select value={category} onValueChange={setCategory}>
+          <SelectTrigger className="w-32">{category === 'all' ? 'ทุกหมวด' : category}</SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">ทุกหมวด</SelectItem>
+            {categories.map(c=> (
+              <SelectItem key={c} value={c}>{c}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ชื่อสินค้า</TableHead>
+            <TableHead>SKU</TableHead>
+            <TableHead className="text-right">คงเหลือ</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map(item => (
+            <TableRow key={item.id} className={rowStyle(item.currentStock)}>
+              <TableCell>{item.name}</TableCell>
+              <TableCell>{item.sku}</TableCell>
+              <TableCell className="text-right">{item.currentStock}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/ui/sidebar.config.ts
+++ b/components/ui/sidebar.config.ts
@@ -23,6 +23,7 @@ export const sidebarSections: SidebarSectionConfig[] = [
     section: "Inventory",
     items: [
       { label: "Products", icon: require("lucide-react").Package, href: "/products" },
+      { label: "Stock", icon: require("lucide-react").ClipboardList, href: "/dashboard/stock" },
     ],
   },
 ]

--- a/lib/mock-stock-settings.ts
+++ b/lib/mock-stock-settings.ts
@@ -1,0 +1,28 @@
+export interface StockAlertSetting {
+  enabled: boolean
+  threshold: number
+}
+
+let stockAlert: StockAlertSetting = { enabled: true, threshold: 5 }
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('stockAlert', JSON.stringify(stockAlert))
+  }
+}
+
+export function loadStockAlert() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('stockAlert')
+    if (stored) stockAlert = JSON.parse(stored)
+  }
+}
+
+export function getStockAlert() {
+  return stockAlert
+}
+
+export function setStockAlert(setting: StockAlertSetting) {
+  stockAlert = setting
+  save()
+}


### PR DESCRIPTION
## Summary
- add stock pages with import/export, edit and overview
- add setting for low stock alert
- expose Stock in sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aaeac5a9c8325afd03447489ded7f