### PR TITLE
Add remember me login option

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { mockUsers } from '@/lib/mock-users'
+
+export async function POST(request: NextRequest) {
+  const { email, password } = await request.json()
+  const user = mockUsers.find(u => u.email === email)
+  if (user && password === 'password') {
+    const token = Buffer.from(`${user.id}:${Date.now()}`).toString('base64')
+    return NextResponse.json({ success: true, token, user })
+  }
+  return NextResponse.json({ success: false, message: 'Invalid credentials' }, { status: 401 })
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,6 +5,7 @@ import type React from "react"
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/buttons/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/inputs/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Label } from "@/components/ui/label"
@@ -12,7 +13,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Eye, EyeOff } from "lucide-react"
 import Link from "next/link"
 import { useAuth } from "@/contexts/auth-context"
-import { mockUsers } from "@/lib/mock-users"
+import { useAuthStore } from "@/contexts/auth-store"
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
@@ -20,6 +21,7 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState("")
   const [isLoading, setIsLoading] = useState(false)
+  const [rememberMe, setRememberMe] = useState(false)
   const { login } = useAuth()
   const router = useRouter()
 
@@ -29,10 +31,10 @@ export default function LoginPage() {
     setIsLoading(true)
 
     try {
-      const success = await login(email, password)
+      const success = await login(email, password, rememberMe)
       if (success) {
-        const userData = mockUsers.find((u) => u.email === email)
-        if (userData?.role === "admin") {
+        const currentUser = useAuthStore.getState().user
+        if (currentUser?.role === "admin") {
           router.push("/admin/dashboard")
         } else {
           router.push("/")
@@ -99,6 +101,11 @@ export default function LoginPage() {
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </Button>
               </div>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox id="remember" checked={rememberMe} onCheckedChange={(v) => setRememberMe(!!v)} />
+              <Label htmlFor="remember" className="text-sm">จำการเข้าสู่ระบบ</Label>
             </div>
 
             <Button type="submit" className="w-full" disabled={isLoading}>

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -9,7 +9,7 @@ interface AuthState {
   isAuthenticated: boolean
   guestId: string | null
   isLoading: boolean
-  login: (email: string, password: string) => Promise<boolean>
+  login: (email: string, password: string, remember?: boolean) => Promise<boolean>
   logout: () => void
 }
 
@@ -19,8 +19,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter()
   const auth = useAuthStore()
 
-  const login = async (email: string, password: string) => {
-    const success = await auth.login(email, password)
+  const login = async (email: string, password: string, remember = false) => {
+    const success = await auth.login(email, password, remember)
     return success
   }
 

--- a/contexts/auth-store.ts
+++ b/contexts/auth-store.ts
@@ -1,8 +1,6 @@
 "use client"
 
 import { create } from "zustand"
-import { persist } from "zustand/middleware"
-import { mockUsers } from "@/lib/mock-users"
 import { addAccessLog } from "@/lib/mock-access-logs"
 import type { Role } from "@/lib/mock-roles"
 
@@ -16,49 +14,103 @@ export interface User {
 
 interface AuthStore {
   user: User | null
+  token: string | null
   guestId: string | null
   isLoading: boolean
-  login: (email: string, password: string) => Promise<boolean>
+  login: (email: string, password: string, remember?: boolean) => Promise<boolean>
   logout: () => void
   setUser: (u: User | null) => void
 }
 
-export const useAuthStore = create<AuthStore>()(
-  persist(
-    (set, get) => ({
-      user: null,
-      guestId: `guest-${typeof crypto !== "undefined" ? crypto.randomUUID() : Math.random().toString(36).slice(2)}`,
-      isLoading: false,
-      async login(email, password) {
-        set({ isLoading: true })
-        const foundUser = mockUsers.find((u) => u.email === email)
-        if (foundUser && password === "password") {
-          set({ user: foundUser, guestId: null, isLoading: false })
-          if (typeof window !== "undefined") {
-            const ip = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join(".")
-            addAccessLog(ip, navigator.userAgent)
-          }
-          if (typeof document !== "undefined") {
-            document.cookie = "elf_admin_session=1; path=/"
-          }
-          return true
+const STORAGE_KEY = "auth"
+
+interface StoredAuth {
+  user: User
+  token: string
+  expires?: number
+}
+
+function loadAuth(): StoredAuth | null {
+  if (typeof window === "undefined") return null
+  try {
+    const fromLocal = localStorage.getItem(STORAGE_KEY)
+    if (fromLocal) {
+      const data: StoredAuth = JSON.parse(fromLocal)
+      if (!data.expires || Date.now() < data.expires) {
+        return data
+      }
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  } catch {}
+  try {
+    const fromSession = sessionStorage.getItem(STORAGE_KEY)
+    if (fromSession) return JSON.parse(fromSession)
+  } catch {}
+  return null
+}
+
+function saveAuth(data: StoredAuth, remember?: boolean) {
+  if (typeof window === "undefined") return
+  const serialized = JSON.stringify(
+    remember ? { ...data, expires: Date.now() + 30 * 24 * 60 * 60 * 1000 } : data,
+  )
+  if (remember) {
+    localStorage.setItem(STORAGE_KEY, serialized)
+  } else {
+    sessionStorage.setItem(STORAGE_KEY, serialized)
+  }
+}
+
+function clearAuth() {
+  if (typeof window === "undefined") return
+  localStorage.removeItem(STORAGE_KEY)
+  sessionStorage.removeItem(STORAGE_KEY)
+}
+
+export const useAuthStore = create<AuthStore>((set, get) => {
+  const initial = loadAuth()
+  return {
+    user: initial?.user ?? null,
+    token: initial?.token ?? null,
+    guestId: initial ? null : `guest-${typeof crypto !== "undefined" ? crypto.randomUUID() : Math.random().toString(36).slice(2)}`,
+    isLoading: false,
+    async login(email, password, remember = false) {
+      set({ isLoading: true })
+      try {
+        const res = await fetch("/api/auth/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, password }),
+        })
+        if (!res.ok) {
+          set({ isLoading: false })
+          return false
         }
+        const { user, token } = await res.json()
+        set({ user, token, guestId: null, isLoading: false })
+        saveAuth({ user, token }, remember)
+        if (typeof window !== "undefined") {
+          const ip = Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join(".")
+          addAccessLog(ip, navigator.userAgent)
+        }
+        if (typeof document !== "undefined") {
+          document.cookie = "elf_admin_session=1; path=/"
+        }
+        return true
+      } catch {
         set({ isLoading: false })
         return false
-      },
-      logout() {
-        if (typeof document !== "undefined") {
-          document.cookie = "elf_admin_session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
-        }
-        set({ user: null, guestId: `guest-${crypto.randomUUID()}` })
-      },
-      setUser(u) {
-        set({ user: u })
-      },
-    }),
-    {
-      name: "auth", // localStorage key
-      partialize: (state) => ({ user: state.user }),
+      }
     },
-  ),
-)
+    logout() {
+      if (typeof document !== "undefined") {
+        document.cookie = "elf_admin_session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+      }
+      clearAuth()
+      set({ user: null, token: null, guestId: `guest-${crypto.randomUUID()}` })
+    },
+    setUser(u) {
+      set({ user: u })
+    },
+  }
+})


### PR DESCRIPTION
## Summary
- implement `/api/auth/login` route
- persist auth token to the selected storage
- allow auth context to pass remember flag
- support remember me checkbox on login page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b655cc4508325979c91fa4a77f7c8