### PR TITLE
Implement review and NPS modules

### DIFF
--- a/app/dashboard/analytics/reviews/page.tsx
+++ b/app/dashboard/analytics/reviews/page.tsx
@@ -1,0 +1,51 @@
+"use client"
+import { useMemo } from 'react'
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts'
+import { getReviews } from '@/core/mock/store'
+
+export default function ReviewAnalyticsPage() {
+  const reviews = getReviews()
+  const avg = useMemo(() => {
+    if (reviews.length === 0) return 0
+    return reviews.reduce((s,r)=>s+r.rating,0)/reviews.length
+  }, [reviews])
+
+  const pie = [
+    { name: 'พอใจ', value: reviews.filter(r=>r.rating>=4).length },
+    { name: 'เฉยๆ', value: reviews.filter(r=>r.rating===3).length },
+    { name: 'ไม่พอใจ', value: reviews.filter(r=>r.rating<=2).length }
+  ]
+
+  const bars = [1,2,3,4,5].map(n=>({ rating: n, count: reviews.filter(r=>r.rating===n).length }))
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สรุปรีวิว</h1>
+      <p>คะแนนเฉลี่ย {avg.toFixed(2)} จาก {reviews.length} รีวิว</p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie data={pie} dataKey="value" nameKey="name">
+                <Cell fill="#4ade80" />
+                <Cell fill="#fbbf24" />
+                <Cell fill="#f87171" />
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={bars}>
+              <XAxis dataKey="rating" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#60a5fa" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/request-review/page.tsx
+++ b/app/dashboard/orders/[id]/request-review/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function RequestReviewPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [sent, setSent] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setSent(!!localStorage.getItem('reviewRequest-' + id))
+    }
+  }, [id])
+
+  const send = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('reviewRequest-' + id, '1')
+    }
+    setSent(true)
+    alert(`ส่งลิงก์ /store/review/${id} ให้ลูกค้า (mock)`)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ขอรีวิวคำสั่งซื้อ {id}</h1>
+      {sent ? (
+        <p className="text-green-600">ส่งคำขอไปแล้ว</p>
+      ) : (
+        <Button onClick={send}>ส่งคำขอรีวิว</Button>
+      )}
+      <div>
+        <Link href={`/dashboard/orders/${id}`}>กลับ</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/reviews/page.tsx
+++ b/app/dashboard/reviews/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { getReviews, toggleHide, type Review } from '@/core/mock/store'
+
+export default function ReviewManagerPage() {
+  const [list, setList] = useState<Review[]>([])
+  const [rating, setRating] = useState(0)
+  const [q, setQ] = useState('')
+
+  useEffect(() => {
+    setList([...getReviews()])
+  }, [])
+
+  const filtered = list.filter(r => (rating === 0 || r.rating === rating) &&
+    (q === '' || r.comment.includes(q) || (r.customer && r.customer.includes(q))))
+
+  const toggle = (id: string) => {
+    toggleHide(id)
+    setList([...getReviews()])
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">จัดการรีวิว</h1>
+      <div className="flex gap-2">
+        <select className="border rounded p-2" value={rating} onChange={e=>setRating(parseInt(e.target.value))}>
+          <option value={0}>ทุกคะแนน</option>
+          {[1,2,3,4,5].map(n=> <option key={n} value={n}>{n} ดาว</option>)}
+        </select>
+        <Input placeholder="ค้นหา" value={q} onChange={e=>setQ(e.target.value)} />
+      </div>
+      {filtered.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ออเดอร์</TableHead>
+              <TableHead>คะแนน</TableHead>
+              <TableHead>ข้อความ</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map(r=> (
+              <TableRow key={r.orderId} className={r.hidden ? 'opacity-50' : ''}>
+                <TableCell>{r.orderId}</TableCell>
+                <TableCell>{r.rating}</TableCell>
+                <TableCell>{r.comment}</TableCell>
+                <TableCell className="text-right space-x-2">
+                  <Button size="sm" variant="outline" onClick={()=>toggle(r.orderId)}>
+                    {r.hidden ? 'แสดง' : 'ซ่อน'}
+                  </Button>
+                  <Button size="sm" onClick={()=>alert('report (mock)')}>แจ้งเตือน</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/app/store/review/[orderId]/page.tsx
+++ b/app/store/review/[orderId]/page.tsx
@@ -1,0 +1,59 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Button } from '@/components/ui/buttons/button'
+import { Star } from 'lucide-react'
+import { addReview, getReviews } from '@/core/mock/store'
+
+export default function ReviewPage({ params }: { params: { orderId: string } }) {
+  const { orderId } = params
+  const [rating, setRating] = useState(0)
+  const [comment, setComment] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    setSubmitted(getReviews().some(r => r.orderId === orderId))
+  }, [orderId])
+
+  const submit = () => {
+    if (rating === 0 || submitted) return
+    const ok = addReview({ orderId, rating, comment, createdAt: new Date().toISOString() })
+    if (ok) setSubmitted(true)
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8">
+        <div className="max-w-lg mx-auto space-y-4 text-center">
+          <h1 className="text-xl font-bold">ให้คะแนนคำสั่งซื้อ {orderId}</h1>
+          {!submitted ? (
+            <>
+              <div className="flex justify-center space-x-1">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Star
+                    key={i}
+                    onClick={() => setRating(i + 1)}
+                    className={`h-5 w-5 cursor-pointer ${i < rating ? 'text-yellow-400 fill-current' : 'text-gray-300'}`}
+                  />
+                ))}
+              </div>
+              <textarea
+                className="w-full border rounded p-2 text-sm"
+                rows={3}
+                value={comment}
+                onChange={e => setComment(e.target.value)}
+                placeholder="แสดงความคิดเห็น"
+              />
+              <Button className="w-full" onClick={submit}>ส่งรีวิว</Button>
+            </>
+          ) : (
+            <p className="text-green-600">บันทึกรีวิวแล้ว</p>
+          )}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/store/survey/nps/page.tsx
+++ b/app/store/survey/nps/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useState } from 'react'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Button } from '@/components/ui/buttons/button'
+import { addNps } from '@/core/mock/store'
+
+export default function NpsSurveyPage() {
+  const [score, setScore] = useState<number | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  const submit = () => {
+    if (score === null) return
+    addNps({ id: Date.now().toString(), score, createdAt: new Date().toISOString() })
+    setSubmitted(true)
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 container mx-auto px-4 py-8 space-y-4 max-w-lg">
+        <h1 className="text-center text-2xl font-bold">แนะนำร้านให้เพื่อนไหม?</h1>
+        {!submitted ? (
+          <>
+            <div className="flex flex-wrap gap-1 justify-between">
+              {Array.from({ length: 11 }, (_, i) => (
+                <Button key={i} variant={score===i? 'default':'outline'} onClick={() => setScore(i)}>
+                  {i}
+                </Button>
+              ))}
+            </div>
+            <Button className="w-full" onClick={submit} disabled={score===null}>ส่ง</Button>
+          </>
+        ) : (
+          <p className="text-center text-green-600">ขอบคุณสำหรับคำตอบ</p>
+        )}
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/core/mock/__tests__/store.test.ts
+++ b/core/mock/__tests__/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { getOrders, addOrder, resetOrders } from '../store'
+import { getOrders, addOrder, resetOrders, addReview, getReviews, resetReviews, addNps, getNps, resetNps } from '../store'
 import type { Order } from '@/types/order'
 
 const sample: Order = {
@@ -31,5 +31,29 @@ describe('mock store orders', () => {
     const prev = getOrders().length
     addOrder(sample)
     expect(getOrders().length).toBe(prev + 1)
+  })
+})
+
+describe('mock store reviews', () => {
+  beforeEach(() => {
+    resetReviews()
+  })
+
+  it('adds review to store', () => {
+    const prev = getReviews().length
+    addReview({ orderId: 'O1', rating: 5, comment: 'good', createdAt: '' })
+    expect(getReviews().length).toBe(prev + 1)
+  })
+})
+
+describe('mock store nps', () => {
+  beforeEach(() => {
+    resetNps()
+  })
+
+  it('adds nps record', () => {
+    const prev = getNps().length
+    addNps({ id: '1', score: 8, createdAt: '' })
+    expect(getNps().length).toBe(prev + 1)
   })
 })

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -2,15 +2,21 @@ export * from './orders'
 export * from './customers'
 export * from './fabrics'
 export * from './config'
+export * from './reviews'
+export * from './nps'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetCustomers, regenerateCustomers } from './customers'
 import { resetFabrics, regenerateFabrics } from './fabrics'
