### PR TITLE
Add dashboard route meta and breadcrumb support

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,14 @@
 import type React from "react"
 import Guard from "@/components/Guard"
+import DashboardBreadcrumbs from "@/components/dashboard/DashboardBreadcrumbs"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return <Guard role={["admin", "staff"]}>{children}</Guard>
+  return (
+    <Guard role={["admin", "staff"]}>
+      <div className="p-4">
+        <DashboardBreadcrumbs />
+        {children}
+      </div>
+    </Guard>
+  )
 }

--- a/components/dashboard/DashboardBreadcrumbs.tsx
+++ b/components/dashboard/DashboardBreadcrumbs.tsx
@@ -1,0 +1,38 @@
+"use client"
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb'
+import { getDashboardMeta } from '@/lib/dashboardRoutes'
+
+export default function DashboardBreadcrumbs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/').filter(Boolean)
+  let path = ''
+  const crumbs = segments.map((segment) => {
+    path += `/${segment}`
+    return { path, segment, meta: getDashboardMeta(path) }
+  })
+
+  if (!pathname.startsWith('/dashboard')) return null
+
+  return (
+    <Breadcrumb className="mb-4">
+      <BreadcrumbList>
+        {crumbs.map((c, i) => (
+          <BreadcrumbItem key={c.path}>
+            {i < crumbs.length - 1 ? (
+              <>
+                <BreadcrumbLink asChild>
+                  <Link href={c.path}>{c.meta?.title ?? c.segment}</Link>
+                </BreadcrumbLink>
+                <BreadcrumbSeparator />
+              </>
+            ) : (
+              <BreadcrumbPage>{c.meta?.title ?? c.segment}</BreadcrumbPage>
+            )}
+          </BreadcrumbItem>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/components/ui/sidebar.config.ts
+++ b/components/ui/sidebar.config.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-react"
+import { dashboardRoutes } from "@/lib/dashboardRoutes"
 
 export interface SidebarItemConfig {
   label: string
@@ -15,7 +16,7 @@ export const sidebarSections: SidebarSectionConfig[] = [
   {
     section: "General",
     items: [
-      { label: "Dashboard", icon: require("lucide-react").Home, href: "/dashboard" },
+      { label: dashboardRoutes['/dashboard'].title, icon: require("lucide-react").Home, href: "/dashboard" },
       { label: "Orders", icon: require("lucide-react").ShoppingCart, href: "/orders" },
     ],
   },
@@ -23,17 +24,17 @@ export const sidebarSections: SidebarSectionConfig[] = [
     section: "Inventory",
     items: [
       { label: "Products", icon: require("lucide-react").Package, href: "/products" },
-      { label: "Stock", icon: require("lucide-react").ClipboardList, href: "/dashboard/stock" },
+      { label: dashboardRoutes['/dashboard/stock'].title, icon: require("lucide-react").ClipboardList, href: "/dashboard/stock" },
     ],
   },
   {
     section: "System",
     items: [
-      { label: "Access Log", icon: require("lucide-react").List, href: "/dashboard/logs/access" },
-      { label: "Performance", icon: require("lucide-react").BarChart3, href: "/dashboard/insight/performance" },
-      { label: "Campaigns", icon: require("lucide-react").Target, href: "/dashboard/campaigns" },
-      { label: "Lock", icon: require("lucide-react").Lock, href: "/dashboard/settings/lock" },
-      { label: "Backup", icon: require("lucide-react").Database, href: "/dashboard/settings/system-backup" },
+      { label: dashboardRoutes['/dashboard/logs'].title, icon: require("lucide-react").List, href: "/dashboard/logs/access" },
+      { label: dashboardRoutes['/dashboard/insight'].title, icon: require("lucide-react").BarChart3, href: "/dashboard/insight/performance" },
+      { label: dashboardRoutes['/dashboard/campaigns'].title, icon: require("lucide-react").Target, href: "/dashboard/campaigns" },
+      { label: dashboardRoutes['/dashboard/settings'].title, icon: require("lucide-react").Lock, href: "/dashboard/settings/lock" },
+      { label: dashboardRoutes['/dashboard/settings'].title + ' Backup', icon: require("lucide-react").Database, href: "/dashboard/settings/system-backup" },
     ],
   },
 ]

--- a/hooks/use-dashboard-meta.tsx
+++ b/hooks/use-dashboard-meta.tsx
@@ -1,0 +1,10 @@
+"use client"
+import { usePathname } from 'next/navigation'
+import { useMemo } from 'react'
+import { getDashboardMeta } from '@/lib/dashboardRoutes'
+
+export function useDashboardMeta(pathname?: string) {
+  const current = usePathname()
+  const path = pathname || current
+  return useMemo(() => getDashboardMeta(path), [path])
+}

--- a/lib/dashboardRoutes.ts
+++ b/lib/dashboardRoutes.ts
@@ -1,0 +1,36 @@
+export interface DashboardRoute {
+  title: string
+  category: string
+}
+
+export const dashboardRoutes: Record<string, DashboardRoute> = {
+  '/dashboard': { title: 'Dashboard', category: 'general' },
+  '/dashboard/orders': { title: 'Orders', category: 'orders' },
+  '/dashboard/fabrics': { title: 'Fabrics', category: 'inventory' },
+  '/dashboard/collections': { title: 'Collections', category: 'inventory' },
+  '/dashboard/bill': { title: 'Bills', category: 'orders' },
+  '/dashboard/bills': { title: 'Bills', category: 'orders' },
+  '/dashboard/customers': { title: 'Customers', category: 'customers' },
+  '/dashboard/stock': { title: 'Stock', category: 'inventory' },
+  '/dashboard/tools': { title: 'Tools', category: 'tools' },
+  '/dashboard/analytics': { title: 'Analytics', category: 'analytics' },
+  '/dashboard/automation': { title: 'Automation', category: 'automation' },
+  '/dashboard/devtools': { title: 'Dev Tools', category: 'dev' },
+  '/dashboard/shipping': { title: 'Shipping', category: 'orders' },
+  '/dashboard/settings': { title: 'Settings', category: 'settings' },
+  '/dashboard/logs': { title: 'Logs', category: 'system' },
+  '/dashboard/profile': { title: 'Profile', category: 'profile' },
+  '/dashboard/broadcast': { title: 'Broadcast', category: 'marketing' },
+  '/dashboard/campaigns': { title: 'Campaigns', category: 'marketing' },
+  '/dashboard/storefront': { title: 'Storefront', category: 'storefront' },
+  '/dashboard/insight': { title: 'Insight', category: 'analytics' },
+  '/dashboard/alerts': { title: 'Alerts', category: 'system' },
+  '/dashboard/members': { title: 'Members', category: 'customers' },
+}
+
+export function getDashboardMeta(pathname: string): DashboardRoute | undefined {
+  const match = Object.entries(dashboardRoutes)
+    .filter(([path]) => pathname === path || pathname.startsWith(path + '/'))
+    .sort((a, b) => b[0].length - a[0].length)[0]
+  return match?.[1]
+}


### PR DESCRIPTION
## Summary
- configure a dashboard route map with title/category info
- expose a `useDashboardMeta` hook
- display breadcrumbs in the dashboard layout
- use route map for sidebar labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bd65f74a48325afb6cf160c197c46