### PR TITLE
Add basic email system mocks

### DIFF
--- a/app/dashboard/logs/email/page.tsx
+++ b/app/dashboard/logs/email/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { useEffect, useState } from "react"
+import { getEmailLogs, loadEmailData } from "@/lib/mock-email"
+import { Input } from "@/components/ui/inputs/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+export default function EmailLogPage() {
+  const [logs, setLogs] = useState(getEmailLogs())
+  const [filter, setFilter] = useState("")
+
+  useEffect(() => {
+    loadEmailData()
+    setLogs([...getEmailLogs()])
+  }, [])
+
+  const filtered = logs.filter(
+    (l) =>
+      l.to.includes(filter) ||
+      (l.orderId && l.orderId.includes(filter))
+  )
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Email Logs</h1>
+      <Input
+        placeholder="ค้นหา email หรือ order"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="max-w-xs"
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>เวลา</TableHead>
+            <TableHead>ผู้รับ</TableHead>
+            <TableHead>หัวข้อ</TableHead>
+            <TableHead>Order</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((l) => (
+            <TableRow key={l.id}>
+              <TableCell>{new Date(l.sentAt).toLocaleString('th-TH')}</TableCell>
+              <TableCell>{l.to}</TableCell>
+              <TableCell>{l.subject}</TableCell>
+              <TableCell>{l.orderId}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/invoice/page.tsx
+++ b/app/dashboard/orders/[id]/invoice/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { downloadPDF } from "@/lib/mock-export"
+
+export default function OrderInvoice({ params }: { params: { id: string } }) {
+  const { id } = params
+  const handleDownload = () => {
+    downloadPDF('mock invoice pdf', `invoice-${id}.pdf`)
+  }
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Invoice {id}</h1>
+      <iframe src={`/invoice/${id}`} className="w-full h-[600px] border" />
+      <button onClick={handleDownload} className="border rounded px-4 py-2">
+        Download PDF
+      </button>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/send-invoice/page.tsx
+++ b/app/dashboard/orders/[id]/send-invoice/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { sendEmail, loadEmailData } from "@/lib/mock-email"
+import { mockOrders } from "@/mock/orders"
+import { useEffect } from "react"
+import { Button } from "@/components/ui/buttons/button"
+
+export default function SendInvoice({ params }: { params: { id: string } }) {
+  const { id } = params
+  const order = mockOrders.find((o) => o.id === id)
+
+  useEffect(() => {
+    loadEmailData()
+  }, [])
+
+  if (!order) return <div className="p-8">ไม่พบออเดอร์</div>
+
+  const handleSend = () => {
+    sendEmail(order.customer, {
+      "customer.name": order.customer,
+      "order.id": order.id,
+      "order.total": order.total.toString(),
+    })
+    alert("ส่งอีเมลแล้ว")
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">ส่งใบเสร็จ {order.id}</h1>
+      <iframe src={`/invoice/${id}`} className="w-full h-[600px] border" />
+      <Button onClick={handleSend}>ส่งอีเมลพร้อม PDF</Button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/email-template/page.tsx
+++ b/app/dashboard/settings/email-template/page.tsx
@@ -1,0 +1,104 @@
+"use client"
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { Input } from "@/components/ui/inputs/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  emailTemplates,
+  addEmailTemplate,
+  updateEmailTemplate,
+  deleteEmailTemplate,
+  loadEmailData,
+  setSelectedTemplate,
+  selectedTemplateId,
+} from "@/lib/mock-email"
+
+export default function EmailTemplatePage() {
+  const [templates, setTemplates] = useState(emailTemplates)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [name, setName] = useState("")
+  const [subject, setSubject] = useState("")
+  const [content, setContent] = useState("")
+
+  useEffect(() => {
+    loadEmailData()
+    setTemplates([...emailTemplates])
+  }, [])
+
+  const startEdit = (id: string) => {
+    const t = emailTemplates.find((t) => t.id === id)
+    if (t) {
+      setEditing(id)
+      setName(t.name)
+      setSubject(t.subject)
+      setContent(t.content)
+    }
+  }
+
+  const handleSave = () => {
+    if (editing) {
+      updateEmailTemplate(editing, { name, subject, content })
+    } else {
+      addEmailTemplate({ name, subject, content })
+    }
+    setTemplates([...emailTemplates])
+    setEditing(null)
+    setName("")
+    setSubject("")
+    setContent("")
+  }
+
+  const handleDelete = (id: string) => {
+    deleteEmailTemplate(id)
+    setTemplates([...emailTemplates])
+  }
+
+  const handleSelect = (id: string) => {
+    setSelectedTemplate(id)
+    setTemplates([...emailTemplates])
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Email Templates</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {templates.map((t) => (
+          <div key={t.id} className="border rounded p-4 space-y-2">
+            <div className="flex justify-between items-center">
+              <h2 className="font-semibold">
+                {t.name}
+                {t.id === selectedTemplateId && (
+                  <span className="ml-2 text-sm text-primary">(ใช้)</span>
+                )}
+              </h2>
+              <div className="space-x-2">
+                <Button size="sm" variant="outline" onClick={() => startEdit(t.id)}>
+                  แก้ไข
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => handleSelect(t.id)}>
+                  ใช้งาน
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => handleDelete(t.id)}>
+                  ลบ
+                </Button>
+              </div>
+            </div>
+            <div dangerouslySetInnerHTML={{ __html: t.content }} className="border p-2 text-sm" />
+          </div>
+        ))}
+      </div>
+      <div className="border-t pt-4 space-y-2 max-w-2xl">
+        <h2 className="font-semibold">{editing ? "แก้ไขเทมเพลต" : "สร้างเทมเพลต"}</h2>
+        <Input placeholder="ชื่อ" value={name} onChange={(e) => setName(e.target.value)} />
+        <Input placeholder="หัวข้อ" value={subject} onChange={(e) => setSubject(e.target.value)} />
+        <Textarea
+          className="h-40"
+          placeholder="เนื้อหา HTML"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <Button onClick={handleSave}>{editing ? "บันทึก" : "สร้าง"}</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/success/[id]/page.tsx
+++ b/app/success/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/
 import { getOrders } from "@/core/mock/store";
 import { autoMessage, loadAutoMessage } from "@/lib/mock-settings";
 import { addFeedback } from "@/lib/mock-feedback";
+import { sendEmail, loadEmailData } from "@/lib/mock-email";
 import { Star } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -19,6 +20,15 @@ export default function SuccessPage({ params }: { params: { id: string } }) {
   useEffect(() => {
     loadAutoMessage();
     setMessage(autoMessage);
+    loadEmailData();
+    const order = getOrders().find((o) => o.id === id);
+    if (order) {
+      sendEmail(order.customerName || order.customer, {
+        "customer.name": order.customerName || order.customer,
+        "order.id": order.id,
+        "order.total": String(order.total),
+      });
+    }
   }, []);
   const order = getOrders().find((o) => o.id === id);
 

--- a/lib/mock-email.ts
+++ b/lib/mock-email.ts
@@ -1,0 +1,127 @@
+export interface EmailTemplate {
+  id: string
+  name: string
+  subject: string
+  content: string
+}
+
+export interface EmailLog {
+  id: string
+  to: string
+  subject: string
+  templateId: string
+  orderId?: string
+  customerId?: string
+  sentAt: string
+}
+
+const TEMPLATE_KEY = 'emailTemplates'
+const LOG_KEY = 'emailLogs'
+const SELECT_KEY = 'selectedEmailTemplate'
+
+export let emailTemplates: EmailTemplate[] = [
+  {
+    id: 'default',
+    name: 'Default Confirmation',
+    subject: 'Order {{order.id}} Confirmation',
+    content:
+      '<p>Hello {{customer.name}}, your order {{order.id}} totaling {{order.total}} has been received.</p>',
+  },
+]
+
+export let emailLogs: EmailLog[] = []
+export let selectedTemplateId = 'default'
+
+export function loadEmailData() {
+  if (typeof window !== 'undefined') {
+    const t = localStorage.getItem(TEMPLATE_KEY)
+    if (t) emailTemplates = JSON.parse(t)
+    const l = localStorage.getItem(LOG_KEY)
+    if (l) emailLogs = JSON.parse(l)
+    const s = localStorage.getItem(SELECT_KEY)
+    if (s) selectedTemplateId = s
+  }
+}
+
+function saveTemplates() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(TEMPLATE_KEY, JSON.stringify(emailTemplates))
+  }
+}
+
+function saveLogs() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(LOG_KEY, JSON.stringify(emailLogs))
+  }
+}
+
+export function setSelectedTemplate(id: string) {
+  selectedTemplateId = id
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(SELECT_KEY, id)
+  }
+}
+
+export function getEmailTemplate(id: string) {
+  return emailTemplates.find((t) => t.id === id)
+}
+
+export function addEmailTemplate(data: Omit<EmailTemplate, 'id'>) {
+  const template: EmailTemplate = { id: Date.now().toString(), ...data }
+  emailTemplates.unshift(template)
+  saveTemplates()
+  return template
+}
+
+export function updateEmailTemplate(id: string, data: Partial<Omit<EmailTemplate, 'id'>>) {
+  const t = emailTemplates.find((tmp) => tmp.id === id)
+  if (t) {
+    Object.assign(t, data)
+    saveTemplates()
+  }
+  return t
+}
+
+export function deleteEmailTemplate(id: string) {
+  const idx = emailTemplates.findIndex((t) => t.id === id)
+  if (idx !== -1) {
+    emailTemplates.splice(idx, 1)
+    saveTemplates()
+  }
+}
+
+function replaceVars(text: string, vars: Record<string, string>) {
+  let res = text
+  Object.keys(vars).forEach((k) => {
+    res = res.replace(new RegExp(`{{${k}}}`, 'g'), vars[k])
+  })
+  return res
+}
+
+export function sendEmail(to: string, vars: Record<string, string>, templateId = selectedTemplateId) {
+  const t = getEmailTemplate(templateId)
+  if (!t) return false
+  const subject = replaceVars(t.subject, vars)
+  const content = replaceVars(t.content, vars)
+  console.log('Mock send email', { to, subject })
+  emailLogs.unshift({
+    id: Date.now().toString(),
+    to,
+    subject,
+    templateId,
+    orderId: vars['order.id'],
+    customerId: vars['customer.id'],
+    sentAt: new Date().toISOString(),
+  })
+  saveLogs()
+  return true
+}
+
+export function getEmailLogs() {
+  return emailLogs
+}
+
+export function clearEmailLogs() {
+  emailLogs = []
+  saveLogs()
+}


### PR DESCRIPTION
## Summary
- add mock email utility for templates, sending and logs
- create email template manager page
- generate invoice PDF and allow sending via email
- show email logs in dashboard
- send confirmation email on order success

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b39e4cf448325b7dd95a0d86d6490