### PR TITLE
Implement admin role management mock

### DIFF
--- a/app/dashboard/logs/action/page.tsx
+++ b/app/dashboard/logs/action/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/inputs/input"
+import { mockAdminLogs, loadAdminLogs } from "@/lib/mock-admin-logs"
+
+export default function ActionLogPage() {
+  const [logs, setLogs] = useState(mockAdminLogs)
+  const [action, setAction] = useState("")
+  const [user, setUser] = useState("")
+  const [date, setDate] = useState("")
+
+  useEffect(() => {
+    loadAdminLogs()
+    setLogs([...mockAdminLogs])
+  }, [])
+
+  const filtered = logs.filter(l =>
+    (!action || l.action.includes(action)) &&
+    (!user || l.admin.includes(user)) &&
+    (!date || l.timestamp.startsWith(date))
+  )
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Action Logs</h1>
+      <div className="flex gap-2">
+        <Input placeholder="action" value={action} onChange={e=>setAction(e.target.value)} />
+        <Input placeholder="user" value={user} onChange={e=>setUser(e.target.value)} />
+        <Input type="date" value={date} onChange={e=>setDate(e.target.value)} />
+      </div>
+      {filtered.length ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>เวลา</TableHead>
+              <TableHead>ผู้ใช้</TableHead>
+              <TableHead>การกระทำ</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map(l => (
+              <TableRow key={l.id}>
+                <TableCell>{new Date(l.timestamp).toLocaleString()}</TableCell>
+                <TableCell>{l.admin}</TableCell>
+                <TableCell>{l.action}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <p className="text-sm">ไม่มีข้อมูล</p>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/members/[id]/role/page.tsx
+++ b/app/dashboard/members/[id]/role/page.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/buttons/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { loadAdminUsers, getAdminById, updateAdmin } from "@/lib/mock-admin-users"
+import { loadRoles, roles } from "@/lib/mock-admin-roles"
+
+export default function MemberRolePage({ params }: { params: { id: string } }) {
+  const router = useRouter()
+  const [user, setUser] = useState<{ id: string; name: string; role: string } | null>(null)
+  const [roleId, setRoleId] = useState("")
+
+  useEffect(() => {
+    loadAdminUsers()
+    loadRoles()
+    const u = getAdminById(params.id)
+    if (u) {
+      setUser(u as any)
+      setRoleId(u.role || "")
+    }
+  }, [params.id])
+
+  const handleSave = () => {
+    if (!user) return
+    updateAdmin(user.id, { role: roleId })
+    alert("บันทึกแล้ว")
+    router.push("/dashboard/settings/admins")
+  }
+
+  if (!user) return <div className="container mx-auto py-8">ไม่พบผู้ใช้</div>
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">กำหนดบทบาทให้ {user.name}</h1>
+      <Select value={roleId} onValueChange={setRoleId}>
+        <SelectTrigger className="w-52">
+          <SelectValue placeholder="เลือก role" />
+        </SelectTrigger>
+        <SelectContent>
+          {roles.map(r => (
+            <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button onClick={handleSave}>บันทึก</Button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/admin-role/page.tsx
+++ b/app/dashboard/settings/admin-role/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { roles, loadRoles, addRole, removeRole } from "@/lib/mock-admin-roles"
+
+export default function AdminRolePage() {
+  const [list, setList] = useState(roles)
+  const [name, setName] = useState("")
+  useEffect(() => {
+    loadRoles()
+    setList([...roles])
+  }, [])
+
+  const handleAdd = () => {
+    if (!name) return
+    addRole({ name, permissions: {} })
+    setName("")
+    setList([...roles])
+  }
+
+  const handleDelete = (id: string) => {
+    if (confirm("ลบ role นี้?")) {
+      removeRole(id)
+      setList([...roles])
+    }
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Admin Roles</h1>
+      <div className="flex gap-2">
+        <Input placeholder="Role name" value={name} onChange={e=>setName(e.target.value)} />
+        <Button onClick={handleAdd}>เพิ่ม</Button>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">ชื่อ</th>
+            <th className="p-2 text-right">ลบ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {list.map(r => (
+            <tr key={r.id} className="border-b hover:bg-muted/50">
+              <td className="p-2">{r.name}</td>
+              <td className="p-2 text-right">
+                <Button variant="destructive" size="sm" onClick={()=>handleDelete(r.id)}>ลบ</Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/dashboard/settings/invite/page.tsx
+++ b/app/dashboard/settings/invite/page.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { invites, loadInvites, createInvite } from "@/lib/mock-invite"
+
+export default function InvitePage() {
+  const [list, setList] = useState(invites)
+  useEffect(() => {
+    loadInvites()
+    setList([...invites])
+  }, [])
+
+  const handleGenerate = () => {
+    const inv = createInvite(7)
+    setList([...invites])
+    alert(`${location.origin}/auth/setup?token=${inv.token}`)
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Invite Admin</h1>
+      <Button onClick={handleGenerate}>สร้างลิงก์</Button>
+      <ul className="list-disc pl-5 text-sm">
+        {list.map(i => (
+          <li key={i.token}>{i.token} - {new Date(i.expires).toLocaleDateString()}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/lib/mock-admin-logs.ts
+++ b/lib/mock-admin-logs.ts
@@ -7,11 +7,27 @@ export interface AdminLog {
 
 export let mockAdminLogs: AdminLog[] = []
 
+const STORAGE_KEY = 'adminLogs'
+
+export function loadAdminLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) mockAdminLogs = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mockAdminLogs))
+  }
+}
+
 export function addAdminLog(action: string, admin: string) {
-  mockAdminLogs.push({
+  mockAdminLogs.unshift({
     id: Date.now().toString(),
     action,
     admin,
     timestamp: new Date().toISOString(),
   })
+  save()
 }

--- a/lib/mock-admin-roles.ts
+++ b/lib/mock-admin-roles.ts
@@ -1,0 +1,48 @@
+export interface AdminRole {
+  id: string
+  name: string
+  permissions: Record<string, 'view' | 'edit'>
+}
+
+const STORAGE_KEY = 'adminRoles'
+
+export let roles: AdminRole[] = [
+  { id: 'owner', name: 'Owner', permissions: {} },
+  { id: 'manager', name: 'Manager', permissions: {} },
+  { id: 'staff', name: 'Staff', permissions: {} },
+]
+
+export function loadRoles() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) roles = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(roles))
+  }
+}
+
+export function addRole(data: Omit<AdminRole, 'id'>) {
+  const role: AdminRole = { id: Date.now().toString(), ...data }
+  roles.push(role)
+  save()
+  return role
+}
+
+export function updateRole(id: string, data: Partial<Omit<AdminRole, 'id'>>) {
+  const role = roles.find(r => r.id === id)
+  if (!role) return
+  Object.assign(role, data)
+  save()
+}
+
+export function removeRole(id: string) {
+  const idx = roles.findIndex(r => r.id === id)
+  if (idx !== -1) {
+    roles.splice(idx, 1)
+    save()
+  }
+}

--- a/lib/mock-admin-users.ts
+++ b/lib/mock-admin-users.ts
@@ -2,6 +2,7 @@ export interface AdminUser {
   id: string
   name: string
   email: string
+  role: string
   permissions: {
     read: boolean
     write: boolean
@@ -16,6 +17,7 @@ export let adminUsers: AdminUser[] = [
     id: '1',
     name: 'Super Admin',
     email: 'root@sofacover.com',
+    role: 'owner',
     permissions: { read: true, write: true, manage: true },
   },
 ]

--- a/lib/mock-invite.ts
+++ b/lib/mock-invite.ts
@@ -1,0 +1,37 @@
+export interface Invite {
+  token: string
+  expires: string
+}
+
+const STORAGE_KEY = 'adminInvites'
+
+export let invites: Invite[] = []
+
+export function loadInvites() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) invites = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(invites))
+  }
+}
+
+export function createInvite(days: number) {
+  const token = Math.random().toString(36).slice(2)
+  const invite: Invite = { token, expires: new Date(Date.now() + days * 864e5).toISOString() }
+  invites.push(invite)
+  save()
+  return invite
+}
+
+export function removeInvite(token: string) {
+  const idx = invites.findIndex(i => i.token === token)
+  if (idx !== -1) {
+    invites.splice(idx, 1)
+    save()
+  }
+}

--- a/lib/mock-roles.ts
+++ b/lib/mock-roles.ts
@@ -1,6 +1,55 @@
-export type Role = 'superadmin' | 'admin' | 'staff' | 'limited' | 'customer'
+export type Role =
+  | 'owner'
+  | 'manager'
+  | 'superadmin'
+  | 'admin'
+  | 'staff'
+  | 'limited'
+  | 'customer'
 
 const roleAccess: Record<Role, string[]> = {
+  owner: [
+    'dev',
+    'logs',
+    'inventory',
+    'inventorySettings',
+    'claims',
+    'media',
+    'dashboard',
+    'chat',
+    'analytics',
+    'broadcast',
+    'collections',
+    'reviews',
+    'supply',
+    'unpaid',
+    'faq',
+    'feedback',
+    'campaigns',
+    'fastBills',
+    'users',
+  ],
+  manager: [
+    'dev',
+    'logs',
+    'inventory',
+    'inventorySettings',
+    'claims',
+    'media',
+    'dashboard',
+    'chat',
+    'analytics',
+    'broadcast',
+    'collections',
+    'reviews',
+    'supply',
+    'unpaid',
+    'faq',
+    'feedback',
+    'campaigns',
+    'fastBills',
+    'users',
+  ],
   superadmin: [
     'dev',
     'logs',


### PR DESCRIPTION
## Summary
- add mock admin role store and invite utilities
- extend admin user model with role field
- persist admin logs to local storage
- expose new pages for role manager, member role assignment, action log, and invite links
- support new Owner/Manager roles in role definitions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2e1644f48325bf2a9fa2377bf7c4