### PR TITLE
Add route metadata hook

### DIFF
--- a/components/StoreBottomNav.tsx
+++ b/components/StoreBottomNav.tsx
@@ -1,12 +1,12 @@
 "use client"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { useRouteInfo } from "@/hooks/use-route-info"
 import { Home, ShoppingCart, Package, User } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
 
 export default function StoreBottomNav() {
   const isMobile = useIsMobile()
-  const pathname = usePathname()
+  const { category } = useRouteInfo()
 
   if (!isMobile) return null
 
@@ -15,19 +15,19 @@ export default function StoreBottomNav() {
 
   return (
     <nav className="fixed bottom-0 inset-x-0 z-40 border-t bg-background flex text-xs">
-      <Link href="/" className={itemClass(pathname === '/')}> 
+      <Link href="/" className={itemClass(category === 'home')}>
         <Home className="h-5 w-5" />
         Home
       </Link>
-      <Link href="/cart" className={itemClass(pathname.startsWith('/cart'))}>
+      <Link href="/cart" className={itemClass(category === 'cart')}>
         <ShoppingCart className="h-5 w-5" />
         Cart
       </Link>
-      <Link href="/orders" className={itemClass(pathname.startsWith('/orders'))}>
+      <Link href="/orders" className={itemClass(category === 'orders')}>
         <Package className="h-5 w-5" />
         Orders
       </Link>
-      <Link href="/profile" className={itemClass(pathname.startsWith('/profile'))}>
+      <Link href="/profile" className={itemClass(category === 'profile')}>
         <User className="h-5 w-5" />
         Profile
       </Link>

--- a/components/admin/Topbar.tsx
+++ b/components/admin/Topbar.tsx
@@ -6,9 +6,11 @@ import { Button } from "@/components/ui/buttons/button"
 import { useAuth } from "@/contexts/auth-context"
 import GlobalBadge from "./GlobalBadge"
 import { getGlobalAlertCount } from "@/lib/mock-alerts"
+import { useRouteInfo } from "@/hooks/use-route-info"
 
 export default function Topbar({ onMenuClick }: { onMenuClick?: () => void }) {
   const { logout } = useAuth()
+  const { title } = useRouteInfo()
   const [count, setCount] = useState(0)
 
   useEffect(() => {
@@ -30,7 +32,7 @@ export default function Topbar({ onMenuClick }: { onMenuClick?: () => void }) {
           <Menu className="h-5 w-5" />
           <span className="sr-only">เมนู</span>
         </Button>
-        <span className="font-semibold">แดชบอร์ดผู้ดูแล</span>
+        <span className="font-semibold">{title || 'แดชบอร์ดผู้ดูแล'}</span>
         <GlobalBadge count={count} />
       </div>
       <Button variant="ghost" size="icon" onClick={logout}>

--- a/hooks/__tests__/use-route-info.test.ts
+++ b/hooks/__tests__/use-route-info.test.ts
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { useRouteInfo } from '../use-route-info'
+
+const usePathnameMock = vi.fn()
+vi.mock('next/navigation', () => ({
+  usePathname: () => usePathnameMock(),
+}))
+
+describe('useRouteInfo', () => {
+  it('matches static route', () => {
+    usePathnameMock.mockReturnValue('/cart')
+    const { result } = renderHook(() => useRouteInfo())
+    expect(result.current.title).toBe('ตะกร้าสินค้า')
+    expect(result.current.category).toBe('cart')
+  })
+
+  it('matches dynamic route', () => {
+    usePathnameMock.mockReturnValue('/orders/123')
+    const { result } = renderHook(() => useRouteInfo())
+    expect(result.current.category).toBe('orders')
+    expect(result.current.breadcrumb.at(-1)?.href).toBe('/orders/123')
+  })
+})

--- a/hooks/use-route-info.ts
+++ b/hooks/use-route-info.ts
@@ -1,0 +1,39 @@
+"use client"
+
+import { usePathname } from 'next/navigation'
+import type { BreadcrumbItem, RouteMeta } from '@/lib/route-metadata'
+import { routeMeta } from '@/lib/route-metadata'
+
+function matchPath(pattern: string, path: string): [Record<string,string>, boolean] {
+  const keys: string[] = []
+  const regex = new RegExp('^' + pattern.replace(/:([^/]+)/g, (_, k) => {
+    keys.push(k)
+    return '([^/]+)'
+  }) + '$')
+  const m = path.match(regex)
+  if (!m) return [{}, false]
+  const params: Record<string,string> = {}
+  keys.forEach((k,i) => { params[k] = m[i+1] })
+  return [params, true]
+}
+
+function fill(pattern: string, params: Record<string,string>) {
+  return pattern.replace(/:([^/]+)/g, (_, k) => params[k] ?? '')
+}
+
+export function useRouteInfo(): { title: string; category: string; breadcrumb: BreadcrumbItem[] } {
+  const pathname = usePathname()
+
+  for (const meta of routeMeta) {
+    const [params, ok] = matchPath(meta.path, pathname)
+    if (ok) {
+      const breadcrumb = meta.breadcrumb.map(b => ({
+        label: fill(b.label, params),
+        href: fill(b.href, params),
+      }))
+      return { title: meta.title, category: meta.category, breadcrumb }
+    }
+  }
+
+  return { title: '', category: '', breadcrumb: [] }
+}

--- a/lib/route-metadata.ts
+++ b/lib/route-metadata.ts
@@ -1,0 +1,57 @@
+export interface BreadcrumbItem {
+  label: string
+  href: string
+}
+
+export interface RouteMeta {
+  path: string
+  title: string
+  category: string
+  breadcrumb: BreadcrumbItem[]
+}
+
+export const routeMeta: RouteMeta[] = [
+  {
+    path: '/',
+    title: 'หน้าแรก',
+    category: 'home',
+    breadcrumb: [{ label: 'หน้าแรก', href: '/' }],
+  },
+  {
+    path: '/cart',
+    title: 'ตะกร้าสินค้า',
+    category: 'cart',
+    breadcrumb: [
+      { label: 'หน้าแรก', href: '/' },
+      { label: 'ตะกร้า', href: '/cart' },
+    ],
+  },
+  {
+    path: '/orders',
+    title: 'คำสั่งซื้อ',
+    category: 'orders',
+    breadcrumb: [
+      { label: 'หน้าแรก', href: '/' },
+      { label: 'คำสั่งซื้อ', href: '/orders' },
+    ],
+  },
+  {
+    path: '/orders/:id',
+    title: 'รายละเอียดคำสั่งซื้อ',
+    category: 'orders',
+    breadcrumb: [
+      { label: 'หน้าแรก', href: '/' },
+      { label: 'คำสั่งซื้อ', href: '/orders' },
+      { label: 'คำสั่งซื้อ :id', href: '/orders/:id' },
+    ],
+  },
+  {
+    path: '/profile',
+    title: 'โปรไฟล์',
+    category: 'profile',
+    breadcrumb: [
+      { label: 'หน้าแรก', href: '/' },
+      { label: 'โปรไฟล์', href: '/profile' },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- add `routeMeta` configuration with titles, categories and breadcrumbs
- implement `useRouteInfo` hook to parse dynamic routes
- show current route title in admin topbar
- highlight bottom nav by route category
- test route matching logic

## Testing
- `npx vitest run hooks/__tests__/use-route-info.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687bde92d6f48325b0f0449ff677285f