### PR TITLE
Add automation workflow mock

### DIFF
--- a/app/dashboard/automation/actions/page.tsx
+++ b/app/dashboard/automation/actions/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { Button } from '@/components/ui/buttons/button'
+import { sendBroadcast, createSupportTicket } from '@/lib/automation'
+
+export default function AutomationActionsPage() {
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Automation Actions (mock)</h1>
+      <div className="flex gap-2">
+        <Button onClick={() => sendBroadcast({ message: 'hello' })}>Test Broadcast</Button>
+        <Button onClick={() => createSupportTicket({ note: 'unpaid 48h' })}>Test Ticket</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/automation/log/page.tsx
+++ b/app/dashboard/automation/log/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { loadAutomation, logs } from '@/lib/automation'
+import type { AutomationLog } from '@/types/automation'
+
+export default function AutomationLogPage() {
+  const [list, setList] = useState<AutomationLog[]>([])
+  useEffect(() => {
+    loadAutomation()
+    setList([...logs])
+  }, [])
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Workflow Logs (mock)</h1>
+      {list.length ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Rule</TableHead>
+              <TableHead>Event</TableHead>
+              <TableHead>Action</TableHead>
+              <TableHead>Result</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {list.map(l => (
+              <TableRow key={l.id}>
+                <TableCell>{new Date(l.time).toLocaleString()}</TableCell>
+                <TableCell>{l.ruleId}</TableCell>
+                <TableCell>{l.event}</TableCell>
+                <TableCell>{l.action}</TableCell>
+                <TableCell>{l.result}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <p className="text-sm">no logs</p>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/automation/page.tsx
+++ b/app/dashboard/automation/page.tsx
@@ -1,0 +1,12 @@
+export default function AutomationIndexPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-2">
+      <h1 className="text-2xl font-bold">Automation (mock)</h1>
+      <ul className="list-disc pl-5">
+        <li><a href="/dashboard/automation/rules" className="text-blue-600 underline">Rules</a></li>
+        <li><a href="/dashboard/automation/actions" className="text-blue-600 underline">Actions</a></li>
+        <li><a href="/dashboard/automation/log" className="text-blue-600 underline">Logs</a></li>
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/automation/rules/page.tsx
+++ b/app/dashboard/automation/rules/page.tsx
@@ -1,0 +1,75 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { addRule, loadAutomation, rules } from '@/lib/automation'
+import type { AutomationAction, AutomationTrigger, AutomationRule } from '@/types/automation'
+
+export default function AutomationRulesPage() {
+  const [list, setList] = useState<AutomationRule[]>([])
+  const [trigger, setTrigger] = useState<AutomationTrigger>('order_created')
+  const [action, setAction] = useState<AutomationAction>('send_broadcast')
+
+  useEffect(() => {
+    loadAutomation()
+    setList([...rules])
+  }, [])
+
+  const add = () => {
+    const rule: AutomationRule = {
+      id: Date.now().toString(),
+      trigger,
+      action,
+      active: true,
+    }
+    addRule(rule)
+    setList([...rules])
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Workflow Rules (mock)</h1>
+      <div className="flex gap-2">
+        <Select value={trigger} onValueChange={v => setTrigger(v as AutomationTrigger)}>
+          <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="order_created">order_created</SelectItem>
+            <SelectItem value="refund_approved">refund_approved</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={action} onValueChange={v => setAction(v as AutomationAction)}>
+          <SelectTrigger className="w-48"><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="send_broadcast">send_broadcast</SelectItem>
+            <SelectItem value="create_support_ticket">create_support_ticket</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={add}>Add</Button>
+      </div>
+      {list.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Trigger</TableHead>
+              <TableHead>Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {list.map(r => (
+              <TableRow key={r.id}>
+                <TableCell>{r.id}</TableCell>
+                <TableCell>{r.trigger}</TableCell>
+                <TableCell>{r.action}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <p className="text-sm">no rules</p>
+      )}
+    </div>
+  )
+}

--- a/lib/automation.ts
+++ b/lib/automation.ts
@@ -1,0 +1,67 @@
+import { AutomationAction, AutomationLog, AutomationRule, AutomationTrigger } from '@/types/automation'
+
+const RULES_KEY = 'automation_rules'
+const LOGS_KEY = 'automation_logs'
+
+export let rules: AutomationRule[] = []
+export let logs: AutomationLog[] = []
+
+export function loadAutomation() {
+  if (typeof window !== 'undefined') {
+    const r = localStorage.getItem(RULES_KEY)
+    if (r) rules = JSON.parse(r)
+    const l = localStorage.getItem(LOGS_KEY)
+    if (l) logs = JSON.parse(l)
+  }
+}
+
+function saveRules() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(RULES_KEY, JSON.stringify(rules))
+  }
+}
+
+function saveLogs() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(LOGS_KEY, JSON.stringify(logs))
+  }
+}
+
+export function addRule(rule: AutomationRule) {
+  rules.push(rule)
+  saveRules()
+}
+
+export async function triggerEvent(event: AutomationTrigger, payload?: any) {
+  const matched = rules.filter(r => r.active && r.trigger === event)
+  for (const rule of matched) {
+    let result = 'ok'
+    try {
+      if (rule.action === 'send_broadcast') {
+        await sendBroadcast(payload)
+      } else if (rule.action === 'create_support_ticket') {
+        await createSupportTicket(payload)
+      }
+    } catch (e) {
+      result = 'error'
+    }
+    const log: AutomationLog = {
+      id: Date.now().toString(),
+      time: new Date().toISOString(),
+      ruleId: rule.id,
+      event,
+      action: rule.action,
+      result,
+    }
+    logs.push(log)
+  }
+  saveLogs()
+}
+
+export async function sendBroadcast(data?: any) {
+  console.log('mock send broadcast', data)
+}
+
+export async function createSupportTicket(data?: any) {
+  console.log('mock create ticket', data)
+}

--- a/types/automation.ts
+++ b/types/automation.ts
@@ -1,0 +1,19 @@
+export type AutomationTrigger = 'order_created' | 'refund_approved'
+
+export type AutomationAction = 'send_broadcast' | 'create_support_ticket'
+
+export interface AutomationRule {
+  id: string
+  trigger: AutomationTrigger
+  action: AutomationAction
+  active: boolean
+}
+
+export interface AutomationLog {
+  id: string
+  time: string
+  ruleId: string
+  event: AutomationTrigger
+  action: AutomationAction
+  result: string
+}


### PR DESCRIPTION
## Summary
- implement mock automation workflows
- add rule builder, actions tester, and log pages
- store rules and logs in localStorage
- create types and helper functions

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b4c49fea88325a895eb9dd5793651