### PR TITLE
Add document upload mock pages

### DIFF
--- a/app/dashboard/orders/[id]/attach/page.tsx
+++ b/app/dashboard/orders/[id]/attach/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { addStoredFile } from '@/lib/mock/files'
+
+export default function OrderAttachPage() {
+  const { id } = useParams<{ id: string }>()
+  const [file, setFile] = useState<File | null>(null)
+
+  const handleUpload = () => {
+    if (!file) return
+    addStoredFile({
+      name: file.name,
+      type: 'attachment',
+      user: 'admin',
+      orderId: id,
+      url: URL.createObjectURL(file),
+      status: 'reviewed',
+    })
+    setFile(null)
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">แนบไฟล์ให้คำสั่งซื้อ {id}</h1>
+      <Input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+      {file && <p className="text-sm">{file.name}</p>}
+      <Button onClick={handleUpload} disabled={!file}>บันทึกไฟล์</Button>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/slip/page.tsx
+++ b/app/dashboard/orders/[id]/slip/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Image from 'next/image'
+import { Button } from '@/components/ui/buttons/button'
+import { getFilesByOrder, markReviewed, loadStoredFiles, StoredFile } from '@/lib/mock/files'
+
+export default function OrderSlipPage() {
+  const { id } = useParams<{ id: string }>()
+  const [file, setFile] = useState<StoredFile | null>(null)
+
+  useEffect(() => {
+    loadStoredFiles()
+    const f = getFilesByOrder(id, 'slip')[0]
+    if (f) setFile(f)
+  }, [id])
+
+  if (!file) return <div className="p-4">ไม่พบสลิป</div>
+
+  const isImage = file.name.match(/\.(jpg|jpeg|png)$/i)
+
+  const review = () => {
+    markReviewed(file.id)
+    setFile({ ...file, status: 'reviewed' })
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">สลิปออเดอร์ {id}</h1>
+      {isImage ? (
+        <Image src={file.url || '/placeholder.svg'} alt={file.name} width={400} height={400} className="border" />
+      ) : (
+        <p>{file.name}</p>
+      )}
+      <div className="space-x-2">
+        <Button variant="outline">ดูเต็มจอ</Button>
+        <Button variant="outline">ดาวน์โหลด</Button>
+        {file.status === 'pending' && (
+          <Button onClick={review}>ทำเครื่องหมายตรวจแล้ว</Button>
+        )}
+      </div>
+      <p className="text-sm">สถานะ: {file.status === 'pending' ? 'รอตรวจสอบ' : 'ตรวจแล้ว'}</p>
+    </div>
+  )
+}

--- a/app/dashboard/storage/page.tsx
+++ b/app/dashboard/storage/page.tsx
@@ -1,0 +1,38 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/inputs/input'
+import { loadStoredFiles, getFiles, StoredFile } from '@/lib/mock/files'
+
+export default function StoragePage() {
+  const [files, setFiles] = useState<StoredFile[]>([])
+  const [type, setType] = useState('')
+  const [user, setUser] = useState('')
+  const [date, setDate] = useState('')
+
+  useEffect(() => {
+    loadStoredFiles()
+    setFiles(getFiles())
+  }, [])
+
+  const filtered = files.filter(
+    f => (!type || f.type === type) &&
+      (!user || f.user.includes(user)) &&
+      (!date || f.date.startsWith(date))
+  )
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">ไฟล์ทั้งหมด</h1>
+      <div className="flex flex-wrap gap-2">
+        <Input placeholder="วันที่ YYYY-MM-DD" value={date} onChange={e => setDate(e.target.value)} />
+        <Input placeholder="ประเภท" value={type} onChange={e => setType(e.target.value)} />
+        <Input placeholder="ผู้ใช้" value={user} onChange={e => setUser(e.target.value)} />
+      </div>
+      <ul className="list-disc pl-4 space-y-1">
+        {filtered.map(f => (
+          <li key={f.id}>{f.name} - {f.type} - {f.user} - {new Date(f.date).toLocaleString()}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/store/checkout/slip-upload/page.tsx
+++ b/app/store/checkout/slip-upload/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Image from 'next/image'
+import { Input } from '@/components/ui/inputs/input'
+import { Button } from '@/components/ui/buttons/button'
+import { addStoredFile } from '@/lib/mock/files'
+
+export default function SlipUploadPage() {
+  const [file, setFile] = useState<File | null>(null)
+  const params = useSearchParams()
+  const orderId = params.get('orderId') || undefined
+  const router = useRouter()
+
+  const handleUpload = () => {
+    if (!file) return
+    addStoredFile({
+      name: file.name,
+      type: 'slip',
+      user: 'customer',
+      orderId,
+      url: URL.createObjectURL(file),
+    })
+    router.back()
+  }
+
+  const preview = file && file.type.startsWith('image') ? (
+    <Image
+      src={URL.createObjectURL(file)}
+      alt="slip preview"
+      width={300}
+      height={300}
+      className="border"
+    />
+  ) : file ? (
+    <p className="text-sm">{file.name}</p>
+  ) : null
+
+  return (
+    <div className="container mx-auto space-y-4 p-4">
+      <h1 className="text-2xl font-bold">อัปโหลดสลิปโอนเงิน</h1>
+      <Input
+        type="file"
+        accept=".jpg,.png,.pdf"
+        onChange={(e) => setFile(e.target.files?.[0] || null)}
+      />
+      {preview}
+      <Button onClick={handleUpload} disabled={!file}>
+        บันทึกสลิป
+      </Button>
+    </div>
+  )
+}

--- a/app/store/verify/id/page.tsx
+++ b/app/store/verify/id/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useState } from 'react'
+import Image from 'next/image'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import { addStoredFile } from '@/lib/mock/files'
+
+export default function VerifyIdPage() {
+  const [files, setFiles] = useState<File[]>([])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFiles(Array.from(e.target.files || []))
+  }
+
+  const handleSubmit = () => {
+    files.forEach(f =>
+      addStoredFile({
+        name: f.name,
+        type: 'id',
+        user: 'customer',
+        url: URL.createObjectURL(f),
+      }),
+    )
+    setFiles([])
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 p-4">
+      <h1 className="text-2xl font-bold">อัปโหลดเอกสารยืนยันตัวตน</h1>
+      <Input type="file" multiple onChange={handleChange} />
+      <div className="flex flex-wrap gap-2">
+        {files.map(f =>
+          f.type.startsWith('image') ? (
+            <Image key={f.name} src={URL.createObjectURL(f)} alt={f.name} width={120} height={120} className="border" />
+          ) : (
+            <p key={f.name} className="text-sm">{f.name}</p>
+          ),
+        )}
+      </div>
+      <Button onClick={handleSubmit} disabled={files.length === 0}>ส่งเอกสาร</Button>
+    </div>
+  )
+}

--- a/lib/mock/files.ts
+++ b/lib/mock/files.ts
@@ -1,0 +1,56 @@
+export interface StoredFile {
+  id: string
+  name: string
+  type: 'slip' | 'id' | 'attachment'
+  user: string
+  orderId?: string
+  url?: string
+  status?: 'pending' | 'reviewed'
+  date: string
+}
+
+export let storedFiles: StoredFile[] = []
+const STORAGE_KEY = 'storedFiles'
+
+export function loadStoredFiles() {
+  if (typeof window !== 'undefined') {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) storedFiles = JSON.parse(raw)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storedFiles))
+  }
+}
+
+export function addStoredFile(data: Omit<StoredFile, 'id' | 'date' | 'status'> & {status?: 'pending' | 'reviewed'}) {
+  const record: StoredFile = {
+    id: Date.now().toString(),
+    date: new Date().toISOString(),
+    status: data.status ?? 'pending',
+    ...data,
+  }
+  storedFiles.push(record)
+  save()
+  return record
+}
+
+export function markReviewed(id: string) {
+  const f = storedFiles.find((x) => x.id === id)
+  if (f) {
+    f.status = 'reviewed'
+    save()
+  }
+}
+
+export function getFiles() {
+  return storedFiles
+}
+
+export function getFilesByOrder(orderId: string, type?: string) {
+  return storedFiles.filter(
+    (f) => f.orderId === orderId && (!type || f.type === type),
+  )
+}


### PR DESCRIPTION
## Summary
- add generic mock file storage helper
- support slip upload page for customers
- allow admins to review uploaded slip
- add ID verification upload page
- admin can attach files to orders
- show uploaded file list with filters

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b3d63f4d48325a8005a9ed448b468