### PR TITLE
Add admin/store layouts and global fallback components

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { useState } from "react"
+import Sidebar from "@/components/admin/Sidebar"
+import Topbar from "@/components/admin/Topbar"
+import { Sheet, SheetContent } from "@/components/ui/modals/sheet"
+import { useIsMobile } from "@/hooks/use-mobile"
+import WithSuspense from "@/components/WithSuspense"
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const isMobile = useIsMobile()
+
+  return (
+    <WithSuspense>
+      <div className="flex min-h-screen">
+        <Sidebar className="hidden md:flex" />
+        {isMobile && (
+          <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+            <SheetContent side="left" className="p-0 w-60">
+              <Sidebar />
+            </SheetContent>
+          </Sheet>
+        )}
+        <div className="flex flex-1 flex-col">
+          <Topbar onMenuClick={() => setSidebarOpen(true)} />
+          <main className="flex-1 p-4 pb-20 md:pb-4">{children}</main>
+        </div>
+      </div>
+    </WithSuspense>
+  )
+}

--- a/app/fallback/404/page.tsx
+++ b/app/fallback/404/page.tsx
@@ -1,0 +1,8 @@
+import Fallback from '@/components/Fallback'
+export default function NotFoundPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Fallback type="404" title="ไม่พบหน้า" />
+    </div>
+  )
+}

--- a/app/fallback/error/page.tsx
+++ b/app/fallback/error/page.tsx
@@ -1,0 +1,8 @@
+import Fallback from '@/components/Fallback'
+export default function ErrorPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Fallback type="error" />
+    </div>
+  )
+}

--- a/app/fallback/loading/page.tsx
+++ b/app/fallback/loading/page.tsx
@@ -1,0 +1,8 @@
+import Fallback from '@/components/Fallback'
+export default function LoadingPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Fallback type="loading" />
+    </div>
+  )
+}

--- a/app/fallback/under-construction/page.tsx
+++ b/app/fallback/under-construction/page.tsx
@@ -1,0 +1,8 @@
+import Fallback from '@/components/Fallback'
+export default function UnderConstructionPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Fallback type="under-construction" />
+    </div>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,23 +1,5 @@
-"use client"
-
-import Link from "next/link"
-import { Search } from "lucide-react"
-import { Button } from "@/components/ui/buttons/button"
-import EmptyState from "@/components/ui/EmptyState"
+import { redirect } from 'next/navigation'
 
 export default function NotFound() {
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <EmptyState
-        icon={<Search className="h-10 w-10 text-muted-foreground" />}
-        title="ไม่พบหน้าที่คุณค้นหา"
-        description="ขออภัย หน้าที่คุณเปิดอาจถูกย้ายหรือลบไปแล้ว"
-        action={
-          <Link href="/">
-            <Button>กลับหน้าแรก</Button>
-          </Link>
-        }
-      />
-    </div>
-  )
+  redirect('/fallback/404')
 }

--- a/app/store/layout.tsx
+++ b/app/store/layout.tsx
@@ -1,0 +1,20 @@
+"use client"
+import WithSuspense from "@/components/WithSuspense"
+import Navbar from "@/components/navbar"
+import { Footer } from "@/components/footer"
+
+export default function StorefrontLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <WithSuspense>
+        <div className="flex-1">{children}</div>
+      </WithSuspense>
+      <Footer />
+    </div>
+  )
+}

--- a/components/Fallback.tsx
+++ b/components/Fallback.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { ReactNode } from "react"
+import { Loader2, AlertTriangle, Construction } from "lucide-react"
+
+export type FallbackType = "loading" | "error" | "under-construction" | "404"
+
+interface FallbackProps {
+  type?: FallbackType
+  title?: string
+  subtitle?: string
+}
+
+export default function Fallback({
+  type = "loading",
+  title,
+  subtitle,
+}: FallbackProps) {
+  let icon: ReactNode = null
+  switch (type) {
+    case "loading":
+      icon = <Loader2 className="h-10 w-10 animate-spin" />
+      title = title || "กำลังโหลดข้อมูล"
+      break
+    case "error":
+      icon = <AlertTriangle className="h-10 w-10 text-destructive" />
+      title = title || "เกิดข้อผิดพลาด"
+      break
+    case "under-construction":
+      icon = <Construction className="h-10 w-10" />
+      title = title || "อยู่ระหว่างการพัฒนา"
+      break
+    case "404":
+      icon = <AlertTriangle className="h-10 w-10" />
+      title = title || "ไม่พบข้อมูล"
+      break
+  }
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center space-y-2">
+      {icon}
+      {title && <h2 className="text-lg font-semibold">{title}</h2>}
+      {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+    </div>
+  )
+}

--- a/components/WithSuspense.tsx
+++ b/components/WithSuspense.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { Suspense, ReactNode } from "react"
+import Fallback, { FallbackType } from "./Fallback"
+
+export default function WithSuspense({
+  children,
+  fallbackType = "loading",
+}: {
+  children: ReactNode
+  fallbackType?: FallbackType
+}) {
+  return (
+    <Suspense fallback={<Fallback type={fallbackType} />}>{children}</Suspense>
+  )
+}


### PR DESCRIPTION
## Summary
- add `DashboardLayout` with sidebar and topbar for `/dashboard/*`
- implement `StorefrontLayout` for `/store/*` pages
- create reusable `Fallback` and `WithSuspense` components
- add fallback pages under `/fallback/*`
- redirect unknown routes to `/fallback/404`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687abece0fb88325bfb86075be3691d3