### PR TITLE
Add developer tools and demo mode

### DIFF
--- a/app/dashboard/devtools/env/page.tsx
+++ b/app/dashboard/devtools/env/page.tsx
@@ -1,0 +1,22 @@
+"use client"
+import { getEnv, setEnv, EnvMode } from '@/lib/system-config'
+import { useState } from 'react'
+
+export default function EnvPage() {
+  const [env, setEnvState] = useState<EnvMode>(getEnv())
+  const handle = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value as EnvMode
+    setEnvState(val)
+    setEnv(val)
+  }
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Environment Mode</h1>
+      <select value={env} onChange={handle} className="border p-1">
+        <option value="development">development</option>
+        <option value="preview">preview</option>
+        <option value="production">production</option>
+      </select>
+    </div>
+  )
+}

--- a/app/dashboard/devtools/flags/page.tsx
+++ b/app/dashboard/devtools/flags/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+import { useFeatureFlags } from '@/contexts/feature-flag-context'
+
+export default function FlagsPage() {
+  const { isEnabled, toggle } = useFeatureFlags()
+  const flags = ['review', 'newSystem'] as const
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Feature Flags</h1>
+      <ul className="space-y-2">
+        {flags.map((f) => (
+          <li key={f} className="flex items-center gap-2">
+            <label className="capitalize">{f}</label>
+            <input type="checkbox" checked={isEnabled(f)} onChange={() => toggle(f)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/devtools/page.tsx
+++ b/app/dashboard/devtools/page.tsx
@@ -1,0 +1,13 @@
+export default function DevToolsPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Developer Tools</h1>
+      <p>Use the floating DevBar for quick actions.</p>
+      <ul className="list-disc pl-5 space-y-1">
+        <li><a href="/dashboard/devtools/flags" className="text-blue-600 underline">Feature Flags</a></li>
+        <li><a href="/dashboard/devtools/env" className="text-blue-600 underline">Environment Mode</a></li>
+        <li><a href="/dashboard/devtools/mock-editor" className="text-blue-600 underline">Mock Editor</a></li>
+      </ul>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import "./globals.css"
 import { Toaster } from "@/components/ui/toaster"
 import { CartProvider } from "@/contexts/cart-context"
 import { AuthProvider } from "@/contexts/auth-context"
+import { FeatureFlagProvider } from "@/contexts/feature-flag-context"
+import { DemoProvider } from "@/contexts/demo-context"
 import { WishlistProvider } from "@/contexts/wishlist-context"
 import { CompareProvider } from "@/contexts/compare-context"
 import { ReviewImagesProvider } from "@/contexts/review-images-context"
@@ -12,6 +14,7 @@ import { FavoritesProvider } from "@/contexts/favorites-context"
 import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-context"
 import { validateMockData } from "@/lib/mock-validator"
 import RedirectMobileHome from "@/components/RedirectMobileHome"
+import DevBar from "@/components/DevBar"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -32,23 +35,28 @@ export default function RootLayout({
   return (
     <html lang="th">
       <body className={`${inter.className} px-4 sm:px-6 overflow-x-hidden`}>
-        <AuthProvider>
-          <CartProvider>
-            <WishlistProvider>
-              <CompareProvider>
-                <FavoritesProvider>
-                  <AdminProductGroupsProvider>
-                    <ReviewImagesProvider>
-                      <RedirectMobileHome />
-                      {children}
-                      <Toaster />
-                    </ReviewImagesProvider>
-                  </AdminProductGroupsProvider>
-                </FavoritesProvider>
-              </CompareProvider>
-            </WishlistProvider>
-          </CartProvider>
-        </AuthProvider>
+        <FeatureFlagProvider>
+          <DemoProvider>
+            <AuthProvider>
+              <CartProvider>
+                <WishlistProvider>
+                  <CompareProvider>
+                    <FavoritesProvider>
+                      <AdminProductGroupsProvider>
+                        <ReviewImagesProvider>
+                          <RedirectMobileHome />
+                          {children}
+                          <DevBar />
+                          <Toaster />
+                        </ReviewImagesProvider>
+                      </AdminProductGroupsProvider>
+                    </FavoritesProvider>
+                  </CompareProvider>
+                </WishlistProvider>
+              </CartProvider>
+            </AuthProvider>
+          </DemoProvider>
+        </FeatureFlagProvider>
       </body>
     </html>
   )

--- a/components/DevBar.tsx
+++ b/components/DevBar.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
+import { useAuth } from '@/contexts/auth-context'
+import { setEnv, getEnv, EnvMode } from '@/lib/system-config'
+import { useFeatureFlags } from '@/contexts/feature-flag-context'
+import { useDemo } from '@/contexts/demo-context'
+import { APP_VERSION, GIT_BRANCH, GIT_COMMIT } from '@/lib/version'
+
+export default function DevBar() {
+  const { setTheme, resolvedTheme } = useTheme()
+  const { logout } = useAuth()
+  const { toggle } = useFeatureFlags()
+  const { toggle: toggleDemo } = useDemo()
+  const [env, setEnvState] = useState<EnvMode>(getEnv())
+
+  useEffect(() => {
+    setEnv(env)
+  }, [env])
+
+  return (
+    <div className="fixed bottom-2 right-2 z-50 space-x-2 bg-gray-100 border px-2 py-1 rounded shadow text-sm">
+      <button onClick={() => {
+        localStorage.clear();
+        location.reload();
+      }}>Reset Mock</button>
+      <button onClick={() => logout()}>Reset Auth</button>
+      <button onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}>Toggle Theme</button>
+      <button onClick={() => toggle('review')}>Toggle Review</button>
+      <button onClick={toggleDemo}>Demo Mode</button>
+      <select value={env} onChange={e => setEnvState(e.target.value as EnvMode)} className="border ml-2">
+        <option value="development">dev</option>
+        <option value="preview">preview</option>
+        <option value="production">prod</option>
+      </select>
+      <span className="ml-2">{APP_VERSION}</span>
+    </div>
+  )
+}

--- a/components/customers/CustomerCard.tsx
+++ b/components/customers/CustomerCard.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import type { Customer } from "@/lib/mock-customers"
+import { useDemo } from "@/contexts/demo-context"
 
 function statusColor(status: string) {
   if (status === "VIP") return "bg-yellow-200 text-yellow-800"
@@ -11,6 +12,7 @@ function statusColor(status: string) {
 }
 
 export default function CustomerCard({ customer }: { customer: Customer }) {
+  const { enabled } = useDemo()
   const status =
     customer.tier === "VIP" ? "VIP" : (customer.points ?? 0) > 50 ? "returning" : "new"
   return (
@@ -18,7 +20,7 @@ export default function CustomerCard({ customer }: { customer: Customer }) {
       <Card className="hover:bg-muted/50">
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
-            {customer.name}
+            {enabled ? <span className="blur-sm">{customer.name}</span> : customer.name}
             <span
               className={`rounded px-2 py-0.5 text-xs font-medium ${statusColor(status)}`}
             >

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { Facebook, Instagram, Twitter, Mail, Phone, MapPin } from "lucide-react"
+import { APP_VERSION, GIT_BRANCH, GIT_COMMIT } from "@/lib/version"
 
 export function Footer() {
   return (
@@ -84,8 +85,11 @@ export function Footer() {
           </div>
         </div>
 
-        <div className="border-t border-gray-800 mt-8 pt-8 text-center">
+        <div className="border-t border-gray-800 mt-8 pt-8 text-center space-y-1">
           <p className="text-gray-400 text-sm">© 2024 SofaCover Pro. สงวนลิขสิทธิ์ทั้งหมด.</p>
+          <p className="text-gray-500 text-xs">
+            Version {APP_VERSION} ({GIT_BRANCH}@{GIT_COMMIT})
+          </p>
         </div>
       </div>
     </footer>

--- a/contexts/demo-context.tsx
+++ b/contexts/demo-context.tsx
@@ -1,0 +1,38 @@
+"use client"
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+interface DemoState {
+  enabled: boolean
+  toggle: () => void
+}
+
+const DemoContext = createContext<DemoState | null>(null)
+
+export function DemoProvider({ children }: { children: ReactNode }) {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = localStorage.getItem('demo_mode')
+    if (stored) setEnabled(stored === '1')
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('demo_mode', enabled ? '1' : '0')
+  }, [enabled])
+
+  const toggle = () => setEnabled((e) => !e)
+
+  return (
+    <DemoContext.Provider value={{ enabled, toggle }}>
+      {children}
+    </DemoContext.Provider>
+  )
+}
+
+export function useDemo() {
+  const ctx = useContext(DemoContext)
+  if (!ctx) throw new Error('useDemo must be used within DemoProvider')
+  return ctx
+}

--- a/contexts/feature-flag-context.tsx
+++ b/contexts/feature-flag-context.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+export type FeatureFlag = 'review' | 'newSystem'
+
+interface FeatureFlagState {
+  isEnabled: (flag: FeatureFlag) => boolean
+  toggle: (flag: FeatureFlag) => void
+}
+
+const FeatureFlagContext = createContext<FeatureFlagState | null>(null)
+
+export function FeatureFlagProvider({ children }: { children: ReactNode }) {
+  const [flags, setFlags] = useState<Record<FeatureFlag, boolean>>({
+    review: false,
+    newSystem: false,
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const stored = localStorage.getItem('feature_flags')
+      if (stored) setFlags(JSON.parse(stored))
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('feature_flags', JSON.stringify(flags))
+  }, [flags])
+
+  const isEnabled = (flag: FeatureFlag) => !!flags[flag]
+
+  const toggle = (flag: FeatureFlag) =>
+    setFlags((f) => ({ ...f, [flag]: !f[flag] }))
+
+  return (
+    <FeatureFlagContext.Provider value={{ isEnabled, toggle }}>
+      {children}
+    </FeatureFlagContext.Provider>
+  )
+}
+
+export function useFeatureFlags() {
+  const ctx = useContext(FeatureFlagContext)
+  if (!ctx) throw new Error('useFeatureFlags must be used within FeatureFlagProvider')
+  return ctx
+}

--- a/lib/system-config.ts
+++ b/lib/system-config.ts
@@ -1,0 +1,37 @@
+export type EnvMode = 'development' | 'preview' | 'production'
+
+interface Config {
+  env: EnvMode
+}
+
+const defaultConfig: Config = {
+  env: 'development',
+}
+
+let config: Config = { ...defaultConfig }
+
+export function loadConfig() {
+  if (typeof window === 'undefined') return config
+  const stored = localStorage.getItem('system_config')
+  if (stored) {
+    try {
+      config = { ...config, ...JSON.parse(stored) }
+    } catch {}
+  }
+  return config
+}
+
+export function saveConfig(newConfig: Partial<Config>) {
+  config = { ...config, ...newConfig }
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('system_config', JSON.stringify(config))
+  }
+}
+
+export function getEnv() {
+  return loadConfig().env
+}
+
+export function setEnv(env: EnvMode) {
+  saveConfig({ env })
+}

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,0 +1,3 @@
+export const APP_VERSION = 'v0.11.4'
+export const GIT_BRANCH = 'main'
+export const GIT_COMMIT = 'abcdef0'


### PR DESCRIPTION
## Summary
- add DevBar floating toolbar with quick actions
- manage feature flags and environment in localStorage
- provide demo mode with blurred customer names
- show app version info in footer and DevBar
- create DevTools pages for flags and environment modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ac154aee0832584dd65d350ef36a4