### PR TITLE
Implement basic tax management features

### DIFF
--- a/app/dashboard/accounting/export/page.tsx
+++ b/app/dashboard/accounting/export/page.tsx
@@ -1,0 +1,51 @@
+"use client"
+import { useMemo } from "react"
+import { mockOrders } from "@/lib/mock-orders"
+import { getConfig } from "@/core/mock/store"
+import { downloadCSV, downloadPDF } from "@/lib/mock-export"
+
+export default function AccountingExportPage() {
+  const summary = useMemo(() => {
+    const map: Record<string, { total: number; tax: number }> = {}
+    const rate = getConfig().tax.rate / 100
+    mockOrders.forEach(o => {
+      const d = new Date(o.createdAt)
+      const key = `${d.getFullYear()}-${d.getMonth() + 1}`
+      if (!map[key]) map[key] = { total: 0, tax: 0 }
+      map[key].total += o.total
+      map[key].tax += Math.round(o.total * rate)
+    })
+    return Object.entries(map).map(([month, val]) => ({ month, ...val }))
+  }, [])
+
+  const handleCSV = () => downloadCSV(summary, 'accounting.csv')
+  const handlePDF = () => downloadPDF('mock accounting pdf', 'accounting.pdf')
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">สรุปบัญชี</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">เดือน</th>
+            <th className="p-2 text-right">ยอดขาย</th>
+            <th className="p-2 text-right">ภาษี</th>
+          </tr>
+        </thead>
+        <tbody>
+          {summary.map(s => (
+            <tr key={s.month} className="border-b">
+              <td className="p-2">{s.month}</td>
+              <td className="p-2 text-right">฿{s.total.toLocaleString()}</td>
+              <td className="p-2 text-right">฿{s.tax.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2">
+        <button onClick={handleCSV} className="border rounded px-4 py-2">Export CSV</button>
+        <button onClick={handlePDF} className="border rounded px-4 py-2">Export PDF</button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/orders/[id]/tax-invoice/page.tsx
+++ b/app/dashboard/orders/[id]/tax-invoice/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { downloadPDF } from "@/lib/mock-export"
+
+export default function OrderTaxInvoice({ params }: { params: { id: string } }) {
+  const { id } = params
+  const handleDownload = () => {
+    downloadPDF('mock tax invoice pdf', `tax-invoice-${id}.pdf`)
+  }
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Tax Invoice {id}</h1>
+      <iframe src={`/tax-invoice/${id}`} className="w-full h-[600px] border" />
+      <button onClick={handleDownload} className="border rounded px-4 py-2">
+        Download PDF
+      </button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/company/page.tsx
+++ b/app/dashboard/settings/company/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { loadCompanyInfo, companyInfo, setCompanyInfo } from "@/lib/mock-company"
+
+export default function CompanySettingsPage() {
+  const [name, setName] = useState(companyInfo.name)
+  const [address, setAddress] = useState(companyInfo.address)
+  const [taxId, setTaxId] = useState(companyInfo.taxId)
+
+  useEffect(() => {
+    loadCompanyInfo()
+    setName(companyInfo.name)
+    setAddress(companyInfo.address)
+    setTaxId(companyInfo.taxId)
+  }, [])
+
+  const handleSave = () => {
+    setCompanyInfo({ name, address, taxId })
+    alert("บันทึกแล้ว")
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">ข้อมูลบริษัท</h1>
+      <Input placeholder="ชื่อบริษัท" value={name} onChange={e=>setName(e.target.value)} />
+      <Input placeholder="ที่อยู่" value={address} onChange={e=>setAddress(e.target.value)} />
+      <Input placeholder="TAX ID" value={taxId} onChange={e=>setTaxId(e.target.value)} />
+      <Button onClick={handleSave}>บันทึก</Button>
+    </div>
+  )
+}

--- a/app/dashboard/settings/tax/page.tsx
+++ b/app/dashboard/settings/tax/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Button } from "@/components/ui/buttons/button"
+import { getConfig, setTax } from "@/core/mock/store"
+
+export default function TaxSettingsPage() {
+  const [rate, setRate] = useState(getConfig().tax.rate)
+  const [included, setIncluded] = useState(getConfig().tax.included)
+
+  useEffect(() => {
+    const { tax } = getConfig()
+    setRate(tax.rate)
+    setIncluded(tax.included)
+  }, [])
+
+  const handleSave = () => {
+    setTax({ rate, included })
+    alert("บันทึกแล้ว")
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">ตั้งค่าภาษี</h1>
+      <Input
+        type="number"
+        value={rate}
+        onChange={e => setRate(Number(e.target.value))}
+        placeholder="เปอร์เซ็นต์ภาษี"
+      />
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="included"
+          checked={included}
+          onCheckedChange={v => setIncluded(v as boolean)}
+        />
+        <label htmlFor="included" className="text-sm">รวมภาษีในราคาสินค้า</label>
+      </div>
+      <Button onClick={handleSave}>บันทึก</Button>
+    </div>
+  )
+}

--- a/app/store/checkout/page.tsx
+++ b/app/store/checkout/page.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { useEffect, useState } from "react"
+import { getConfig } from "@/core/mock/store"
+
+export default function StoreCheckoutPage() {
+  const [subtotal] = useState(1000)
+  const [tax, setTax] = useState(0)
+  const [total, setTotal] = useState(0)
+
+  useEffect(() => {
+    const cfg = getConfig().tax
+    const taxAmount = Math.round(subtotal * (cfg.rate / 100))
+    console.log("apply tax", cfg)
+    setTax(cfg.included ? 0 : taxAmount)
+    setTotal(cfg.included ? subtotal : subtotal + taxAmount)
+  }, [subtotal])
+
+  return (
+    <div className="container mx-auto py-8 space-y-2">
+      <h1 className="text-2xl font-bold">Store Checkout</h1>
+      <p>ยอดก่อนภาษี: ฿{subtotal.toLocaleString()}</p>
+      <p>ภาษี: ฿{tax.toLocaleString()}</p>
+      <p className="font-bold">ยอดชำระ: ฿{total.toLocaleString()}</p>
+    </div>
+  )
+}

--- a/app/tax-invoice/[id]/page.tsx
+++ b/app/tax-invoice/[id]/page.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useEffect, useState } from "react"
+import { companyInfo, loadCompanyInfo } from "@/lib/mock-company"
+import { mockOrders } from "@/lib/mock-orders"
+
+export default function TaxInvoice({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [info, setInfo] = useState(companyInfo)
+
+  useEffect(() => {
+    loadCompanyInfo()
+    setInfo({ ...companyInfo })
+  }, [])
+
+  const order = mockOrders.find(o => o.id === id)
+  if (!order) return <div className="p-4">ไม่พบออเดอร์</div>
+
+  return (
+    <div className="p-8 space-y-2">
+      <h1 className="text-xl font-bold text-center">ใบกำกับภาษี</h1>
+      <p>บริษัท: {info.name}</p>
+      <p>ที่อยู่: {info.address}</p>
+      <p>เลขประจำตัวผู้เสียภาษี: {info.taxId}</p>
+      <hr className="my-4" />
+      <p>ลูกค้า: {order.customerName}</p>
+      <p>Order: {order.id}</p>
+      <p>ยอดสุทธิ: ฿{order.total.toLocaleString()}</p>
+    </div>
+  )
+}

--- a/core/mock/store/config.ts
+++ b/core/mock/store/config.ts
@@ -1,4 +1,4 @@
-import type { StorefrontConfig, ThemeConfig, LayoutComponent } from '@/types/storefront'
+import type { StorefrontConfig, ThemeConfig, LayoutComponent, TaxConfig } from '@/types/storefront'
 import { loadFromStorage, saveToStorage } from './persist'
 
 const KEY = 'mockStore_config'
@@ -14,6 +14,7 @@ const defaultConfig: StorefrontConfig = {
     },
   },
   layout: [],
+  tax: { rate: 7, included: false },
 }
 
 let config: StorefrontConfig = loadFromStorage(KEY, defaultConfig)
@@ -33,6 +34,11 @@ export function setTheme(theme: ThemeConfig) {
 
 export function setLayout(layout: LayoutComponent[]) {
   config.layout = layout
+  persist()
+}
+
+export function setTax(tax: TaxConfig) {
+  config.tax = tax
   persist()
 }
 

--- a/lib/mock-company.ts
+++ b/lib/mock-company.ts
@@ -1,0 +1,23 @@
+export interface CompanyInfo {
+  name: string
+  address: string
+  taxId: string
+}
+
+const KEY = 'companyInfo'
+
+export let companyInfo: CompanyInfo = { name: 'My Company', address: '', taxId: '' }
+
+export function loadCompanyInfo() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(KEY)
+    if (stored) companyInfo = JSON.parse(stored)
+  }
+}
+
+export function setCompanyInfo(info: CompanyInfo) {
+  companyInfo = info
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(info))
+  }
+}

--- a/types/storefront.ts
+++ b/types/storefront.ts
@@ -19,7 +19,13 @@ export interface LayoutComponent {
   type: LayoutComponentType
 }
 
+export interface TaxConfig {
+  rate: number
+  included: boolean
+}
+
 export interface StorefrontConfig {
   theme: ThemeConfig
   layout: LayoutComponent[]
+  tax: TaxConfig
 }


### PR DESCRIPTION
## Summary
- extend `StorefrontConfig` with `TaxConfig`
- persist tax settings in mock store config
- add company info mock store
- create tax settings and company info settings pages
- show tax calculation in store checkout
- generate mock tax invoices
- add accounting export summary page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b469396b48325b773c6ff02684062