### PR TITLE
Implement store dev previews and UX tweaks

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-cont
 import { validateMockData } from "@/lib/mock-validator"
 import RedirectMobileHome from "@/components/RedirectMobileHome"
 import DevBar from "@/components/DevBar"
+import StoreBottomNav from "@/components/StoreBottomNav"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -46,6 +47,7 @@ export default function RootLayout({
                         <ReviewImagesProvider>
                           <RedirectMobileHome />
                           {children}
+                          <StoreBottomNav />
                           <DevBar />
                           <Toaster />
                         </ReviewImagesProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,8 @@ import { Card, CardContent } from "@/components/ui/cards/card"
 import { Badge } from "@/components/ui/badge"
 import { Star, Shield, Truck, Headphones, ArrowRight } from "lucide-react"
 import Link from "next/link"
-import Image from "next/image"
+import LazyImage from "@/components/LazyImage"
+import PrefetchLink from "@/components/PrefetchLink"
 import { HeroBannerSection } from "@/components/HeroBannerSection"
 import { mockProducts } from "@/lib/mock-products"
 import { getCollections } from "@/lib/mock-collections"
@@ -33,9 +34,9 @@ export default async function HomePage() {
               {curatedProducts.map((product) => (
                 <Card key={product.id} className="group hover:shadow-lg transition-shadow">
                   <CardContent className="p-0">
-                    <Link href={`/products/${product.slug}`}>
+                    <PrefetchLink href={`/products/${product.slug}`}>
                       <div className="relative overflow-hidden rounded-t-lg">
-                        <Image
+                        <LazyImage
                           src={product.images[0] || "/placeholder.svg"}
                           alt={product.name}
                           width={300}
@@ -52,7 +53,7 @@ export default async function HomePage() {
                           )}
                         </div>
                       </div>
-                    </Link>
+                    </PrefetchLink>
                   </CardContent>
                 </Card>
               ))}
@@ -119,7 +120,7 @@ export default async function HomePage() {
                 className="border rounded-lg overflow-hidden bg-white hover:shadow transition"
               >
                 <div className="relative w-full h-40">
-                  <Image
+                  <LazyImage
                     src={col.images[0] || "/placeholder.svg"}
                     alt={col.name}
                     fill
@@ -157,14 +158,14 @@ export default async function HomePage() {
               <Card key={product.id} className="group hover:shadow-lg transition-shadow">
                 <CardContent className="p-0">
                   <div className="relative overflow-hidden rounded-t-lg">
-                    <Image
+                    <LazyImage
                       src={product.images[0] || "/placeholder.svg"}
                       alt={product.name}
                       width={300}
                       height={300}
                       className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
                     />
-                    {product.originalPrice && (
+                  {product.originalPrice && (
                       <Badge className="absolute top-2 left-2 bg-red-500">
                         ลด {Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)}%
                       </Badge>
@@ -196,9 +197,9 @@ export default async function HomePage() {
                       )}
                     </div>
 
-                    <Link href={`/products/${product.slug}`}> 
+                    <PrefetchLink href={`/products/${product.slug}`}>
                       <Button className="w-full mt-4">ดูรายละเอียด</Button>
-                    </Link>
+                    </PrefetchLink>
                   </div>
                 </CardContent>
               </Card>

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Star, Heart, Share2, ShoppingCart, Truck, Shield, RotateCcw, Minus, Plus } from "lucide-react"
-import Image from "next/image"
+import LazyImage from "@/components/LazyImage"
 import Link from "next/link"
 import { mockProducts } from "@/lib/mock-products"
 import { mockOrders } from "@/lib/mock-orders"
@@ -173,7 +173,7 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
           {/* Product Images */}
           <div className="space-y-4">
             <div className="aspect-square overflow-hidden rounded-lg border">
-              <Image
+              <LazyImage
                 src={product.images[selectedImage] || "/placeholder.svg"}
                 alt={product.name}
                 width={600}
@@ -190,7 +190,7 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
                     selectedImage === index ? "border-primary" : "border-gray-200"
                   }`}
                 >
-                  <Image
+                  <LazyImage
                     src={image || "/placeholder.svg"}
                     alt={`${product.name} ${index + 1}`}
                     width={150}
@@ -514,9 +514,9 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
               .map((relatedProduct) => (
                 <Card key={relatedProduct.id} className="group hover:shadow-lg transition-shadow">
                   <CardContent className="p-0">
-                    <Link href={`/products/${relatedProduct.slug}`}>
+                    <PrefetchLink href={`/products/${relatedProduct.slug}`}>
                       <div className="relative overflow-hidden rounded-t-lg">
-                        <Image
+                        <LazyImage
                           src={relatedProduct.images[0] || "/placeholder.svg"}
                           alt={relatedProduct.name}
                           width={300}
@@ -537,7 +537,7 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
                           )}
                         </div>
                       </div>
-                    </Link>
+                    </PrefetchLink>
                   </CardContent>
                 </Card>
               ))}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -11,7 +11,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Checkbox } from "@/components/ui/checkbox"
 import { Star, Filter, Grid, List } from "lucide-react"
 import Link from "next/link"
-import Image from "next/image"
+import LazyImage from "@/components/LazyImage"
+import PrefetchLink from "@/components/PrefetchLink"
 import { mockProducts } from "@/lib/mock-products"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
@@ -170,7 +171,7 @@ export default function ProductsPage() {
                     {viewMode === "grid" ? (
                       <>
                         <div className="relative overflow-hidden rounded-t-lg">
-                          <Image
+                          <LazyImage
                             src={product.images[0] || "/placeholder.svg"}
                             alt={product.name}
                             width={300}
@@ -214,15 +215,15 @@ export default function ProductsPage() {
                             )}
                           </div>
 
-                          <Link href={`/products/${product.slug}`}> 
+                          <PrefetchLink href={`/products/${product.slug}`}>
                             <Button className="w-full mt-4">ดูรายละเอียด</Button>
-                          </Link>
+                          </PrefetchLink>
                         </div>
                       </>
                     ) : (
                       <div className="flex p-4 space-x-4">
                         <div className="relative w-32 h-32 flex-shrink-0">
-                          <Image
+                          <LazyImage
                             src={product.images[0] || "/placeholder.svg"}
                             alt={product.name}
                             width={128}
@@ -267,9 +268,9 @@ export default function ProductsPage() {
                               )}
                             </div>
 
-                            <Link href={`/products/${product.slug}`}> 
+                            <PrefetchLink href={`/products/${product.slug}`}>
                               <Button>ดูรายละเอียด</Button>
-                            </Link>
+                            </PrefetchLink>
                           </div>
                         </div>
                       </div>

--- a/app/store/dev/responsive/page.tsx
+++ b/app/store/dev/responsive/page.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+
+export default function ResponsivePreviewPage() {
+  if (process.env.NODE_ENV !== "development") {
+    return <div className="p-4">Available only in development mode.</div>
+  }
+  const [device, setDevice] = useLocalStorage<"desktop" | "tablet" | "mobile">(
+    "preview-device",
+    "desktop",
+  )
+  const width = device === "desktop" ? "100%" : device === "tablet" ? "768px" : "375px"
+  return (
+    <div className="p-4 space-y-4">
+      <ToggleGroup type="single" value={device} onValueChange={(v) => setDevice(v as any)}>
+        <ToggleGroupItem value="desktop">Desktop</ToggleGroupItem>
+        <ToggleGroupItem value="tablet">Tablet</ToggleGroupItem>
+        <ToggleGroupItem value="mobile">Mobile</ToggleGroupItem>
+      </ToggleGroup>
+      <div className="border mx-auto" style={{ width }}>
+        <iframe src="/" className="w-full h-[800px]" />
+      </div>
+    </div>
+  )
+}

--- a/app/store/dev/simulator/page.tsx
+++ b/app/store/dev/simulator/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+export default function MobileSimulatorPage() {
+  if (process.env.NODE_ENV !== "development") {
+    return <div className="p-4">Available only in development mode.</div>
+  }
+  return (
+    <div className="flex justify-center p-4">
+      <div className="border-8 rounded-[2rem] border-gray-800 w-[600px] h-[800px] overflow-hidden">
+        <iframe src="/" className="w-full h-full" />
+      </div>
+    </div>
+  )
+}

--- a/components/LazyImage.tsx
+++ b/components/LazyImage.tsx
@@ -1,0 +1,33 @@
+"use client"
+import Image, { type ImageProps } from "next/image"
+import { useEffect, useRef, useState } from "react"
+
+export default function LazyImage({ className, ...props }: ImageProps) {
+  const [visible, setVisible] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+    const obs = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        setVisible(true)
+        obs.disconnect()
+      }
+    })
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [])
+
+  const style = !('fill' in props && props.fill) ? { width: props.width, height: props.height } : {}
+
+  return (
+    <div ref={ref} style={style} className={"relative " + (className || "")}>
+      {visible ? (
+        <Image {...props} className={props.className} />
+      ) : (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+      )}
+    </div>
+  )
+}

--- a/components/PrefetchLink.tsx
+++ b/components/PrefetchLink.tsx
@@ -1,0 +1,20 @@
+"use client"
+import Link, { LinkProps } from "next/link"
+import { useRouter } from "next/navigation"
+import { AnchorHTMLAttributes, PropsWithChildren } from "react"
+
+export default function PrefetchLink({ href, children, ...props }: PropsWithChildren<LinkProps & AnchorHTMLAttributes<HTMLAnchorElement>>) {
+  const router = useRouter()
+  return (
+    <Link
+      href={href}
+      {...props}
+      onMouseEnter={(e) => {
+        props.onMouseEnter?.(e)
+        router.prefetch(href.toString())
+      }}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/components/StoreBottomNav.tsx
+++ b/components/StoreBottomNav.tsx
@@ -1,0 +1,36 @@
+"use client"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { Home, ShoppingCart, Package, User } from "lucide-react"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+export default function StoreBottomNav() {
+  const isMobile = useIsMobile()
+  const pathname = usePathname()
+
+  if (!isMobile) return null
+
+  const itemClass = (active: boolean) =>
+    `flex flex-col items-center flex-1 ${active ? 'text-primary' : ''}`
+
+  return (
+    <nav className="fixed bottom-0 inset-x-0 z-40 border-t bg-background flex text-xs">
+      <Link href="/" className={itemClass(pathname === '/')}> 
+        <Home className="h-5 w-5" />
+        Home
+      </Link>
+      <Link href="/cart" className={itemClass(pathname.startsWith('/cart'))}>
+        <ShoppingCart className="h-5 w-5" />
+        Cart
+      </Link>
+      <Link href="/orders" className={itemClass(pathname.startsWith('/orders'))}>
+        <Package className="h-5 w-5" />
+        Orders
+      </Link>
+      <Link href="/profile" className={itemClass(pathname.startsWith('/profile'))}>
+        <User className="h-5 w-5" />
+        Profile
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add LazyImage for IntersectionObserver-based lazy loading
- prefetch product links on hover
- introduce mobile bottom navigation
- add responsive preview and mobile simulator dev pages
- wire bottom nav into app layout

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac4c759808325a235be88e01d385f