### PR TITLE
Implement campaign utilities

### DIFF
--- a/app/dashboard/analytics/campaigns/page.tsx
+++ b/app/dashboard/analytics/campaigns/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useEffect, useState } from "react"
+import CampaignReportCard, { CampaignReport } from "@/components/CampaignReportCard"
+import { loadCampaignReports, mockCampaignReports } from "@/lib/mock-campaigns"
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts"
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
+
+export default function CampaignSummaryPage() {
+  const [reports, setReports] = useState<CampaignReport[]>([])
+
+  useEffect(() => {
+    loadCampaignReports()
+    setReports([...mockCampaignReports])
+  }, [])
+
+  const data = reports.map(r => ({ slug: r.slug, bills: r.bills }))
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สรุปแคมเปญ</h1>
+      {reports.length > 0 ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {reports.map(r => <CampaignReportCard key={r.slug} report={r} />)}
+        </div>
+      ) : (
+        <p className="text-muted-foreground">ไม่มีข้อมูล</p>
+      )}
+      {data.length > 0 && (
+        <ChartContainer className="h-60" config={{ campaign: { color: "hsl(221,83%,53%)" } }}>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="slug" />
+            <YAxis allowDecimals={false} />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Bar dataKey="bills" fill="var(--color-campaign)" />
+          </BarChart>
+        </ChartContainer>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/analytics/conversion/page.tsx
+++ b/app/dashboard/analytics/conversion/page.tsx
@@ -1,0 +1,55 @@
+"use client"
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { Input } from "@/components/ui/inputs/input"
+import { toast } from "sonner"
+
+interface Log {
+  id: string
+  point: string
+  time: string
+}
+
+export default function ConversionSetupPage() {
+  const [point, setPoint] = useState("")
+  const [logs, setLogs] = useState<Log[]>([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem("conversionLogs")
+    if (stored) setLogs(JSON.parse(stored))
+  }, [])
+
+  const add = () => {
+    const entry = { id: Date.now().toString(), point, time: new Date().toISOString() }
+    const next = [...logs, entry]
+    setLogs(next)
+    localStorage.setItem("conversionLogs", JSON.stringify(next))
+    setPoint("")
+  }
+
+  const exportCsv = () => {
+    toast("ดาวน์โหลด CSV (mock)")
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ตั้งค่า Conversion</h1>
+      <div className="flex gap-2 max-w-xl">
+        <Input placeholder="conversion point" value={point} onChange={e=>setPoint(e.target.value)} />
+        <Button onClick={add} disabled={!point}>บันทึก</Button>
+      </div>
+      {logs.length > 0 && (
+        <div className="space-y-2">
+          <Button size="sm" onClick={exportCsv}>Export CSV</Button>
+          <ul className="space-y-1 text-sm">
+            {logs.map(l => (
+              <li key={l.id} className="rounded border p-2">
+                {l.point} - {new Date(l.time).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/broadcast/page.tsx
+++ b/app/dashboard/broadcast/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+import { useState } from "react"
+import { mockCustomers } from "@/lib/mock-customers"
+import { Input } from "@/components/ui/inputs/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/buttons/button"
+import { toast } from "sonner"
+
+interface Schedule {
+  id: string
+  segment: string
+  message: string
+  time: string
+}
+
+export default function BroadcastSchedulerPage() {
+  const [segment, setSegment] = useState("all")
+  const [message, setMessage] = useState("")
+  const [time, setTime] = useState("")
+  const [list, setList] = useState<Schedule[]>([])
+
+  const schedule = () => {
+    const item = { id: Date.now().toString(), segment, message, time }
+    setList([...list, item])
+    setMessage("")
+    setTime("")
+    toast.success("ตั้งเวลาส่งข้อความแล้ว")
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ตั้งเวลาข้อความ</h1>
+      <div className="grid gap-2 max-w-xl">
+        <select className="rounded border p-2" value={segment} onChange={e=>setSegment(e.target.value)}>
+          <option value="all">ลูกค้าทั้งหมด ({mockCustomers.length})</option>
+          <option value="VIP">เฉพาะ VIP</option>
+          <option value="Gold">เฉพาะ Gold</option>
+          <option value="Silver">เฉพาะ Silver</option>
+        </select>
+        <Textarea placeholder="ข้อความ" value={message} onChange={e=>setMessage(e.target.value)} />
+        <Input type="datetime-local" value={time} onChange={e=>setTime(e.target.value)} />
+        <Button onClick={schedule} disabled={!message || !time}>ตั้งเวลา</Button>
+      </div>
+      {list.length > 0 && (
+        <div className="space-y-2">
+          {list.map(item => (
+            <div key={item.id} className="rounded border p-2 text-sm">
+              <p>{item.message}</p>
+              <p className="text-muted-foreground">{item.segment} - {new Date(item.time).toLocaleString()}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/customers/reorder/page.tsx
+++ b/app/dashboard/customers/reorder/page.tsx
@@ -1,0 +1,51 @@
+"use client"
+import { mockCustomers } from "@/lib/mock-customers"
+import { orders as mockOrders } from "@/mock/orders"
+import { Button } from "@/components/ui/buttons/button"
+import { useState } from "react"
+import { toast } from "sonner"
+
+export default function ReorderCustomersPage() {
+  const [customers, setCustomers] = useState([...mockCustomers])
+  const ordersByCustomer: Record<string, number> = {}
+  mockOrders.forEach(o => {
+    ordersByCustomer[o.customer] = (ordersByCustomer[o.customer] || 0) + 1
+  })
+  const handleSuggest = (name: string) => {
+    toast.success(`ส่งข้อเสนอซื้อซ้ำให้ ${name}`)
+    setCustomers(prev => {
+      const next = prev.map(c => {
+        if (c.name === name) {
+          const tags = c.tags || []
+          if (!tags.includes("เคยซื้อ")) tags.push("เคยซื้อ")
+          return { ...c, tags }
+        }
+        return c
+      })
+      return next
+    })
+  }
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">ลูกค้าที่เคยสั่งซื้อ</h1>
+      <div className="space-y-2">
+        {customers
+          .filter(c => ordersByCustomer[c.name])
+          .map(c => (
+            <div key={c.id} className="flex items-center justify-between rounded border p-4">
+              <div>
+                <p className="font-medium">{c.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  ออเดอร์ {ordersByCustomer[c.name] || 0} ครั้ง
+                  {c.tags?.includes("เคยซื้อ") && <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs">เคยซื้อ</span>}
+                </p>
+              </div>
+              <Button size="sm" onClick={() => handleSuggest(c.name)}>
+                เสนอซื้อซ้ำ
+              </Button>
+            </div>
+          ))}
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/upsell/page.tsx
+++ b/app/dashboard/orders/[id]/upsell/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { useParams, useRouter } from "next/navigation"
+import { mockOrders } from "@/lib/mock-orders"
+import { Button } from "@/components/ui/buttons/button"
+import { toast } from "sonner"
+
+const rules: Record<string, string> = {
+  "ผ้าคลุมโซฟา": "สเปรย์กันฝุ่น",
+  Cotton: "น้ำยาซักผ้าอ่อนโยน",
+}
+
+export default function OrderUpsellPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const order = mockOrders.find(o => o.id === params.id)
+  if (!order) return <p className="p-4">ไม่พบออเดอร์</p>
+  const items = order.items.map(i => i.productName).join(", ")
+  const suggestions = Object.entries(rules)
+    .filter(([k]) => items.includes(k))
+    .map(([_, v]) => v)
+  const add = (item: string) => {
+    order.items.push({
+      productId: Date.now().toString(),
+      productName: item,
+      quantity: 1,
+      price: 100,
+    })
+    order.total += 100
+    toast.success(`เพิ่ม ${item} แล้ว`)
+    router.back()
+  }
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">เสนอขายเพิ่ม</h1>
+      <p className="text-sm">ออเดอร์ {order.id}: {items}</p>
+      {suggestions.length ? (
+        <div className="space-y-2">
+          {suggestions.map(s => (
+            <div key={s} className="flex items-center justify-between rounded border p-4">
+              <span>{s}</span>
+              <Button size="sm" onClick={() => add(s)}>เพิ่ม</Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground">ไม่มีสินค้าแนะนำ</p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- re-engage customers from past orders
- upsell suggestion after admin opens bill
- schedule broadcast messages
- record conversion tracking events
- show campaign tracker summary with mock bar chart

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b24b494388325a0784f96a1aa1070