### PR TITLE
Add insight mock dashboards

### DIFF
--- a/app/dashboard/insight/customer/page.tsx
+++ b/app/dashboard/insight/customer/page.tsx
@@ -1,0 +1,78 @@
+"use client"
+import React from "react"
+import { useMemo } from "react"
+import { PieChart, Pie, Cell, Tooltip } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { getOrders, getCustomers } from "@/core/mock/store"
+
+const COLORS = ["#0088FE", "#FFBB28"]
+
+export default function CustomerBehaviorPage() {
+  const orders = getOrders()
+  const customers = getCustomers()
+
+  const ordersPerCustomer = useMemo(() => {
+    const map: Record<string, number> = {}
+    orders.forEach(o => {
+      map[o.customerId] = (map[o.customerId] || 0) + 1
+    })
+    const counts = Object.values(map)
+    const avg = counts.reduce((s, n) => s + n, 0) / customers.length
+    const repeat = counts.filter(n => n > 1).length
+    return { avg: avg.toFixed(2), repeatRate: ((repeat / customers.length) * 100).toFixed(1) }
+  }, [orders, customers])
+
+  const heatmap = useMemo(() => {
+    const map: Record<string, number> = {}
+    orders.forEach(o => {
+      const d = new Date(o.createdAt)
+      const key = `${d.getDay()}-${d.getHours()}`
+      map[key] = (map[key] || 0) + 1
+    })
+    return map
+  }, [orders])
+
+  const pieData = [
+    { name: "กลับมาซื้อ", value: ordersPerCustomer.repeatRate ? parseFloat(ordersPerCustomer.repeatRate) : 0 },
+    { name: "ลูกค้าใหม่", value: 100 - (ordersPerCustomer.repeatRate ? parseFloat(ordersPerCustomer.repeatRate) : 0) },
+  ]
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Customer Behavior (mock)</h1>
+      <p className="text-sm">เฉลี่ย {ordersPerCustomer.avg} ออเดอร์/คน, repeat rate {ordersPerCustomer.repeatRate}%</p>
+      <Card>
+        <CardHeader><CardTitle>Repeat Rate</CardTitle></CardHeader>
+        <CardContent className="flex justify-center">
+          <PieChart width={200} height={200}>
+            <Pie data={pieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+              {pieData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>ช่วงเวลาซื้อบ่อย</CardTitle></CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-8 gap-1 text-center text-xs">
+            <div></div>
+            {Array.from({ length: 24 }).map((_,h)=>(<div key={h}>{h}</div>))}
+            {[0,1,2,3,4,5,6].map(d=> (
+              <React.Fragment key={d}>
+                <div className="font-bold">{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d]}</div>
+                {Array.from({ length:24 }).map((_,h)=>{
+                  const val = heatmap[`${d}-${h}`]||0
+                  const bg = val? `rgba(56,189,248,${Math.min(1,val/5)})` : 'rgba(0,0,0,0.05)'
+                  return <div key={h} style={{backgroundColor:bg}} className="h-4" />
+                })}
+              </React.Fragment>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/insight/export/page.tsx
+++ b/app/dashboard/insight/export/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { useState, useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Button } from "@/components/ui/buttons/button"
+import { getOrders, getCustomers } from "@/core/mock/store"
+import { formatCurrency } from "@/lib/utils"
+
+export default function ExportDashboardPage() {
+  const [range, setRange] = useState(30)
+  const orders = getOrders()
+  const customers = getCustomers()
+
+  const filtered = useMemo(() => {
+    const start = new Date()
+    start.setDate(start.getDate() - range)
+    return orders.filter(o => new Date(o.createdAt) >= start)
+  }, [orders, range])
+
+  const totalSales = filtered.reduce((s,o)=>s+o.total,0)
+
+  const handleExport = () => {
+    const text = `รายงานยอดขาย ${formatCurrency(totalSales)} ใน ${range} วัน\nจำนวนออเดอร์ ${filtered.length}`
+    const blob = new Blob([text], { type: 'application/pdf' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'report.pdf'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Export Dashboard (mock)</h1>
+      <div className="flex items-center gap-2">
+        <label className="text-sm">ช่วงวัน:</label>
+        <input type="number" value={range} onChange={e=>setRange(parseInt(e.target.value)||1)} className="w-20 border rounded-md p-1" />
+      </div>
+      <Card>
+        <CardHeader><CardTitle>สรุป</CardTitle></CardHeader>
+        <CardContent className="space-y-2">
+          <p>ยอดขาย: {formatCurrency(totalSales)}</p>
+          <p>ออเดอร์: {filtered.length}</p>
+          <p>ลูกค้าใหม่: {customers.length}</p>
+          <Button onClick={handleExport}>Export PDF</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/insight/kpi/page.tsx
+++ b/app/dashboard/insight/kpi/page.tsx
@@ -1,0 +1,91 @@
+"use client"
+import { useMemo } from "react"
+import { BarChart, Bar, LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { getOrders, getCustomers } from "@/core/mock/store"
+import { formatCurrency } from "@/lib/utils"
+
+export default function InsightKpiPage() {
+  const orders = getOrders()
+  const customers = getCustomers()
+
+  const totalSales = useMemo(() => orders.reduce((s, o) => s + o.total, 0), [orders])
+  const totalOrders = orders.length
+  const newCustomers = customers.filter(c => {
+    const d = new Date(c.createdAt)
+    const aMonthAgo = new Date()
+    aMonthAgo.setDate(aMonthAgo.getDate() - 30)
+    return d >= aMonthAgo
+  }).length
+
+  // mock return rate 0
+  const returnRate = 0
+
+  const dailyData = useMemo(() => {
+    const map: Record<string, number> = {}
+    orders.forEach(o => {
+      const day = o.createdAt.slice(5, 10)
+      map[day] = (map[day] || 0) + 1
+    })
+    return Object.entries(map).map(([day, count]) => ({ day, count }))
+  }, [orders])
+
+  const monthlyData = useMemo(() => {
+    const map: Record<string, number> = {}
+    orders.forEach(o => {
+      const month = o.createdAt.slice(0, 7)
+      map[month] = (map[month] || 0) + 1
+    })
+    return Object.entries(map).map(([month, count]) => ({ month, count }))
+  }, [orders])
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">KPI Overview (mock)</h1>
+      <div className="grid gap-4 sm:grid-cols-4">
+        <Card>
+          <CardHeader><CardTitle>ยอดขายรวม</CardTitle></CardHeader>
+          <CardContent>{formatCurrency(totalSales)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>ออเดอร์ทั้งหมด</CardTitle></CardHeader>
+          <CardContent>{totalOrders}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>ลูกค้าใหม่</CardTitle></CardHeader>
+          <CardContent>{newCustomers}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>อัตราการคืน</CardTitle></CardHeader>
+          <CardContent>{returnRate}%</CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader><CardTitle>ยอดออเดอร์รายวัน</CardTitle></CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={dailyData}>
+              <XAxis dataKey="day" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#8884d8" name="orders" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>ยอดออเดอร์รายเดือน</CardTitle></CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={monthlyData}>
+              <XAxis dataKey="month" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="count" stroke="#82ca9d" name="orders" />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/insight/product/page.tsx
+++ b/app/dashboard/insight/product/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+import { useState, useMemo } from "react"
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { getOrders } from "@/core/mock/store"
+
+export default function ProductPerformancePage() {
+  const [range, setRange] = useState(30)
+  const orders = getOrders()
+
+  const filtered = useMemo(() => {
+    const start = new Date()
+    start.setDate(start.getDate() - range)
+    return orders.filter(o => new Date(o.createdAt) >= start)
+  }, [orders, range])
+
+  const sales = useMemo(() => {
+    const map: Record<string, number> = {}
+    filtered.forEach(o => {
+      o.items.forEach(it => {
+        map[it.productName] = (map[it.productName] || 0) + it.quantity
+      })
+    })
+    return Object.entries(map).map(([name, qty]) => ({ name, qty }))
+  }, [filtered])
+
+  const top = sales.slice().sort((a,b)=>b.qty-a.qty)[0]
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Product Performance (mock)</h1>
+      <div className="flex items-center gap-2">
+        <label className="text-sm">ช่วงวัน:</label>
+        <input type="number" value={range} onChange={e=>setRange(parseInt(e.target.value)||1)} className="w-20 border rounded-md p-1" />
+      </div>
+      <p className="text-sm">สินค้าขายดีสุด: {top? top.name : '-'} ({top? top.qty : 0} ชิ้น)</p>
+      <p className="text-sm">สินค้าที่ถูกคืนบ่อยสุด: - (mock)</p>
+      <Card>
+        <CardHeader><CardTitle>ยอดขาย/ชิ้น</CardTitle></CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={sales}>
+              <XAxis dataKey="name" tick={{fontSize:10}} interval={0} angle={-20} textAnchor="end" height={70} />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="qty" fill="#8884d8" name="จำนวน" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/dashboard/insight/time/page.tsx
+++ b/app/dashboard/insight/time/page.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { useMemo } from "react"
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { getOrders } from "@/core/mock/store"
+
+export default function OrderPeakTimePage() {
+  const orders = getOrders()
+
+  const data = useMemo(() => {
+    const weekday: number[] = Array(24).fill(0)
+    const weekend: number[] = Array(24).fill(0)
+    orders.forEach(o => {
+      const d = new Date(o.createdAt)
+      const arr = d.getDay() === 0 || d.getDay() === 6 ? weekend : weekday
+      arr[d.getHours()]++
+    })
+    return Array.from({ length:24 }).map((_,h)=>({ hour:h, weekday:weekday[h], weekend:weekend[h] }))
+  }, [orders])
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Order Peak Time (mock)</h1>
+      <Card>
+        <CardHeader><CardTitle>เวลาที่มียอดสั่งมากที่สุด</CardTitle></CardHeader>
+        <CardContent className="h-60">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data}>
+              <XAxis dataKey="hour" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="weekday" stroke="#8884d8" name="Weekday" />
+              <Line type="monotone" dataKey="weekend" stroke="#82ca9d" name="Weekend" />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add KPI overview dashboard using mock store
- add customer behavior analytics page
- add product performance report
- add order peak time chart comparing weekday/weekend
- add export dashboard page with fake PDF

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687b4228d31c83258502fabd7f933adf