### PR TITLE
Add SupportSys mock pages

### DIFF
--- a/app/dashboard/support/[id]/page.tsx
+++ b/app/dashboard/support/[id]/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { tickets, loadTickets, addReply, closeTicket, type SupportTicket } from '@/lib/mock-support'
+import { Button } from '@/components/ui/buttons/button'
+import { Textarea } from '@/components/ui/textarea'
+
+export default function TicketDetailPage({ params }: { params: { id: string } }) {
+  const [ticket, setTicket] = useState<SupportTicket | null>(null)
+  const [reply, setReply] = useState('')
+
+  useEffect(() => {
+    loadTickets()
+    const t = tickets.find(t => t.id === params.id)
+    if (t) setTicket({ ...t })
+  }, [params.id])
+
+  const handleReply = () => {
+    if (!ticket || !reply) return
+    addReply(ticket.id, reply, 'staff')
+    setTicket({ ...ticket, messages: [...ticket.messages, { from: 'staff', text: reply, date: new Date().toISOString() }], status: 'ตอบแล้ว' })
+    setReply('')
+  }
+
+  const handleClose = () => {
+    if (!ticket) return
+    closeTicket(ticket.id)
+    setTicket({ ...ticket, status: 'ปิดแล้ว' })
+  }
+
+  if (!ticket) return <div className='container mx-auto py-8'>ไม่พบ Ticket</div>
+
+  return (
+    <div className='container mx-auto py-8 space-y-4'>
+      <div className='flex justify-between items-center'>
+        <h1 className='text-2xl font-bold'>Ticket {ticket.id}</h1>
+        {ticket.status !== 'ปิดแล้ว' && <Button variant='outline' onClick={handleClose}>ปิดเรื่อง</Button>}
+      </div>
+      <div className='grid md:grid-cols-3 gap-6'>
+        <div className='md:col-span-2 space-y-4'>
+          {ticket.messages.map((m, idx) => (
+            <div key={idx} className={`p-3 rounded border ${m.from==='staff' ? 'bg-gray-50' : 'bg-blue-50'}`}>{m.text}</div>
+          ))}
+          {ticket.status !== 'ปิดแล้ว' && (
+            <div className='space-y-2'>
+              <Textarea value={reply} onChange={e=>setReply(e.target.value)} />
+              <Button onClick={handleReply} disabled={!reply}>ตอบกลับ</Button>
+            </div>
+          )}
+        </div>
+        <div className='border rounded p-4 space-y-2'>
+          <h2 className='font-semibold'>ข้อมูลลูกค้า</h2>
+          <p>{ticket.name}</p>
+          <p>{ticket.email}</p>
+          <p>สถานะ: {ticket.status}</p>
+          <p>สร้างเมื่อ: {new Date(ticket.createdAt).toLocaleString('th-TH')}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/support/inbox/page.tsx
+++ b/app/dashboard/support/inbox/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { tickets, loadTickets, type SupportTicket } from '@/lib/mock-support'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/buttons/button'
+import EmptyState from '@/components/EmptyState'
+
+export default function SupportInboxPage() {
+  const [status, setStatus] = useState('ทั้งหมด')
+  const [list, setList] = useState<SupportTicket[]>([])
+
+  useEffect(() => {
+    loadTickets()
+    setList([...tickets])
+  }, [])
+
+  const filtered = list.filter(t => status === 'ทั้งหมด' || t.status === status)
+
+  return (
+    <div className='container mx-auto py-8 space-y-4'>
+      <div className='flex items-center justify-between'>
+        <h1 className='text-2xl font-bold'>กล่องข้อความ</h1>
+        <select value={status} onChange={e=>setStatus(e.target.value)} className='border rounded p-2'>
+          <option value='ทั้งหมด'>ทั้งหมด</option>
+          <option value='ใหม่'>ใหม่</option>
+          <option value='ตอบแล้ว'>ตอบแล้ว</option>
+          <option value='ปิดแล้ว'>ปิดแล้ว</option>
+        </select>
+      </div>
+      {filtered.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>รหัส</TableHead>
+              <TableHead>ผู้ติดต่อ</TableHead>
+              <TableHead>สถานะ</TableHead>
+              <TableHead className='text-right'></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map(t => (
+              <TableRow key={t.id}>
+                <TableCell>{t.id}</TableCell>
+                <TableCell>{t.name}</TableCell>
+                <TableCell>{t.status}</TableCell>
+                <TableCell className='text-right'>
+                  <Link href={`/dashboard/support/${t.id}`}><Button variant='outline' size='sm'>ตอบ</Button></Link>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <EmptyState title='ไม่มีคำถาม' />
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/support/stats/page.tsx
+++ b/app/dashboard/support/stats/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { tickets, loadTickets, averageReplyHours, type SupportTicket } from '@/lib/mock-support'
+import { PieChart, Pie, Cell } from 'recharts'
+
+export default function SupportStatsPage() {
+  const [list, setList] = useState<SupportTicket[]>([])
+
+  useEffect(() => {
+    loadTickets()
+    setList([...tickets])
+  }, [])
+
+  const total = list.length
+  const closed = list.filter(t => t.status === 'ปิดแล้ว').length
+  const answered = list.filter(t => t.status === 'ตอบแล้ว').length
+  const newCount = list.filter(t => t.status === 'ใหม่').length
+  const avg = averageReplyHours()
+
+  const data = [
+    { name: 'ใหม่', value: newCount },
+    { name: 'ตอบแล้ว', value: answered },
+    { name: 'ปิดแล้ว', value: closed },
+  ]
+  const colors = ['#8884d8', '#82ca9d', '#ffc658']
+
+  return (
+    <div className='container mx-auto py-8 space-y-6'>
+      <h1 className='text-2xl font-bold'>สถิติการซัพพอร์ต</h1>
+      <div className='grid md:grid-cols-2 gap-6'>
+        <div className='space-y-2'>
+          <p>จำนวน Ticket ทั้งหมด: {total}</p>
+          <p>เวลาตอบเฉลี่ย: {avg.toFixed(2)} ชั่วโมง</p>
+        </div>
+        <PieChart width={300} height={300}>
+          <Pie data={data} dataKey='value' nameKey='name' cx='50%' cy='50%' outerRadius={80}>
+            {data.map((entry, index) => (
+              <Cell key={`c-${index}`} fill={colors[index]} />
+            ))}
+          </Pie>
+        </PieChart>
+      </div>
+    </div>
+  )
+}

--- a/app/store/help/contact/page.tsx
+++ b/app/store/help/contact/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useState } from 'react'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Input } from '@/components/ui/inputs/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/buttons/button'
+import { useToast } from '@/hooks/use-toast'
+import { createTicket } from '@/lib/mock-support'
+
+export default function SupportContactPage() {
+  const [form, setForm] = useState<{name:string; email:string; question:string; file:File|null}>({name:'', email:'', question:'', file:null})
+  const { toast } = useToast()
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    createTicket({ name: form.name, email: form.email, question: form.question })
+    setTimeout(() => {
+      toast({ title: 'ส่งคำถามเรียบร้อย', description: 'เราจะติดต่อกลับโดยเร็ว' })
+      setForm({ name: '', email: '', question: '', file: null })
+      setLoading(false)
+    }, 500)
+  }
+
+  return (
+    <div className='min-h-screen flex flex-col'>
+      <Navbar />
+      <div className='container mx-auto flex-1 py-8'>
+        <h1 className='text-2xl font-bold mb-4'>ติดต่อฝ่ายบริการลูกค้า</h1>
+        <form onSubmit={handleSubmit} className='space-y-4 max-w-lg'>
+          <div className='space-y-2'>
+            <Label htmlFor='name'>ชื่อ</Label>
+            <Input id='name' value={form.name} onChange={e=>setForm({...form,name:e.target.value})} required />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='email'>อีเมล</Label>
+            <Input id='email' type='email' value={form.email} onChange={e=>setForm({...form,email:e.target.value})} required />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='question'>คำถาม / ปัญหา</Label>
+            <Textarea id='question' value={form.question} onChange={e=>setForm({...form,question:e.target.value})} required />
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='file'>แนบไฟล์ (mock)</Label>
+            <Input id='file' type='file' onChange={e=>setForm({...form,file:e.target.files?.[0]||null})} />
+          </div>
+          <Button disabled={loading}>{loading ? 'กำลังส่ง...' : 'ส่งข้อความ'}</Button>
+        </form>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/store/help/page.tsx
+++ b/app/store/help/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useState } from 'react'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
+
+interface Faq {
+  id: string
+  question: string
+  answer: string
+  category: string
+}
+
+const items: Faq[] = [
+  { id: '1', question: 'สั่งซื้อสินค้าอย่างไร?', answer: 'เลือกสินค้าที่ต้องการแล้วกดสั่งซื้อ', category: 'การสั่งซื้อ' },
+  { id: '2', question: 'มีบริการจัดส่งฟรีหรือไม่?', answer: 'จัดส่งฟรีเมื่อสั่งครบ 1,500 บาท', category: 'การจัดส่ง' },
+  { id: '3', question: 'คืนสินค้าได้ภายในกี่วัน?', answer: 'สามารถคืนได้ภายใน 30 วัน', category: 'การคืนสินค้า' },
+  { id: '4', question: 'ติดต่อร้านได้ทางไหนบ้าง?', answer: 'ติดต่อได้ทางอีเมลและโทรศัพท์', category: 'ทั่วไป' },
+]
+
+const categories = ['ทั้งหมด', 'ทั่วไป', 'การสั่งซื้อ', 'การจัดส่ง', 'การคืนสินค้า']
+
+export default function HelpCenterPage() {
+  const [keyword, setKeyword] = useState('')
+  const [category, setCategory] = useState('ทั้งหมด')
+
+  const filtered = items.filter((i) =>
+    (category === 'ทั้งหมด' || i.category === category) &&
+    (i.question.includes(keyword) || i.answer.includes(keyword))
+  )
+
+  return (
+    <div className='min-h-screen flex flex-col'>
+      <Navbar />
+      <div className='container mx-auto flex-1 py-8 space-y-4'>
+        <h1 className='text-3xl font-bold text-center'>ศูนย์ช่วยเหลือ</h1>
+        <div className='flex gap-2 justify-center'>
+          <select value={category} onChange={(e)=>setCategory(e.target.value)} className='border rounded p-2'>
+            {categories.map(c=> <option key={c} value={c}>{c}</option>)}
+          </select>
+          <input value={keyword} onChange={(e)=>setKeyword(e.target.value)} placeholder='ค้นหา...' className='border rounded p-2 flex-1 max-w-xs' />
+        </div>
+        <Accordion type='single' collapsible className='max-w-2xl mx-auto'>
+          {filtered.map(f => (
+            <AccordionItem key={f.id} value={f.id}>
+              <AccordionTrigger>{f.question}</AccordionTrigger>
+              <AccordionContent>{f.answer}</AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/lib/mock-support.ts
+++ b/lib/mock-support.ts
@@ -1,0 +1,86 @@
+export interface SupportMessage {
+  from: 'customer' | 'staff'
+  text: string
+  date: string
+}
+
+export interface SupportTicket {
+  id: string
+  name: string
+  email: string
+  question: string
+  status: 'ใหม่' | 'ตอบแล้ว' | 'ปิดแล้ว'
+  createdAt: string
+  messages: SupportMessage[]
+}
+
+export let tickets: SupportTicket[] = [
+  {
+    id: 'TIC-001',
+    name: 'สมชาย ใจดี',
+    email: 'somchai@example.com',
+    question: 'สินค้ามีสีอะไรบ้าง',
+    status: 'ใหม่',
+    createdAt: new Date().toISOString(),
+    messages: [
+      { from: 'customer', text: 'สินค้ามีสีอะไรบ้าง', date: new Date().toISOString() },
+    ],
+  },
+]
+
+export function loadTickets() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('supportTickets')
+    if (stored) tickets = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('supportTickets', JSON.stringify(tickets))
+  }
+}
+
+export function createTicket(data: { name: string; email: string; question: string }) {
+  const t: SupportTicket = {
+    id: `TIC-${Date.now()}`,
+    name: data.name,
+    email: data.email,
+    question: data.question,
+    status: 'ใหม่',
+    createdAt: new Date().toISOString(),
+    messages: [
+      { from: 'customer', text: data.question, date: new Date().toISOString() },
+    ],
+  }
+  tickets.unshift(t)
+  save()
+  return t
+}
+
+export function addReply(id: string, text: string, from: 'customer' | 'staff' = 'staff') {
+  const t = tickets.find((tk) => tk.id === id)
+  if (!t) return
+  t.messages.push({ from, text, date: new Date().toISOString() })
+  if (from === 'staff') t.status = 'ตอบแล้ว'
+  save()
+}
+
+export function closeTicket(id: string) {
+  const t = tickets.find((tk) => tk.id === id)
+  if (!t) return
+  t.status = 'ปิดแล้ว'
+  save()
+}
+
+export function averageReplyHours() {
+  const withReply = tickets.filter((t) => t.messages.some((m) => m.from === 'staff'))
+  if (withReply.length === 0) return 0
+  const sum = withReply.reduce((acc, t) => {
+    const q = t.messages.find((m) => m.from === 'customer')
+    const a = t.messages.find((m) => m.from === 'staff')
+    if (!q || !a) return acc
+    return acc + (new Date(a.date).getTime() - new Date(q.date).getTime())
+  }, 0)
+  return sum / withReply.length / 3600000
+}


### PR DESCRIPTION
## Summary
- add mock data for support tickets
- implement help center frontend with FAQ filtering
- add customer support contact form
- create admin ticket inbox and ticket detail view
- show support statistics with pie chart

## Testing
- `npm test` *(fails: Error [ERR_REQUIRE_ESM])*

------
https://chatgpt.com/codex/tasks/task_e_687b49e8eac08325924e5561e41e57d0