### PR TITLE
Add admin settings pages

### DIFF
--- a/app/dashboard/settings/admins/add/page.tsx
+++ b/app/dashboard/settings/admins/add/page.tsx
@@ -1,0 +1,36 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { addAdmin } from '@/lib/mock-admins'
+import { toast } from 'sonner'
+
+export default function AddAdminPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<'read' | 'write' | 'manage'>('read')
+
+  const disabled = !name.trim() || !email.trim()
+
+  const handleSave = () => {
+    addAdmin({ name, email, role })
+    toast.success('เพิ่มแอดมินแล้ว')
+    router.push('/dashboard/settings/admins')
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8 max-w-md">
+      <h1 className="text-2xl font-bold">เพิ่มแอดมินใหม่</h1>
+      <Input placeholder="ชื่อ" value={name} onChange={e=>setName(e.target.value)} />
+      <Input placeholder="อีเมล" value={email} onChange={e=>setEmail(e.target.value)} />
+      <select value={role} onChange={e=>setRole(e.target.value as any)} className="w-full rounded border p-2">
+        <option value="read">อ่าน</option>
+        <option value="write">เขียน</option>
+        <option value="manage">จัดการ</option>
+      </select>
+      <Button onClick={handleSave} disabled={disabled}>Save</Button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/admins/edit/[id]/page.tsx
+++ b/app/dashboard/settings/admins/edit/[id]/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useRouter, useParams } from 'next/navigation'
+import { useState } from 'react'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { getAdmin, updateAdmin } from '@/lib/mock-admins'
+import { toast } from 'sonner'
+
+export default function EditAdminPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const admin = getAdmin(params.id)
+  const [name, setName] = useState(admin?.name || '')
+  const [email, setEmail] = useState(admin?.email || '')
+  const [role, setRole] = useState<'read' | 'write' | 'manage'>(admin?.role || 'read')
+
+  if (!admin) return <div className="p-8">ไม่พบผู้ใช้งาน</div>
+
+  const handleSave = () => {
+    updateAdmin(admin.id, { name, email, role })
+    toast.success('บันทึกแล้ว')
+    router.push('/dashboard/settings/admins')
+  }
+
+  const handleReset = () => toast.success('ส่งลิงก์รีเซ็ตรหัสผ่านแล้ว')
+
+  const disabled = !name.trim() || !email.trim()
+
+  return (
+    <div className="container mx-auto space-y-4 py-8 max-w-md">
+      <h1 className="text-2xl font-bold">แก้ไขแอดมิน</h1>
+      <Input value={name} onChange={e=>setName(e.target.value)} />
+      <Input value={email} onChange={e=>setEmail(e.target.value)} />
+      <select value={role} onChange={e=>setRole(e.target.value as any)} className="w-full rounded border p-2">
+        <option value="read">อ่าน</option>
+        <option value="write">เขียน</option>
+        <option value="manage">จัดการ</option>
+      </select>
+      <div className="flex gap-2">
+        <Button onClick={handleSave} disabled={disabled}>Save</Button>
+        <Button variant="outline" onClick={handleReset}>Reset Password</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/settings/admins/page.tsx
+++ b/app/dashboard/settings/admins/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+import Link from 'next/link'
+import { useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { getAdmins, deleteAdmin } from '@/lib/mock-admins'
+import { toast } from 'sonner'
+
+export default function AdminListPage() {
+  const [admins, setAdmins] = useState(getAdmins())
+
+  const handleDelete = (id: string) => {
+    deleteAdmin(id)
+    setAdmins(getAdmins())
+    toast.success('ลบแล้ว')
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">ผู้ดูแลระบบ</h1>
+        <Link href="/dashboard/settings/admins/add"><Button>เพิ่มแอดมิน</Button></Link>
+      </div>
+      {admins.length ? (
+        <table className="w-full table-auto border">
+          <thead className="bg-muted">
+            <tr>
+              <th className="p-2 text-left">ชื่อ</th>
+              <th className="p-2 text-left">อีเมล</th>
+              <th className="p-2 text-left">สิทธิ์</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {admins.map(a => (
+              <tr key={a.id} className="border-t">
+                <td className="p-2">{a.name}</td>
+                <td className="p-2">{a.email}</td>
+                <td className="p-2">{a.role}</td>
+                <td className="p-2 space-x-2">
+                  <Link href={`/dashboard/settings/admins/edit/${a.id}`}><Button size="sm">แก้ไข</Button></Link>
+                  <Button size="sm" variant="destructive" onClick={()=>handleDelete(a.id)}>ลบ</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-center text-muted-foreground">ไม่มีผู้ดูแลระบบ</p>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/settings/general/page.tsx
+++ b/app/dashboard/settings/general/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { loadGeneralConfig, generalConfig, setGeneralConfig } from '@/lib/mock-general-settings'
+import { toast } from 'sonner'
+
+export default function GeneralSettingsPage() {
+  const [loaded, setLoaded] = useState(false)
+  const [name, setName] = useState('')
+  const [logo, setLogo] = useState('')
+  const [lang, setLang] = useState('th')
+
+  useEffect(() => {
+    try {
+      loadGeneralConfig()
+      setName(generalConfig.storeName)
+      setLogo(generalConfig.logo)
+      setLang(generalConfig.language)
+      setLoaded(true)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
+
+  if (!loaded) {
+    return <p className="p-4 text-red-500">เกิดข้อผิดพลาดในการโหลดข้อมูล</p>
+  }
+
+  const handleSave = () => {
+    setGeneralConfig({ storeName: name, logo, language: lang })
+    toast.success('บันทึกแล้ว')
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8 max-w-md">
+      <h1 className="text-2xl font-bold">ตั้งค่าทั่วไป</h1>
+      <Input placeholder="ชื่อร้าน" value={name} onChange={e=>setName(e.target.value)} />
+      <Input placeholder="โลโก้ URL" value={logo} onChange={e=>setLogo(e.target.value)} />
+      <div>
+        <label className="mb-1 block text-sm font-medium">ภาษาหลัก</label>
+        <select value={lang} onChange={e=>setLang(e.target.value)} className="w-full rounded border p-2">
+          <option value="th">TH</option>
+          <option value="en">EN</option>
+        </select>
+      </div>
+      <Button onClick={handleSave}>Save</Button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/permissions/page.tsx
+++ b/app/dashboard/settings/permissions/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useState } from 'react'
+import { getAdmins } from '@/lib/mock-admins'
+import { Button } from '@/components/ui/buttons/button'
+import { toast } from 'sonner'
+
+export default function PermissionsPreviewPage() {
+  const [admins] = useState(getAdmins())
+
+  const exportCsv = () => {
+    toast.success('Exported CSV')
+  }
+
+  const canRead = (role: string) => role === 'read' || role === 'write' || role === 'manage'
+  const canWrite = (role: string) => role === 'write' || role === 'manage'
+  const canManage = (role: string) => role === 'manage'
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">สรุปสิทธิ์การเข้าถึง</h1>
+        <Button onClick={exportCsv}>Export CSV</Button>
+      </div>
+      <table className="w-full table-auto border">
+        <thead className="bg-muted">
+          <tr>
+            <th className="p-2 text-left">ชื่อ</th>
+            <th className="p-2 text-center">อ่าน</th>
+            <th className="p-2 text-center">เขียน</th>
+            <th className="p-2 text-center">จัดการ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {admins.map(a => (
+            <tr key={a.id} className="border-t">
+              <td className="p-2">{a.name}</td>
+              <td className="p-2 text-center">{canRead(a.role) ? '✓' : ''}</td>
+              <td className="p-2 text-center">{canWrite(a.role) ? '✓' : ''}</td>
+              <td className="p-2 text-center">{canManage(a.role) ? '✓' : ''}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/lib/mock-admins.ts
+++ b/lib/mock-admins.ts
@@ -1,0 +1,37 @@
+export interface AdminUser {
+  id: string
+  name: string
+  email: string
+  role: 'read' | 'write' | 'manage'
+}
+
+let mockAdmins: AdminUser[] = [
+  { id: '1', name: 'Alice', email: 'alice@example.com', role: 'manage' },
+  { id: '2', name: 'Bob', email: 'bob@example.com', role: 'write' },
+  { id: '3', name: 'Charlie', email: 'charlie@example.com', role: 'read' },
+]
+
+export function getAdmins() {
+  return mockAdmins
+}
+
+export function getAdmin(id: string) {
+  return mockAdmins.find(a => a.id === id)
+}
+
+export function addAdmin(data: Omit<AdminUser, 'id'>) {
+  const admin: AdminUser = { id: Date.now().toString(), ...data }
+  mockAdmins.push(admin)
+  return admin
+}
+
+export function updateAdmin(id: string, data: Partial<Omit<AdminUser, 'id'>>) {
+  const idx = mockAdmins.findIndex(a => a.id === id)
+  if (idx !== -1) {
+    mockAdmins[idx] = { ...mockAdmins[idx], ...data }
+  }
+}
+
+export function deleteAdmin(id: string) {
+  mockAdmins = mockAdmins.filter(a => a.id !== id)
+}

--- a/lib/mock-general-settings.ts
+++ b/lib/mock-general-settings.ts
@@ -1,0 +1,25 @@
+export interface GeneralConfig {
+  storeName: string
+  logo: string
+  language: string
+}
+
+export let generalConfig: GeneralConfig = {
+  storeName: 'Sofa Store',
+  logo: '/logo.png',
+  language: 'th',
+}
+
+export function loadGeneralConfig() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('generalConfig')
+    if (stored) generalConfig = JSON.parse(stored)
+  }
+}
+
+export function setGeneralConfig(config: GeneralConfig) {
+  generalConfig = config
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('generalConfig', JSON.stringify(config))
+  }
+}


### PR DESCRIPTION
## Summary
- mock admin data and general config utilities
- add dashboard pages to manage admin users
- add general settings page and permissions preview

## Testing
- `npm test` *(fails: Error [ERR_REQUIRE_ESM])*

------
https://chatgpt.com/codex/tasks/task_e_687aae3f3a708325aaa43973f9e36afb