### PR TITLE
Implement basic mock store

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -20,7 +20,7 @@ import Image from "next/image"
 import { useCart } from "@/contexts/cart-context"
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/hooks/use-toast"
-import { mockOrders } from "@/lib/mock-orders"
+import { addOrder } from "@/core/mock/store"
 import type { OrderStatus, ShippingStatus } from "@/types/order"
 import { db } from "@/lib/database"
 import { SuggestedExtras } from "@/components/SuggestedExtras"
@@ -112,7 +112,7 @@ export default function CheckoutPage() {
     setTimeout(() => {
       const orderId = `ORD-${Date.now()}`
 
-      mockOrders.push({
+      addOrder({
         id: orderId,
         customerId: user?.id || guestId || "guest",
         customerName: `${shippingInfo.firstName} ${shippingInfo.lastName}`,

--- a/app/dashboard/devtools/mock/page.tsx
+++ b/app/dashboard/devtools/mock/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { Button } from '@/components/ui/buttons/button'
+import { resetStore, generateMockData } from '@/core/mock/store'
+
+export default function MockDevtoolsPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Mock Store Devtools</h1>
+      <div className="flex gap-2">
+        <Button onClick={() => { resetStore(); alert('reset') }}>Reset Store</Button>
+        <Button variant="outline" onClick={() => { generateMockData(); alert('generated') }}>สร้าง mock data ชุดใหม่</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/order-track/[orderId]/page.tsx
+++ b/app/order-track/[orderId]/page.tsx
@@ -4,13 +4,13 @@ import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
-import { mockOrders } from "@/lib/mock-orders"
+import { getOrders } from "@/core/mock/store"
 import Link from "next/link"
 import { CheckCircle, Hammer, Package, Truck, MapPin, CreditCard } from "lucide-react"
 
 export default function OrderTrackPage({ params }: { params: { orderId: string } }) {
   const { orderId } = params
-  const order = mockOrders.find((o) => o.id === orderId)
+  const order = getOrders().find((o) => o.id === orderId)
 
   if (!order) {
     return (

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { ArrowLeft, Download, MessageCircle, Package, Truck, CheckCircle } from "lucide-react"
 import Link from "next/link"
-import { mockOrders } from "@/lib/mock-orders"
+import { getOrders } from "@/core/mock/store"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
 import type { OrderStatus } from "@/types/order"
 import {
@@ -17,7 +17,7 @@ import {
 
 export default function OrderDetailPage({ params }: { params: { id: string } }) {
   const { id } = params
-  const order = mockOrders.find((o) => o.id === id)
+  const order = getOrders().find((o) => o.id === id)
 
   if (!order) {
     return (

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -16,7 +16,7 @@ import { Package, Eye, Download, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/auth-context";
 import { useCart } from "@/contexts/cart-context";
-import { mockOrders } from "@/lib/mock-orders";
+import { getOrders } from "@/core/mock/store";
 import { mockProducts } from "@/lib/mock-products";
 import { mockFeedbacks } from "@/lib/mock-feedback";
 import { reviewReminder, loadReviewReminder } from "@/lib/mock-settings";
@@ -60,7 +60,7 @@ export default function OrdersPage() {
     if (!isAuthenticated) return;
     loadReviewReminder();
     if (!reviewReminder) return;
-    const pending = mockOrders.find(
+    const pending = getOrders().find(
       (o) =>
         o.customerId === user?.id &&
         o.status === "delivered" &&
@@ -84,7 +84,7 @@ export default function OrdersPage() {
     return null;
   }
 
-  const userOrders = mockOrders.filter(
+  const userOrders = getOrders().filter(
     (order) =>
       order.customerId === user?.id &&
       (statusFilter === "all" || order.status === statusFilter),

--- a/app/success/[id]/page.tsx
+++ b/app/success/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/buttons/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card";
-import { mockOrders } from "@/lib/mock-orders";
+import { getOrders } from "@/core/mock/store";
 import { autoMessage, loadAutoMessage } from "@/lib/mock-settings";
 import { addFeedback } from "@/lib/mock-feedback";
 import { Star } from "lucide-react";
@@ -20,7 +20,7 @@ export default function SuccessPage({ params }: { params: { id: string } }) {
     loadAutoMessage();
     setMessage(autoMessage);
   }, []);
-  const order = mockOrders.find((o) => o.id === id);
+  const order = getOrders().find((o) => o.id === id);
 
   const submitFeedback = () => {
     if (submitted || rating === 0) return;

--- a/core/mock/__tests__/store.test.ts
+++ b/core/mock/__tests__/store.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getOrders, addOrder, resetOrders } from '../store'
+import type { Order } from '@/types/order'
+
+const sample: Order = {
+  id: 'T-1',
+  customerId: 'c',
+  customerName: 'test',
+  customerEmail: 'x@test',
+  items: [],
+  total: 0,
+  status: 'paid',
+  depositPercent: 100,
+  createdAt: new Date().toISOString(),
+  shippingAddress: { name: 'n', address: '', city: '', postalCode: '', phone: '' },
+  delivery_method: '',
+  tracking_number: '',
+  shipping_fee: 0,
+  shipping_status: 'pending',
+  shipping_date: '',
+  delivery_note: '',
+  timeline: [],
+}
+
+describe('mock store orders', () => {
+  beforeEach(() => {
+    resetOrders()
+  })
+
+  it('adds order to store', () => {
+    const prev = getOrders().length
+    addOrder(sample)
+    expect(getOrders().length).toBe(prev + 1)
+  })
+})

--- a/core/mock/store/customers.ts
+++ b/core/mock/store/customers.ts
@@ -1,0 +1,42 @@
+import type { Customer } from '@/lib/mock-customers'
+import {
+  mockCustomers as seedCustomers,
+  regenerateMockCustomers,
+} from '@/lib/mock-customers'
+import { loadFromStorage, saveToStorage } from './persist'
+
+const KEY = 'mockStore_customers'
+
+let customers: Customer[] = loadFromStorage<Customer[]>(KEY, [...seedCustomers])
+
+function persist() {
+  saveToStorage(KEY, customers)
+}
+
+export function getCustomers() {
+  return customers
+}
+
+export function addCustomer(customer: Customer) {
+  customers.push(customer)
+  persist()
+}
+
+export function updateCustomer(id: string, data: Partial<Customer>) {
+  const idx = customers.findIndex(c => c.id === id)
+  if (idx !== -1) {
+    customers[idx] = { ...customers[idx], ...data }
+    persist()
+  }
+}
+
+export function resetCustomers() {
+  customers = []
+  persist()
+}
+
+export function regenerateCustomers() {
+  regenerateMockCustomers()
+  customers = [...seedCustomers]
+  persist()
+}

--- a/core/mock/store/fabrics.ts
+++ b/core/mock/store/fabrics.ts
@@ -1,0 +1,44 @@
+import type { Fabric } from '@/mock/fabrics'
+import { fabrics as seedFabrics, addFabric as baseAdd, updateFabric as baseUpdate, removeFabric as baseRemove } from '@/mock/fabrics'
+import { loadFromStorage, saveToStorage } from './persist'
+
+const KEY = 'mockStore_fabrics'
+
+let fabrics: Fabric[] = loadFromStorage<Fabric[]>(KEY, [...seedFabrics])
+
+function persist() {
+  saveToStorage(KEY, fabrics)
+}
+
+export function getFabrics() {
+  return fabrics
+}
+
+export function addFabric(data: Omit<Fabric, 'id'>) {
+  const fabric = baseAdd ? baseAdd(data) : { id: `fab-${Date.now()}`, ...data }
+  fabrics = [...seedFabrics]
+  persist()
+  return fabric
+}
+
+export function updateFabric(id: string, data: Partial<Omit<Fabric, 'id'>>) {
+  if (baseUpdate) baseUpdate(id, data)
+  fabrics = [...seedFabrics]
+  persist()
+}
+
+export function removeFabric(id: string) {
+  if (baseRemove) baseRemove(id)
+  fabrics = [...seedFabrics]
+  persist()
+}
+
+export function resetFabrics() {
+  fabrics = []
+  persist()
+}
+
+export function regenerateFabrics() {
+  fabrics = [...seedFabrics]
+  persist()
+}

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -1,0 +1,19 @@
+export * from './orders'
+export * from './customers'
+export * from './fabrics'
+
+import { resetOrders, regenerateOrders } from './orders'
+import { resetCustomers, regenerateCustomers } from './customers'
+import { resetFabrics, regenerateFabrics } from './fabrics'
+
+export function resetStore() {
+  resetOrders()
+  resetCustomers()
+  resetFabrics()
+}
+
+export function generateMockData() {
+  regenerateOrders()
+  regenerateCustomers()
+  regenerateFabrics()
+}

--- a/core/mock/store/orders.ts
+++ b/core/mock/store/orders.ts
@@ -1,0 +1,42 @@
+import type { Order } from '@/types/order'
+import {
+  mockOrders as seedOrders,
+  regenerateMockOrders,
+} from '@/lib/mock-orders'
+import { loadFromStorage, saveToStorage } from './persist'
+
+const KEY = 'mockStore_orders'
+
+let orders: Order[] = loadFromStorage<Order[]>(KEY, [...seedOrders])
+
+function persist() {
+  saveToStorage(KEY, orders)
+}
+
+export function getOrders() {
+  return orders
+}
+
+export function addOrder(order: Order) {
+  orders.push(order)
+  persist()
+}
+
+export function updateOrder(id: string, data: Partial<Order>) {
+  const idx = orders.findIndex(o => o.id === id)
+  if (idx !== -1) {
+    orders[idx] = { ...orders[idx], ...data }
+    persist()
+  }
+}
+
+export function resetOrders() {
+  orders = []
+  persist()
+}
+
+export function regenerateOrders() {
+  regenerateMockOrders()
+  orders = [...seedOrders]
+  persist()
+}

--- a/core/mock/store/persist.ts
+++ b/core/mock/store/persist.ts
@@ -1,0 +1,21 @@
+export function loadFromStorage<T>(key: string, fallback: T): T {
+  if (typeof window !== 'undefined') {
+    try {
+      const raw = localStorage.getItem(key)
+      if (raw) return JSON.parse(raw) as T
+    } catch {
+      // ignore
+    }
+  }
+  return fallback
+}
+
+export function saveToStorage<T>(key: string, data: T) {
+  if (typeof window !== 'undefined') {
+    try {
+      localStorage.setItem(key, JSON.stringify(data))
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- build a global mock store under `core/mock/store` with orders, customers and fabrics
- wire mock store into checkout and order pages
- add a mock store devtools page
- test adding an order to the store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aba3e516c8325859d7fc70a8eb201