### PR TITLE
Fix dashboard page for client hooks

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import DashboardQuickCard from '@/components/dashboard/DashboardQuickCard'
 import OrderCard from '@/components/orders/OrderCard'
 import { fabrics } from '@/mock/fabrics'


### PR DESCRIPTION
## Summary
- mark dashboard page as a client component so useSearchParams can run

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687bb00e4434832589569a7720f6d2a1