### PR TITLE
Add auth store tests

### DIFF
--- a/contexts/__tests__/auth-store.test.ts
+++ b/contexts/__tests__/auth-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAuthStore } from '../auth-store'
+import { mockUsers } from '@/lib/mock-users'
+
+function resetStore() {
+  const state = useAuthStore.getState()
+  useAuthStore.setState({
+    ...state,
+    user: null,
+    guestId: `guest-${crypto.randomUUID()}`,
+    isLoading: false,
+  })
+}
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useAuthStore.persist.clearStorage()
+    resetStore()
+  })
+
+  it('login succeeds with correct credentials', async () => {
+    const email = mockUsers[0].email
+    const success = await useAuthStore.getState().login(email, 'password')
+    expect(success).toBe(true)
+    expect(useAuthStore.getState().user?.email).toBe(email)
+  })
+
+  it('logout clears localStorage', async () => {
+    const email = mockUsers[0].email
+    await useAuthStore.getState().login(email, 'password')
+    expect(localStorage.getItem('auth')).not.toBeNull()
+    useAuthStore.getState().logout()
+    expect(localStorage.getItem('auth')).toBeNull()
+  })
+
+  it('persists user when remember-me is enabled', async () => {
+    const email = mockUsers[0].email
+    await useAuthStore.getState().login(email, 'password')
+    expect(localStorage.getItem('auth')).not.toBeNull()
+
+    resetStore()
+    await useAuthStore.persist.rehydrate()
+
+    expect(useAuthStore.getState().user?.email).toBe(email)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for auth store login, logout and persistence

## Testing
- `npm test` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687b6a5790fc8325a947ff167a11b90e