### PR TITLE
Implement storefront builder tools

### DIFF
--- a/app/api/storefront/save/route.ts
+++ b/app/api/storefront/save/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { setLayout, setTheme } from '@/core/mock/store'
+import type { LayoutComponent, ThemeConfig } from '@/types/storefront'
+
+export async function POST(req: Request) {
+  try {
+    const { layout, theme } = await req.json()
+    if (layout) setLayout(layout)
+    if (theme) setTheme(theme)
+    return NextResponse.json({ success: true })
+  } catch (e) {
+    console.error('Save layout error', e)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/app/dashboard/storefront/colors/page.tsx
+++ b/app/dashboard/storefront/colors/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useEffect, useState } from 'react'
+import SectionHeader from '@/components/ui/SectionHeader'
+import { Button } from '@/components/ui/buttons/button'
+import { getConfig, setTheme } from '@/core/mock/store'
+import type { ColorPalette } from '@/types/storefront'
+
+export default function ColorsPage() {
+  const [colors, setColors] = useState<ColorPalette>({
+    primary: '#2563eb',
+    secondary: '#ec4899',
+    background: '#ffffff',
+    text: '#000000',
+  })
+
+  useEffect(() => {
+    const cfg = getConfig()
+    setColors(cfg.theme.colors)
+  }, [])
+
+  const change = (key: keyof ColorPalette, value: string) =>
+    setColors((c) => ({ ...c, [key]: value }))
+
+  const handleSave = () => {
+    const cfg = getConfig()
+    setTheme({ ...cfg.theme, colors })
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <SectionHeader title="กำหนดสีหลัก" />
+      <div className="grid grid-cols-2 gap-4 max-w-md">
+        {(['primary','secondary','background','text'] as Array<keyof ColorPalette>).map((k) => (
+          <label key={k} className="space-y-1 text-sm capitalize">
+            <span>{k}</span>
+            <input type="color" value={colors[k]} onChange={(e) => change(k, e.target.value)} />
+          </label>
+        ))}
+      </div>
+      <div className="border p-4 rounded" style={{background: colors.background, color: colors.text}}>
+        <div className="p-2" style={{background: colors.primary}}>Header</div>
+        <div className="p-2 mt-2" style={{background: colors.secondary}}>Product Card</div>
+      </div>
+      <Button onClick={handleSave}>บันทึกสี</Button>
+    </div>
+  )
+}

--- a/app/dashboard/storefront/layout/page.tsx
+++ b/app/dashboard/storefront/layout/page.tsx
@@ -1,0 +1,68 @@
+"use client"
+import { useEffect, useState } from 'react'
+import SectionHeader from '@/components/ui/SectionHeader'
+import { Button } from '@/components/ui/buttons/button'
+import { getConfig, setLayout } from '@/core/mock/store'
+import type { LayoutComponent, LayoutComponentType } from '@/types/storefront'
+
+const options: { label: string; type: LayoutComponentType }[] = [
+  { label: 'Banner', type: 'banner' },
+  { label: 'Product List', type: 'product' },
+  { label: 'CTA', type: 'cta' },
+  { label: 'Review', type: 'review' },
+]
+
+export default function LayoutBuilderPage() {
+  const [items, setItems] = useState<LayoutComponent[]>([])
+  const [dragId, setDragId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const cfg = getConfig()
+    setItems(cfg.layout.length ? cfg.layout : [])
+  }, [])
+
+  const addComponent = (type: LayoutComponentType) =>
+    setItems((it) => [...it, { id: Date.now().toString(), type }])
+
+  const handleDragStart = (id: string) => setDragId(id)
+  const handleDrop = (id: string) => {
+    if (!dragId || dragId === id) return
+    const arr = items.slice()
+    const from = arr.findIndex((i) => i.id === dragId)
+    const to = arr.findIndex((i) => i.id === id)
+    const [m] = arr.splice(from, 1)
+    arr.splice(to, 0, m)
+    setItems(arr)
+    setDragId(null)
+  }
+
+  const handleSave = () => setLayout(items)
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <SectionHeader title="หน้าแรก" description="Drag & Drop ปรับลำดับ" />
+      <div className="flex gap-2">
+        {options.map((o) => (
+          <Button key={o.type} variant="outline" onClick={() => addComponent(o.type)}>
+            {o.label}
+          </Button>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {items.map((it) => (
+          <div
+            key={it.id}
+            draggable
+            onDragStart={() => handleDragStart(it.id)}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => handleDrop(it.id)}
+            className="border p-2 rounded bg-white"
+          >
+            {it.type}
+          </div>
+        ))}
+      </div>
+      <Button onClick={handleSave}>บันทึก Layout</Button>
+    </div>
+  )
+}

--- a/app/dashboard/storefront/theme/page.tsx
+++ b/app/dashboard/storefront/theme/page.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { useState, useEffect } from 'react'
+import SectionHeader from '@/components/ui/SectionHeader'
+import { Button } from '@/components/ui/buttons/button'
+import { getConfig, setTheme } from '@/core/mock/store'
+import type { ThemeName, ThemeConfig } from '@/types/storefront'
+
+const themes: ThemeName[] = ['light', 'dark', 'soft', 'neon']
+
+export default function ThemeSelectorPage() {
+  const [current, setCurrent] = useState<ThemeName>('light')
+
+  useEffect(() => {
+    const cfg = getConfig()
+    setCurrent(cfg.theme.theme)
+  }, [])
+
+  const handleSave = () => {
+    const cfg = getConfig()
+    const newTheme: ThemeConfig = { ...cfg.theme, theme: current }
+    setTheme(newTheme)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <SectionHeader title="เลือกธีมหลัก" />
+      <div className="flex gap-4">
+        {themes.map((t) => (
+          <button
+            key={t}
+            onClick={() => setCurrent(t)}
+            className={`border px-4 py-2 rounded ${current === t ? 'bg-primary text-white' : ''}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="border p-4 rounded">Preview: {current}</div>
+      <Button onClick={handleSave}>บันทึกธีม</Button>
+    </div>
+  )
+}

--- a/app/store/preview/page.tsx
+++ b/app/store/preview/page.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { getConfig } from '@/core/mock/store'
+import type { LayoutComponent } from '@/types/storefront'
+import { HeroBannerSection } from '@/components/HeroBannerSection'
+import { Footer } from '@/components/footer'
+
+function renderItem(item: LayoutComponent) {
+  switch (item.type) {
+    case 'banner':
+      return <HeroBannerSection key={item.id} />
+    case 'product':
+      return (
+        <section key={item.id} className="p-8 text-center bg-gray-50">
+          Product List (mock)
+        </section>
+      )
+    case 'cta':
+      return (
+        <section key={item.id} className="p-8 text-center bg-blue-600 text-white">
+          CTA Section (mock)
+        </section>
+      )
+    case 'review':
+      return (
+        <section key={item.id} className="p-8 text-center bg-gray-100">
+          Review Section (mock)
+        </section>
+      )
+    default:
+      return null
+  }
+}
+
+export default function StorePreviewPage() {
+  const [layout, setLayout] = useState<LayoutComponent[]>([])
+
+  useEffect(() => {
+    const cfg = getConfig()
+    setLayout(cfg.layout)
+  }, [])
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      {layout.map(renderItem)}
+      <Footer />
+    </div>
+  )
+}

--- a/core/mock/store/config.ts
+++ b/core/mock/store/config.ts
@@ -1,0 +1,42 @@
+import type { StorefrontConfig, ThemeConfig, LayoutComponent } from '@/types/storefront'
+import { loadFromStorage, saveToStorage } from './persist'
+
+const KEY = 'mockStore_config'
+
+const defaultConfig: StorefrontConfig = {
+  theme: {
+    theme: 'light',
+    colors: {
+      primary: '#2563eb',
+      secondary: '#ec4899',
+      background: '#ffffff',
+      text: '#000000',
+    },
+  },
+  layout: [],
+}
+
+let config: StorefrontConfig = loadFromStorage(KEY, defaultConfig)
+
+function persist() {
+  saveToStorage(KEY, config)
+}
+
+export function getConfig() {
+  return config
+}
+
+export function setTheme(theme: ThemeConfig) {
+  config.theme = theme
+  persist()
+}
+
+export function setLayout(layout: LayoutComponent[]) {
+  config.layout = layout
+  persist()
+}
+
+export function resetConfig() {
+  config = { ...defaultConfig }
+  persist()
+}

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -1,6 +1,7 @@
 export * from './orders'
 export * from './customers'
 export * from './fabrics'
+export * from './config'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetCustomers, regenerateCustomers } from './customers'

--- a/types/storefront.ts
+++ b/types/storefront.ts
@@ -1,0 +1,25 @@
+export type ThemeName = 'light' | 'dark' | 'soft' | 'neon'
+
+export interface ColorPalette {
+  primary: string
+  secondary: string
+  background: string
+  text: string
+}
+
+export interface ThemeConfig {
+  theme: ThemeName
+  colors: ColorPalette
+}
+
+export type LayoutComponentType = 'banner' | 'product' | 'cta' | 'review'
+
+export interface LayoutComponent {
+  id: string
+  type: LayoutComponentType
+}
+
+export interface StorefrontConfig {
+  theme: ThemeConfig
+  layout: LayoutComponent[]
+}


### PR DESCRIPTION
## Summary
- add `StorefrontConfig` types and mock store
- create theme, color and layout editors under dashboard
- add live storefront preview page
- expose internal API to save config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b21ea67c48325944dd965604d79bd