### PR TITLE
Implement admin log features

### DIFF
--- a/app/dashboard/logs/[id]/page.tsx
+++ b/app/dashboard/logs/[id]/page.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { loadAdminLogs, mockAdminLogs, type AdminLog } from "@/lib/mock-admin-logs"
+
+export default function LogDetailPage() {
+  const params = useParams<{ id: string }>()
+  const [log, setLog] = useState<AdminLog | null>(null)
+
+  useEffect(() => {
+    loadAdminLogs()
+    const entry = mockAdminLogs.find(l => l.id === params.id)
+    if (entry) setLog({ ...entry })
+  }, [params.id])
+
+  if (!log) return <div className="p-8">ไม่พบข้อมูล</div>
+
+  return (
+    <div className="container mx-auto space-y-2 py-8">
+      <h1 className="text-2xl font-bold">รายละเอียด Log</h1>
+      <p>เวลา: {new Date(log.timestamp).toLocaleString()}</p>
+      <p>การกระทำ: {log.action}</p>
+      <p>แอดมิน: {log.admin}</p>
+    </div>
+  )
+}

--- a/app/dashboard/logs/export/page.tsx
+++ b/app/dashboard/logs/export/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { loadAdminLogs, mockAdminLogs, type AdminLog } from "@/lib/mock-admin-logs"
+import { exportLogsCsv } from "@/lib/logs"
+
+export default function LogExportPage() {
+  const [logs, setLogs] = useState<AdminLog[]>([])
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+
+  useEffect(() => {
+    loadAdminLogs()
+    setLogs([...mockAdminLogs])
+  }, [])
+
+  const filtered = logs.filter(l => {
+    if (start && new Date(l.timestamp) < new Date(start)) return false
+    if (end && new Date(l.timestamp) > new Date(end)) return false
+    return true
+  })
+
+  const handleExport = () => {
+    exportLogsCsv(filtered, 'logs.csv')
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Export Logs</h1>
+      <div className="flex flex-wrap gap-2">
+        <input type="date" value={start} onChange={e=>setStart(e.target.value)} className="border rounded p-2" />
+        <input type="date" value={end} onChange={e=>setEnd(e.target.value)} className="border rounded p-2" />
+        <Button onClick={handleExport}>ดาวน์โหลด CSV</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/logs/filter/page.tsx
+++ b/app/dashboard/logs/filter/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { loadAdminLogs, mockAdminLogs, type AdminLog } from "@/lib/mock-admin-logs"
+import { loadAdminUsers, adminUsers } from "@/lib/mock-admin-users"
+
+export default function LogFilterPage() {
+  const [logs, setLogs] = useState<AdminLog[]>([])
+  const [user, setUser] = useState('')
+  const [search, setSearch] = useState('')
+  const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+
+  useEffect(() => {
+    loadAdminUsers()
+    loadAdminLogs()
+    setLogs([...mockAdminLogs])
+  }, [])
+
+  const filtered = logs.filter(l => {
+    if (user && l.admin !== user) return false
+    if (search && !l.action.includes(search)) return false
+    if (start && new Date(l.timestamp) < new Date(start)) return false
+    if (end && new Date(l.timestamp) > new Date(end)) return false
+    return true
+  })
+
+  const sorted = [...filtered].sort((a,b)=>new Date(b.timestamp).getTime()-new Date(a.timestamp).getTime())
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">ค้นหา Log</h1>
+      <div className="flex flex-wrap gap-2">
+        <select value={user} onChange={e=>setUser(e.target.value)} className="border rounded p-2">
+          <option value="">ทุกคน</option>
+          {adminUsers.map(u=> <option key={u.id} value={u.email}>{u.email}</option>)}
+        </select>
+        <Input placeholder="ค้นหา..." value={search} onChange={e=>setSearch(e.target.value)} className="max-w-xs" />
+        <input type="date" value={start} onChange={e=>setStart(e.target.value)} className="border rounded p-2" />
+        <input type="date" value={end} onChange={e=>setEnd(e.target.value)} className="border rounded p-2" />
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>เวลา</TableHead>
+            <TableHead>การกระทำ</TableHead>
+            <TableHead>แอดมิน</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map(log => (
+            <TableRow key={log.id}>
+              <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+              <TableCell>{log.action}</TableCell>
+              <TableCell>{log.admin}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/dashboard/logs/page.tsx
+++ b/app/dashboard/logs/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { loadAdminLogs, mockAdminLogs, type AdminLog } from "@/lib/mock-admin-logs"
+
+export default function AdminLogsPage() {
+  const [logs, setLogs] = useState<AdminLog[]>([])
+
+  useEffect(() => {
+    loadAdminLogs()
+    setLogs([...mockAdminLogs])
+  }, [])
+
+  const sorted = [...logs].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">กิจกรรมล่าสุด</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>เวลา</TableHead>
+            <TableHead>การกระทำ</TableHead>
+            <TableHead>แอดมิน</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map(log => (
+            <TableRow key={log.id} className="hover:bg-muted/50">
+              <TableCell className="whitespace-nowrap">{new Date(log.timestamp).toLocaleString()}</TableCell>
+              <TableCell>
+                <Link href={`/dashboard/logs/${log.id}`} className="underline">
+                  {log.action}
+                </Link>
+              </TableCell>
+              <TableCell>{log.admin}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/dashboard/settings/admins/audit/page.tsx
+++ b/app/dashboard/settings/admins/audit/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { loadAdminUsers, adminUsers } from "@/lib/mock-admin-users"
+import { loadAdminLogs, mockAdminLogs, type AdminLog } from "@/lib/mock-admin-logs"
+
+export default function AdminAuditPage() {
+  const [logs, setLogs] = useState<AdminLog[]>([])
+  const [admin, setAdmin] = useState('')
+
+  useEffect(() => {
+    loadAdminUsers()
+    loadAdminLogs()
+    setLogs([...mockAdminLogs])
+  }, [])
+
+  const filtered = logs.filter(l => (admin ? l.admin === admin : true))
+  const sorted = [...filtered].sort((a,b)=>new Date(b.timestamp).getTime()-new Date(a.timestamp).getTime())
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Admin Audit</h1>
+      <select value={admin} onChange={e=>setAdmin(e.target.value)} className="border rounded p-2">
+        <option value="">เลือกแอดมิน</option>
+        {adminUsers.map(a=> <option key={a.id} value={a.email}>{a.email}</option>)}
+      </select>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>เวลา</TableHead>
+            <TableHead>การกระทำ</TableHead>
+            <TableHead>แอดมิน</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map(log => (
+            <TableRow key={log.id}>
+              <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+              <TableCell>{log.action}</TableCell>
+              <TableCell>{log.admin}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -55,3 +55,20 @@ export function exportLogsJson(entries: LogEntry[], filename: string) {
   a.click()
   URL.revokeObjectURL(url)
 }
+
+export function exportLogsCsv(entries: LogEntry[], filename: string) {
+  const header = ['id', 'timestamp', 'action', 'payload'].join(',')
+  const rows = entries.map(e => {
+    const payload = e.payload ? JSON.stringify(e.payload).replace(/"/g, '""') : ''
+    return [e.id, e.timestamp, e.action, `"${payload}"`].join(',')
+  })
+  const csv = [header, ...rows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+

--- a/lib/mock-admin-logs.ts
+++ b/lib/mock-admin-logs.ts
@@ -7,6 +7,21 @@ export interface AdminLog {
 
 export let mockAdminLogs: AdminLog[] = []
 
+const STORAGE_KEY = 'adminLogs'
+
+export function loadAdminLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) mockAdminLogs = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mockAdminLogs))
+  }
+}
+
 export function addAdminLog(action: string, admin: string) {
   mockAdminLogs.push({
     id: Date.now().toString(),
@@ -14,4 +29,6 @@ export function addAdminLog(action: string, admin: string) {
     admin,
     timestamp: new Date().toISOString(),
   })
+  save()
 }
+


### PR DESCRIPTION
## Summary
- store admin logs to localStorage
- add ability to export logs to CSV
- add dashboard log pages for overview, filter, detail, and export
- add admin audit log page

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_687ab3b419a883258af96846939d03d0