### PR TITLE
Implement CSV import/export utilities

### DIFF
--- a/app/dashboard/customers/export/page.tsx
+++ b/app/dashboard/customers/export/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { downloadCSV } from '@/lib/mock-export'
+import { getCustomers } from '@/core/mock/store'
+import { getCustomerStats } from '@/lib/mock-customers'
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { addImportExportLog } from '@/lib/mock-import-log'
+
+export default function ExportCustomersPage() {
+  const [rows, setRows] = useState<any[]>([])
+  useEffect(() => {
+    const customers = getCustomers()
+    const data = customers.map(c => ({
+      name: c.name,
+      phone: c.phone || '',
+      email: c.email,
+      lastOrder: getCustomerStats(c.id).lastOrderDate || ''
+    }))
+    setRows(data)
+  }, [])
+
+  const handleDownload = () => {
+    downloadCSV(rows, 'customers.csv')
+    addImportExportLog('customers.csv', rows.length)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Export Customers</h1>
+      <Button onClick={handleDownload} disabled={rows.length === 0}>Download CSV</Button>
+    </div>
+  )
+}

--- a/app/dashboard/orders/export/page.tsx
+++ b/app/dashboard/orders/export/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { useState } from 'react'
+import { downloadCSV } from '@/lib/mock-export'
+import { getOrders } from '@/core/mock/store'
+import { Button } from '@/components/ui/buttons/button'
+import { addImportExportLog } from '@/lib/mock-import-log'
+
+export default function ExportOrdersPage() {
+  const all = getOrders()
+  const [status, setStatus] = useState('all')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+
+  const filtered = all.filter(o => {
+    const d = new Date(o.createdAt)
+    return (status === 'all' || o.status === status) &&
+      (!from || d >= new Date(from)) &&
+      (!to || d <= new Date(to))
+  })
+
+  const rows = filtered.map(o => ({
+    id: o.id,
+    customer: o.customerName,
+    status: o.status,
+    total: o.total,
+    date: o.createdAt,
+  }))
+
+  const handleDownload = () => {
+    downloadCSV(rows, 'orders.csv')
+    addImportExportLog('orders.csv', rows.length)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Export Orders</h1>
+      <div className="flex gap-2">
+        <select className="border p-2 rounded" value={status} onChange={e=>setStatus(e.target.value)}>
+          <option value="all">ทั้งหมด</option>
+          <option value="pendingPayment">pendingPayment</option>
+          <option value="depositPaid">depositPaid</option>
+          <option value="paid">paid</option>
+        </select>
+        <input type="date" className="border p-2 rounded" value={from} onChange={e=>setFrom(e.target.value)} />
+        <input type="date" className="border p-2 rounded" value={to} onChange={e=>setTo(e.target.value)} />
+        <Button onClick={handleDownload}>Download CSV</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/products/bulk-update/page.tsx
+++ b/app/dashboard/products/bulk-update/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/buttons/button'
+import { mockProducts } from '@/lib/mock-products'
+import { addImportExportLog } from '@/lib/mock-import-log'
+
+interface Row { id: string; price: number; stock: number }
+
+export default function BulkUpdateProductsPage() {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [rows, setRows] = useState<Row[]>([])
+
+  const parseFile = async () => {
+    if (!file) return
+    const text = await file.text()
+    const lines = text.trim().split(/\r?\n/).map(l => l.split(','))
+    lines.shift()
+    setRows(lines.map(l => ({ id: l[0], price: Number(l[1]||0), stock: Number(l[2]||0) })))
+  }
+
+  const apply = () => {
+    rows.forEach(r => {
+      const p = mockProducts.find(p => p.id === r.id)
+      if (p) {
+        p.price = r.price
+        p.inStock = r.stock > 0
+      }
+    })
+    addImportExportLog(file?.name || 'update.csv', rows.length)
+    router.push('/dashboard/products')
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Bulk Update Products</h1>
+      <input type="file" accept=".csv" onChange={e=>setFile(e.target.files?.[0]||null)} />
+      <Button onClick={parseFile} disabled={!file}>Preview</Button>
+      {rows.length > 0 && (
+        <div className="space-y-4">
+          <table className="table-auto border w-full">
+            <thead><tr><th>ID</th><th>Price</th><th>Stock</th></tr></thead>
+            <tbody>
+              {rows.map((r,i)=>(<tr key={i}><td>{r.id}</td><td>{r.price}</td><td>{r.stock}</td></tr>))}
+            </tbody>
+          </table>
+          <Button onClick={apply}>Apply Update</Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/products/import/page.tsx
+++ b/app/dashboard/products/import/page.tsx
@@ -1,0 +1,101 @@
+"use client"
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/buttons/button'
+import { mockProducts } from '@/lib/mock-products'
+import { addImportExportLog } from '@/lib/mock-import-log'
+
+interface Row { [key: string]: string }
+
+export default function ImportProductsPage() {
+  const router = useRouter()
+  const [file, setFile] = useState<File | null>(null)
+  const [headers, setHeaders] = useState<string[]>([])
+  const [rows, setRows] = useState<Row[]>([])
+  const [map, setMap] = useState<{name:string;price:string;stock:string}>({name:'',price:'',stock:''})
+
+  const parseFile = async () => {
+    if (!file) return
+    const text = await file.text()
+    const lines = text.trim().split(/\r?\n/).map(l => l.split(','))
+    const h = lines.shift() || []
+    setHeaders(h)
+    setRows(lines.map(line => {
+      const obj: Row = {}
+      h.forEach((k,i)=>{ obj[k]=line[i] || '' })
+      return obj
+    }))
+    setMap({name:h[0]||'',price:h[1]||'',stock:h[2]||''})
+  }
+
+  const handleImport = () => {
+    rows.forEach((r,i) => {
+      mockProducts.push({
+        id: Date.now().toString() + i,
+        slug: r[map.name].toLowerCase().replace(/\s+/g,'-'),
+        name: r[map.name],
+        description: '',
+        price: Number(r[map.price]||0),
+        images: ['/placeholder.svg?height=400&width=400'],
+        category: '',
+        collectionId: '',
+        sizes: [],
+        colors: [],
+        inStock: Number(r[map.stock]||0) > 0,
+        rating: 0,
+        reviews: 0,
+        features: [],
+        material: '',
+        care: [],
+        status: 'active',
+        tags: [],
+        curated: false,
+      })
+    })
+    addImportExportLog(file?.name || 'import.csv', rows.length)
+    router.push('/dashboard/products')
+  }
+
+  const preview = rows.map(r => ({
+    name: r[map.name],
+    price: r[map.price],
+    stock: r[map.stock],
+  }))
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Import Products from CSV</h1>
+      <input type="file" accept=".csv" onChange={e=>setFile(e.target.files?.[0]||null)} />
+      <Button onClick={parseFile} disabled={!file}>Preview</Button>
+      {preview.length > 0 && (
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <label>name</label>
+            <select className="border p-2" value={map.name} onChange={e=>setMap({...map,name:e.target.value})}>
+              {headers.map(h=> <option key={h} value={h}>{h}</option>)}
+            </select>
+            <label>price</label>
+            <select className="border p-2" value={map.price} onChange={e=>setMap({...map,price:e.target.value})}>
+              {headers.map(h=> <option key={h} value={h}>{h}</option>)}
+            </select>
+            <label>stock</label>
+            <select className="border p-2" value={map.stock} onChange={e=>setMap({...map,stock:e.target.value})}>
+              {headers.map(h=> <option key={h} value={h}>{h}</option>)}
+            </select>
+          </div>
+          <table className="table-auto border w-full">
+            <thead>
+              <tr><th>name</th><th>price</th><th>stock</th></tr>
+            </thead>
+            <tbody>
+              {preview.map((r,i)=>(
+                <tr key={i}><td>{r.name}</td><td>{r.price}</td><td>{r.stock}</td></tr>
+              ))}
+            </tbody>
+          </table>
+          <Button onClick={handleImport}>Import</Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/tools/import-log/page.tsx
+++ b/app/dashboard/tools/import-log/page.tsx
@@ -1,0 +1,34 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { importExportLog, loadImportExportLog } from '@/lib/mock-import-log'
+
+export default function ImportLogPage() {
+  const [logs, setLogs] = useState(importExportLog)
+  useEffect(() => {
+    loadImportExportLog()
+    setLogs([...importExportLog])
+  }, [])
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Import/Export History</h1>
+      {logs.length > 0 ? (
+        <table className="table-auto w-full border">
+          <thead>
+            <tr><th>File</th><th>Count</th><th>Time</th></tr>
+          </thead>
+          <tbody>
+            {logs.map(l => (
+              <tr key={l.id}>
+                <td>{l.file}</td>
+                <td>{l.count}</td>
+                <td>{new Date(l.time).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm">No history</p>
+      )}
+    </div>
+  )
+}

--- a/lib/mock-import-log.ts
+++ b/lib/mock-import-log.ts
@@ -1,0 +1,29 @@
+export interface ImportLogEntry {
+  id: string
+  file: string
+  time: string
+  count: number
+}
+
+const KEY = 'importExportLog'
+export let importExportLog: ImportLogEntry[] = []
+
+export function loadImportExportLog() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(KEY)
+    if (stored) importExportLog = JSON.parse(stored)
+  }
+}
+
+export function addImportExportLog(file: string, count: number) {
+  const entry: ImportLogEntry = {
+    id: Date.now().toString(),
+    file,
+    time: new Date().toISOString(),
+    count,
+  }
+  importExportLog.unshift(entry)
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(importExportLog))
+  }
+}


### PR DESCRIPTION
## Summary
- add helper for import/export log
- implement customer CSV export with last order information
- implement order report CSV export with filters
- support CSV import for products with column mapping
- add bulk update of product price and stock from CSV
- show import/export history in dashboard

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b340644f48325b71dde7ec11e9e2a