### PR TITLE
Implement basic order store and hook

### DIFF
--- a/app/invoice/[id]/page.tsx
+++ b/app/invoice/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/cards/card"
 import { Separator } from "@/components/ui/separator"
 import { Download, PrinterIcon as Print, ArrowLeft } from "lucide-react"
 import Link from "next/link"
-import { mockOrders } from "@/lib/mock-orders"
+import { useOrder } from "@/lib/hooks/useOrder"
 import { Badge } from "@/components/ui/badge"
 import { packingStatusOptions } from "@/types/order"
 import { mockBills } from "@/lib/mock-bills"
@@ -15,7 +15,7 @@ import { toast } from "sonner"
 
 export default function InvoicePage({ params }: { params: { id: string } }) {
   const { id } = params
-  const order = mockOrders.find((o) => o.id === id)
+  const { order } = useOrder(id)
 
   if (!order) {
     return (

--- a/app/orders/[id]/page.tsx
+++ b/app/orders/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { ArrowLeft, Download, MessageCircle, Package, Truck, CheckCircle } from "lucide-react"
 import Link from "next/link"
-import { getOrders } from "@/core/mock/store"
+import { useOrder } from "@/lib/hooks/useOrder"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
 import type { OrderStatus } from "@/types/order"
 import {
@@ -17,7 +17,7 @@ import {
 
 export default function OrderDetailPage({ params }: { params: { id: string } }) {
   const { id } = params
-  const order = getOrders().find((o) => o.id === id)
+  const { order } = useOrder(id)
 
   if (!order) {
     return (

--- a/lib/hooks/useOrder.ts
+++ b/lib/hooks/useOrder.ts
@@ -1,0 +1,23 @@
+'use client'
+import { useEffect, useState } from 'react'
+import type { OrderType } from '@/lib/schema/order'
+import { getOrderById, saveOrder } from '@/lib/store/orderStore'
+
+export function useOrder(orderId: string) {
+  const [order, setOrder] = useState<OrderType | undefined>(() => getOrderById(orderId))
+
+  useEffect(() => {
+    setOrder(getOrderById(orderId))
+  }, [orderId])
+
+  const updateOrderStatus = (status: OrderType['status']) => {
+    setOrder(prev => {
+      if (!prev) return prev
+      const updated = { ...prev, status }
+      saveOrder(updated)
+      return updated
+    })
+  }
+
+  return { order, updateOrderStatus }
+}

--- a/lib/schema/order.ts
+++ b/lib/schema/order.ts
@@ -1,0 +1,18 @@
+import type { OrderStatus } from '@/types/order'
+
+export interface OrderItemSchema {
+  productId: string
+  quantity: number
+  price: number
+}
+
+export interface OrderType {
+  id: string
+  customerId: string
+  items: OrderItemSchema[]
+  status: OrderStatus | string
+  createdAt: string
+  updatedAt: string
+  slipUrl?: string
+  [key: string]: any
+}

--- a/lib/store/orderStore.ts
+++ b/lib/store/orderStore.ts
@@ -1,0 +1,35 @@
+import { mockOrders } from '@/lib/mock-orders'
+import { mockCustomers } from '@/lib/mock-customers'
+import { mockProducts } from '@/lib/mock-products'
+import type { OrderType, OrderItemSchema } from '@/lib/schema/order'
+
+let orders: OrderType[] = mockOrders as unknown as OrderType[]
+
+export function getOrders(): OrderType[] {
+  return orders
+}
+
+export function getOrderById(id: string): OrderType | undefined {
+  return orders.find(o => o.id === id)
+}
+
+export function saveOrder(order: OrderType): void {
+  const idx = orders.findIndex(o => o.id === order.id)
+  if (idx !== -1) orders[idx] = order
+  else orders.push(order)
+}
+
+export function getOrderDetailsById(id: string) {
+  const order = getOrderById(id)
+  if (!order) return undefined
+  const customer = mockCustomers.find(c => c.id === order.customerId)
+  const items = order.items.map(i => {
+    const product = mockProducts.find(p => p.id === i.productId)
+    return {
+      ...i,
+      name: product?.name,
+      price: product?.price ?? i.price,
+    }
+  })
+  return { ...order, customer, items }
+}


### PR DESCRIPTION
## Summary
- define `OrderType` schema
- implement memory-backed `orderStore`
- add `useOrder` React hook
- use the new store in order and invoice pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b796aaaa483259b058e475adc8fed