### PR TITLE
Add notification features

### DIFF
--- a/app/dashboard/notifications/page.tsx
+++ b/app/dashboard/notifications/page.tsx
@@ -1,0 +1,48 @@
+"use client"
+import { useEffect } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Badge } from "@/components/ui/badge"
+import { Eye } from "lucide-react"
+import { useNotifications } from "@/contexts/notifications-context"
+import { getStatus } from "@/lib/mock-read-status"
+
+export default function NotificationsPage() {
+  const { notifications, markRead, markAllRead } = useNotifications()
+
+  useEffect(() => {
+    markAllRead()
+  }, [])
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">ศูนย์แจ้งเตือน</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>แจ้งเตือนทั้งหมด</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {notifications.map((n) => {
+            const s = getStatus(n.id)
+            return (
+              <div key={n.id} className="flex items-start justify-between border-b pb-2 last:border-b-0">
+                <div className="space-y-1">
+                  <Link href={n.link} className="font-medium hover:underline">
+                    {n.message}
+                  </Link>
+                  {!s.read && <Badge variant="destructive">ใหม่</Badge>}
+                </div>
+                {!s.read && (
+                  <Button variant="outline" size="icon" onClick={() => markRead(n.id)}>
+                    <Eye className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/orders/create/page.tsx
+++ b/app/dashboard/orders/create/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { orders as mockOrders } from '@/mock/orders'
+import { sendLineNotify } from '@/lib/mock-line-notify'
 import { Button } from '@/components/ui/buttons/button'
 import { Input } from '@/components/ui/inputs/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -28,6 +29,7 @@ export default function CreateOrderPage() {
       total: Math.max(0, 1000 - discount),
       date: new Date().toISOString(),
     })
+    sendLineNotify(`มีออเดอร์ใหม่จาก ${customer}`)
     router.push('/dashboard/orders')
   }
 

--- a/app/dashboard/profile/notifications/page.tsx
+++ b/app/dashboard/profile/notifications/page.tsx
@@ -1,0 +1,52 @@
+"use client"
+import { useEffect, useState } from "react"
+import { useAuth } from "@/contexts/auth-context"
+import { loadPrefs, getPref, setPref, type NotificationPref } from "@/lib/mock-user-notify-pref"
+import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/buttons/button"
+
+export default function ProfileNotificationPage() {
+  const { user } = useAuth()
+  const [pref, setPrefState] = useState<NotificationPref>({ line: false, email: true, push: false, inApp: true })
+
+  useEffect(() => {
+    loadPrefs()
+    if (user) setPrefState(getPref(user.id))
+  }, [user])
+
+  const toggle = (key: keyof NotificationPref) => {
+    setPrefState({ ...pref, [key]: !pref[key] })
+  }
+
+  const save = () => {
+    if (user) setPref(user.id, pref)
+    alert("saved (mock)")
+  }
+
+  if (!user) return <div className="p-4">Loading...</div>
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">การแจ้งเตือนของฉัน</h1>
+      <div className="space-y-2 max-w-md">
+        <div className="flex items-center justify-between">
+          <span>LINE</span>
+          <Switch checked={pref.line} onCheckedChange={() => toggle('line')} />
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Email</span>
+          <Switch checked={pref.email} onCheckedChange={() => toggle('email')} />
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Push</span>
+          <Switch checked={pref.push} onCheckedChange={() => toggle('push')} />
+        </div>
+        <div className="flex items-center justify-between">
+          <span>In-App</span>
+          <Switch checked={pref.inApp} onCheckedChange={() => toggle('inApp')} />
+        </div>
+        <Button onClick={save}>บันทึก</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/settings/line-notify/page.tsx
+++ b/app/dashboard/settings/line-notify/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { loadLineToken, setLineToken, sendLineNotify } from "@/lib/mock-line-notify"
+
+export default function LineNotifySettingsPage() {
+  const [token, setToken] = useState("")
+
+  useEffect(() => {
+    setToken(loadLineToken())
+  }, [])
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">LINE Notify</h1>
+      <Input placeholder="Token" value={token} onChange={(e) => setToken(e.target.value)} />
+      <div className="space-x-2">
+        <Button onClick={() => setLineToken(token)}>บันทึก</Button>
+        <Button variant="secondary" onClick={() => sendLineNotify("ทดสอบการแจ้งเตือน")}>ทดสอบยิงข้อความ</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/settings/web-push/page.tsx
+++ b/app/dashboard/settings/web-push/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/buttons/button"
+import { loadWebPush, setWebPushEnabled, testWebPush } from "@/lib/mock-web-push"
+
+export default function WebPushSettingsPage() {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    setEnabled(loadWebPush())
+  }, [])
+
+  const toggle = (v: boolean) => {
+    setEnabled(v)
+    setWebPushEnabled(v)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Web Push</h1>
+      <div className="flex items-center space-x-2">
+        <Switch checked={enabled} onCheckedChange={toggle} />
+        <span>{enabled ? "เปิด" : "ปิด"}</span>
+      </div>
+      <Button onClick={() => testWebPush("การแจ้งเตือนทดสอบ")}>ทดสอบ</Button>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,8 @@ import { validateMockData } from "@/lib/mock-validator"
 import RedirectMobileHome from "@/components/RedirectMobileHome"
 import DevBar from "@/components/DevBar"
 import StoreBottomNav from "@/components/StoreBottomNav"
+import { NotificationProvider } from "@/contexts/notifications-context"
+import NotificationBell from "@/components/NotificationBell"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -36,8 +38,9 @@ export default function RootLayout({
   return (
     <html lang="th">
       <body className={`${inter.className} px-4 sm:px-6 overflow-x-hidden`}>
-        <FeatureFlagProvider>
-          <DemoProvider>
+        <NotificationProvider>
+          <FeatureFlagProvider>
+            <DemoProvider>
             <AuthProvider>
               <CartProvider>
                 <WishlistProvider>
@@ -48,6 +51,7 @@ export default function RootLayout({
                           <RedirectMobileHome />
                           {children}
                           <StoreBottomNav />
+                          <NotificationBell />
                           <DevBar />
                           <Toaster />
                         </ReviewImagesProvider>
@@ -57,8 +61,9 @@ export default function RootLayout({
                 </WishlistProvider>
               </CartProvider>
             </AuthProvider>
-          </DemoProvider>
-        </FeatureFlagProvider>
+            </DemoProvider>
+          </FeatureFlagProvider>
+        </NotificationProvider>
       </body>
     </html>
   )

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,20 @@
+"use client"
+import Link from "next/link"
+import { Bell } from "lucide-react"
+import { useNotifications } from "@/contexts/notifications-context"
+
+export default function NotificationBell() {
+  const { unreadCount } = useNotifications()
+  return (
+    <Link href="/dashboard/notifications" className="fixed right-4 top-4 z-40">
+      <div className="relative">
+        <Bell className="h-6 w-6" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-xs text-white">
+            {unreadCount}
+          </span>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/contexts/notifications-context.tsx
+++ b/contexts/notifications-context.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { createContext, useContext, useEffect, useMemo, useState } from "react"
+import {
+  mockNotifications,
+  loadNotifications,
+  type Notification,
+} from "@/lib/mock-notifications"
+import {
+  loadNotificationStatus,
+  getStatus,
+  markRead as markReadLib,
+  markAllRead as markAllReadLib,
+} from "@/lib/mock-read-status"
+
+interface NotificationState {
+  notifications: Notification[]
+  unreadCount: number
+  markRead: (id: string) => void
+  markAllRead: () => void
+}
+
+const NotificationContext = createContext<NotificationState | null>(null)
+
+export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const [list, setList] = useState<Notification[]>([])
+
+  useEffect(() => {
+    loadNotifications()
+    loadNotificationStatus()
+    setList([...mockNotifications])
+  }, [])
+
+  const unread = list.filter((n) => !getStatus(n.id).read).length
+
+  const markRead = (id: string) => {
+    markReadLib(id)
+    setList([...mockNotifications])
+  }
+
+  const markAllRead = () => {
+    markAllReadLib(list.map((n) => n.id))
+    setList([...mockNotifications])
+  }
+
+  const value = useMemo(
+    () => ({ notifications: list, unreadCount: unread, markRead, markAllRead }),
+    [list, unread],
+  )
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>
+}
+
+export function useNotifications() {
+  const ctx = useContext(NotificationContext)
+  if (!ctx) throw new Error("useNotifications must be used within NotificationProvider")
+  return ctx
+}

--- a/lib/mock-line-notify.ts
+++ b/lib/mock-line-notify.ts
@@ -1,0 +1,25 @@
+let token = ""
+
+export function loadLineToken() {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("line_notify_token")
+    if (stored) token = stored
+  }
+  return token
+}
+
+export function setLineToken(t: string) {
+  token = t
+  if (typeof window !== "undefined") {
+    localStorage.setItem("line_notify_token", token)
+  }
+}
+
+export function getLineToken() {
+  return token
+}
+
+export async function sendLineNotify(message: string): Promise<boolean> {
+  console.log("LINE Notify:", message)
+  return true
+}

--- a/lib/mock-notifications.ts
+++ b/lib/mock-notifications.ts
@@ -1,6 +1,6 @@
 export interface Notification {
   id: string
-  type: 'order' | 'claim' | 'chat'
+  type: 'order' | 'claim' | 'chat' | 'comment' | 'payment'
   message: string
   link: string
 }
@@ -35,6 +35,18 @@ export const mockNotifications: Notification[] = [
     type: 'chat',
     message: 'ลูกค้าเก่าทักแชทอีกครั้ง',
     link: '/admin/chat-customers',
+  },
+  {
+    id: 'cmt-4001',
+    type: 'comment',
+    message: 'มีคอมเมนต์ใหม่ในบล็อก',
+    link: '/dashboard/comments',
+  },
+  {
+    id: 'pay-5001',
+    type: 'payment',
+    message: 'ลูกค้าชำระเงินสำหรับ #ORD-1001',
+    link: '/dashboard/orders/ORD-1001',
   },
 ]
 

--- a/lib/mock-user-notify-pref.ts
+++ b/lib/mock-user-notify-pref.ts
@@ -1,0 +1,37 @@
+export interface NotificationPref {
+  line: boolean
+  email: boolean
+  push: boolean
+  inApp: boolean
+}
+
+const defaultPref: NotificationPref = {
+  line: false,
+  email: true,
+  push: false,
+  inApp: true,
+}
+
+let prefs: Record<string, NotificationPref> = {}
+
+function save() {
+  if (typeof window !== "undefined") {
+    localStorage.setItem("user_notify_pref", JSON.stringify(prefs))
+  }
+}
+
+export function loadPrefs() {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("user_notify_pref")
+    if (stored) prefs = JSON.parse(stored)
+  }
+}
+
+export function getPref(userId: string): NotificationPref {
+  return prefs[userId] || { ...defaultPref }
+}
+
+export function setPref(userId: string, pref: NotificationPref) {
+  prefs[userId] = pref
+  save()
+}

--- a/lib/mock-web-push.ts
+++ b/lib/mock-web-push.ts
@@ -1,0 +1,30 @@
+let enabled = false
+
+export function loadWebPush() {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("web_push_enabled")
+    if (stored) enabled = JSON.parse(stored)
+  }
+  return enabled
+}
+
+export function setWebPushEnabled(val: boolean) {
+  enabled = val
+  if (typeof window !== "undefined") {
+    localStorage.setItem("web_push_enabled", JSON.stringify(enabled))
+  }
+}
+
+export function isWebPushEnabled() {
+  return enabled
+}
+
+export function testWebPush(message: string) {
+  if (typeof window !== "undefined" && "Notification" in window) {
+    Notification.requestPermission().then((p) => {
+      if (p === "granted") {
+        new Notification(message)
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- integrate NotificationProvider and bell icon globally
- implement notification center page
- add LINE notify, web push, and user preference pages
- track orders with LINE notify and extend mock notifications

## Testing
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b37399b548325978344565c5270ce