### PR TITLE
Add logout page

### DIFF
--- a/app/auth/logout/page.tsx
+++ b/app/auth/logout/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/contexts/auth-context"
+
+export default function LogoutPage() {
+  const { logout } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    logout()
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("auth")
+    }
+    if (typeof document !== "undefined") {
+      document.cookie =
+        "elf_admin_session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    }
+    router.replace("/auth/login")
+  }, [logout, router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      กำลังออกจากระบบ...
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `/auth/logout` page that removes auth data and redirects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b64292cf88325be555900eee233fc