### PR TITLE
Implement basic internal dashboard pages

### DIFF
--- a/app/dashboard/overview/page.tsx
+++ b/app/dashboard/overview/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { getOrders } from '@/core/mock/store'
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+export default function OverviewPage() {
+  const orders = getOrders()
+  const pending = orders.filter(o => o.status === 'pendingPayment').length
+  const delivered = orders.filter(o => o.status === 'delivered').length
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/dashboard">Dashboard</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Overview</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <h1 className="text-2xl font-bold">System Overview</h1>
+      <ul className="space-y-1">
+        <li>Total orders: {orders.length}</li>
+        <li>Pending payment: {pending}</li>
+        <li>Delivered: {delivered}</li>
+      </ul>
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,36 +1,35 @@
 import DashboardQuickCard from '@/components/dashboard/DashboardQuickCard'
 import OrderCard from '@/components/orders/OrderCard'
-import { fabrics } from '@/mock/fabrics'
 import { orders } from '@/mock/orders'
-import { mockBills } from '@/mock/bills'
 import SectionHeader from '@/components/ui/SectionHeader'
 
 export default function DashboardPage() {
   const today = new Date().toLocaleDateString('th-TH')
   const links = [
     {
-      link: '/dashboard/fabrics',
-      title: 'Fabrics',
-      icon: '🧵',
-      count: fabrics.length,
-    },
-    {
       link: '/dashboard/orders',
       title: 'Orders',
       icon: '📦',
-      count: orders.length,
     },
     {
-      link: '/dashboard/collections',
-      title: 'Collections',
-      icon: '🗂️',
-      count: null,
+      link: '/dashboard/customers',
+      title: 'Customers',
+      icon: '👥',
     },
     {
-      link: '/dashboard/bill/BILL-001',
-      title: 'Bills',
-      icon: '🧾',
-      count: mockBills.length,
+      link: '/dashboard/analytics',
+      title: 'Reports',
+      icon: '📊',
+    },
+    {
+      link: '/reviews',
+      title: 'Reviews',
+      icon: '⭐',
+    },
+    {
+      link: '/dashboard/settings',
+      title: 'Settings',
+      icon: '⚙️',
     },
   ]
   const latest = orders.slice(0, 3)

--- a/app/internal/dev/feature-map/page.tsx
+++ b/app/internal/dev/feature-map/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+const featureMap: Record<string, string[]> = {
+  Order: [
+    "Order list",
+    "Order detail",
+    "Invoice generation",
+    "Shipping label",
+  ],
+  Customer: ["Customer directory", "Customer profile"],
+  Product: ["Product catalog", "Collections"],
+  Payment: ["Slip upload", "Online invoice"],
+  Review: ["Customer reviews", "Admin reply"],
+}
+
+export default function FeatureMapPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/dashboard">Dashboard</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Feature Map</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <h1 className="text-2xl font-bold">Feature Map</h1>
+      <pre className="bg-muted p-4 rounded overflow-auto text-sm">
+        {JSON.stringify(featureMap, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/app/internal/dev/flow-graph/page.tsx
+++ b/app/internal/dev/flow-graph/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+const flow = [
+  "Customer → Order",
+  "Order → Payment",
+  "Payment → Status",
+  "Status → Delivery",
+]
+
+export default function FlowGraphPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/dashboard">Dashboard</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Flow Diagram</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <h1 className="text-2xl font-bold">Flow Diagram</h1>
+      <div className="space-y-1 bg-muted p-4 rounded">
+        {flow.map((line) => (
+          <div key={line}>{line}</div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/ui/sidebar.config.ts
+++ b/components/ui/sidebar.config.ts
@@ -16,7 +16,10 @@ export const sidebarSections: SidebarSectionConfig[] = [
     section: "General",
     items: [
       { label: "Dashboard", icon: require("lucide-react").Home, href: "/dashboard" },
+      { label: "Overview", icon: require("lucide-react").GaugeCircle, href: "/dashboard/overview" },
       { label: "Orders", icon: require("lucide-react").ShoppingCart, href: "/orders" },
+      { label: "Customers", icon: require("lucide-react").Users, href: "/dashboard/customers" },
+      { label: "Reviews", icon: require("lucide-react").Star, href: "/reviews" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add overview metrics page under dashboard
- add feature map and flow diagram internal pages
- simplify dashboard landing sections
- update sidebar navigation items

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687b95b209088325bae2587e2c35a5e7