+import { resetReviews } from './reviews'
+import { resetNps } from './nps'
 
 export function resetStore() {
   resetOrders()
   resetCustomers()
   resetFabrics()
+  resetReviews()
+  resetNps()
 }
 
 export function generateMockData() {

--- a/core/mock/store/nps.ts
+++ b/core/mock/store/nps.ts
@@ -1,0 +1,24 @@
+import { loadFromStorage, saveToStorage } from './persist'
+import type { NpsRecord } from '@/types/review'
+
+const KEY = 'mockStore_nps'
+
+let records: NpsRecord[] = loadFromStorage<NpsRecord[]>(KEY, [])
+
+function persist() {
+  saveToStorage(KEY, records)
+}
+
+export function getNps() {
+  return records
+}
+
+export function addNps(rec: NpsRecord) {
+  records.push(rec)
+  persist()
+}
+
+export function resetNps() {
+  records = []
+  persist()
+}

--- a/core/mock/store/reviews.ts
+++ b/core/mock/store/reviews.ts
@@ -1,0 +1,34 @@
+import { loadFromStorage, saveToStorage } from './persist'
+import type { Review } from '@/types/review'
+
+const KEY = 'mockStore_reviews'
+
+let reviews: Review[] = loadFromStorage<Review[]>(KEY, [])
+
+function persist() {
+  saveToStorage(KEY, reviews)
+}
+
+export function getReviews() {
+  return reviews
+}
+
+export function addReview(review: Review): boolean {
+  if (reviews.some(r => r.orderId === review.orderId)) return false
+  reviews.push(review)
+  persist()
+  return true
+}
+
+export function toggleHide(orderId: string) {
+  const r = reviews.find(rv => rv.orderId === orderId)
+  if (r) {
+    r.hidden = !r.hidden
+    persist()
+  }
+}
+
+export function resetReviews() {
+  reviews = []
+  persist()
+}

--- a/types/review.ts
+++ b/types/review.ts
@@ -1,0 +1,14 @@
+export interface Review {
+  orderId: string
+  rating: number
+  comment: string
+  createdAt: string
+  customer?: string
+  hidden?: boolean
+}
+
+export interface NpsRecord {
+  id: string
+  score: number
+  createdAt: string
+}


### PR DESCRIPTION
## Summary
- implement review/NPS store modules
- add admin review manager
- add analytics page for reviews
- add customer review submission and request pages
- add NPS survey page
- extend mock store tests

## Testing
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b29281df083258b3a60ff4a8278c7