### PR TITLE
Fix Chatwoot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ The notification service uses additional variables:
 
 ## Chatwoot
 
-The store now uses [Chatwoot](https://www.chatwoot.com/) for the customer chat
-system. The source for Chatwoot is included under the `chatwoot/` directory.
-To run Chatwoot locally:
+The store uses [Chatwoot](https://www.chatwoot.com/) for the customer chat
+system. The Chatwoot source code is not bundled in this repository. To run the
+chat backend locally, clone the official Chatwoot repository into a `chatwoot/`
+folder (or point the application to an existing instance) and start it using
+Docker:
 
 ```bash
+git clone https://github.com/chatwoot/chatwoot.git chatwoot
 cd chatwoot
 cp .env.example .env
 docker-compose build


### PR DESCRIPTION
## Summary
- clarify that Chatwoot sources are not bundled
- show how to clone Chatwoot for local development

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b20e57cfc8325bdd5234360e5fae3