### PR TITLE
Implement dev dashboard overview and mapping pages

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,19 @@
 import type React from "react"
 import Guard from "@/components/Guard"
+import DashboardLayout from "@/components/layouts/DashboardLayout"
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return <Guard role={["admin", "staff"]}>{children}</Guard>
+const sections = [
+  { href: "/dashboard", title: "Overview" },
+  { href: "/dashboard/orders", title: "Orders" },
+  { href: "/dashboard/customers", title: "Customers" },
+  { href: "/dashboard/reviews", title: "Reviews" },
+  { href: "/dashboard/settings", title: "Settings" },
+]
+
+export default function DashboardLayoutRoot({ children }: { children: React.ReactNode }) {
+  return (
+    <Guard role={["admin", "staff"]}>
+      <DashboardLayout sections={sections}>{children}</DashboardLayout>
+    </Guard>
+  )
 }

--- a/app/dashboard/overview/page.tsx
+++ b/app/dashboard/overview/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { fetchDashboardStats } from '@/lib/mock-dashboard'
+import DashboardLayout from '@/components/layouts/DashboardLayout'
+
+export default function OverviewPage() {
+  const [stats, setStats] = useState<any>()
+  useEffect(() => {
+    fetchDashboardStats().then(setStats)
+  }, [])
+
+  const sections = [
+    { href: '/dashboard', title: 'Overview' },
+    { href: '/dashboard/orders', title: 'Orders' },
+    { href: '/dashboard/customers', title: 'Customers' },
+    { href: '/dashboard/reviews', title: 'Reviews' },
+    { href: '/dashboard/settings', title: 'Settings' },
+  ]
+
+  return (
+    <DashboardLayout sections={sections}>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">System Overview</h1>
+        {stats ? (
+          <ul className="list-disc ml-5 space-y-1 text-sm">
+            <li>Total orders: {stats.totalOrders}</li>
+            <li>Pending orders: {stats.pendingOrders}</li>
+            <li>Total products: {stats.totalProducts}</li>
+            <li>Total customers: {stats.totalCustomers}</li>
+          </ul>
+        ) : (
+          <p>Loading...</p>
+        )}
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/internal/dev/component-map/page.tsx
+++ b/app/internal/dev/component-map/page.tsx
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Component Map'
+}
+
+function getComponents() {
+  const dir = path.join(process.cwd(), 'components')
+  const files = fs.readdirSync(dir)
+  return files.filter(f => f.endsWith('.tsx'))
+}
+
+export default function ComponentMapPage() {
+  const list = getComponents()
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Component Map</h1>
+      <pre className="bg-muted p-4 rounded-md text-sm">
+        {JSON.stringify(list, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/app/internal/dev/feature-map/page.tsx
+++ b/app/internal/dev/feature-map/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Feature Map'
+}
+
+const features = [
+  { category: 'Orders', feature: 'List orders' },
+  { category: 'Products', feature: 'Manage products' },
+  { category: 'Customers', feature: 'Customer profiles' },
+]
+
+export default function FeatureMapPage() {
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Feature Map</h1>
+      <pre className="bg-muted p-4 rounded-md text-sm">
+        {JSON.stringify(features, null, 2)}
+      </pre>
+    </div>
+  )
+}

--- a/components/layouts/DashboardLayout.tsx
+++ b/components/layouts/DashboardLayout.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+export interface DashboardSection {
+  title: string
+  href: string
+}
+
+interface DashboardLayoutProps {
+  sections: DashboardSection[]
+  children: React.ReactNode
+}
+
+export default function DashboardLayout({ sections, children }: DashboardLayoutProps) {
+  const pathname = usePathname()
+  return (
+    <div className="flex flex-col md:flex-row gap-6">
+      <nav className="md:w-60">
+        <ul className="space-y-2">
+          {sections.map(sec => (
+            <li key={sec.href}>
+              <Link
+                href={sec.href}
+                className={`block px-3 py-2 rounded-md hover:bg-muted/40 ${pathname === sec.href ? 'bg-muted/40 font-medium' : ''}`}
+              >
+                {sec.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="flex-1">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/lib/hooks/useDashboardRoute.ts
+++ b/lib/hooks/useDashboardRoute.ts
@@ -1,0 +1,20 @@
+'use client'
+import { usePathname } from 'next/navigation'
+
+const routeMap: Record<string, { title: string; category: string }> = {
+  '/dashboard': { title: 'Overview', category: 'Overview' },
+  '/dashboard/orders': { title: 'Orders', category: 'Orders' },
+  '/dashboard/customers': { title: 'Customers', category: 'Customers' },
+  '/dashboard/reviews': { title: 'Reviews', category: 'Reviews' },
+  '/dashboard/settings': { title: 'Settings', category: 'Settings' },
+}
+
+export function useDashboardRoute() {
+  const pathname = usePathname()
+  const info = routeMap[pathname] ?? { title: 'Dashboard', category: 'Other' }
+  const breadcrumb = [
+    { title: 'Dashboard', href: '/dashboard' },
+    pathname !== '/dashboard' ? { title: info.title, href: pathname } : null,
+  ].filter(Boolean)
+  return { ...info, breadcrumb }
+}


### PR DESCRIPTION
## Summary
- add DashboardLayout component with nav sections
- wrap dashboard pages in new layout
- add overview page using mock dashboard stats
- add feature-map and component-map dev pages
- add useDashboardRoute hook

## Testing
- `pnpm test` *(fails: require() of ES Module vite index.js not supported)*

------
https://chatgpt.com/codex/tasks/task_e_687bb3ae1b88832589307323bee9550c