### PR TITLE
Add configurable DashboardLayout

### DIFF
--- a/components/layouts/DashboardLayout.tsx
+++ b/components/layouts/DashboardLayout.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export interface DashboardCategory {
+  label: string;
+  content: React.ReactNode;
+}
+
+export interface DashboardLayoutProps {
+  /**
+   * Object where key is the tab value and value contains label and content.
+   */
+  categories?: Record<string, DashboardCategory>;
+  /**
+   * default active tab key
+   */
+  defaultCategory?: string;
+}
+
+export const defaultCategories: Record<string, DashboardCategory> = {
+  orders: { label: "Orders", content: null },
+  customers: { label: "Customers", content: null },
+  marketing: { label: "Marketing", content: null },
+};
+
+export default function DashboardLayout({
+  categories = defaultCategories,
+  defaultCategory,
+}: DashboardLayoutProps) {
+  const keys = Object.keys(categories);
+  const defaultValue = defaultCategory ?? keys[0];
+  return (
+    <Tabs defaultValue={defaultValue} className="space-y-4">
+      <TabsList className="flex w-full flex-wrap gap-2">
+        {keys.map((key) => (
+          <TabsTrigger key={key} value={key} className="capitalize">
+            {categories[key].label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {keys.map((key) => (
+        <TabsContent key={key} value={key} className="mt-0">
+          {categories[key].content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `DashboardLayout` component with tabbed categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bdc44264883258f403756247afa34