### PR TITLE
Dynamic sidebar groups

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -37,7 +37,9 @@ import {
   SidebarMenuSubItem,
   sidebarMenuButtonVariants,
 } from "./SidebarItem"
-import { sidebarSections } from "./sidebar.config"
+import { useDashboardRoute, type DashboardRoute } from "@/hooks/useDashboardRoute"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { ChevronDown } from "lucide-react"
 import {
   Tooltip,
   TooltipContent,
@@ -335,26 +337,52 @@ const SidebarInput = React.forwardRef<
 SidebarInput.displayName = "SidebarInput"
 
 function SidebarNavigation() {
+  const routes = useDashboardRoute()
+
+  const groups = React.useMemo(() => {
+    const map = new Map<string, DashboardRoute[]>()
+    routes.forEach((r) => {
+      if (!map.has(r.category)) map.set(r.category, [])
+      map.get(r.category)!.push(r)
+    })
+    return Array.from(map.entries())
+  }, [routes])
+
   return (
     <SidebarContent>
-      {sidebarSections.map((section) => (
-        <SidebarGroup key={section.section}>
-          <SidebarGroupLabel>{section.section}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {section.items.map((item) => (
-                <SidebarMenuItem key={item.href}>
-                  <SidebarMenuButton asChild>
-                    <a href={item.href} className="flex items-center gap-2">
-                      <item.icon className="size-4" />
-                      <span>{item.label}</span>
-                    </a>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+      {groups.map(([category, items]) => (
+        <Collapsible key={category} defaultOpen>
+          <SidebarGroup className="p-0">
+            <div className="flex items-center">
+              <CollapsibleTrigger asChild>
+                <SidebarGroupLabel className="flex-1 cursor-pointer">
+                  {category}
+                </SidebarGroupLabel>
+              </CollapsibleTrigger>
+              <SidebarGroupAction asChild>
+                <CollapsibleTrigger className="ml-auto">
+                  <ChevronDown className="size-4 transition-transform data-[state=open]:rotate-180" />
+                </CollapsibleTrigger>
+              </SidebarGroupAction>
+            </div>
+            <CollapsibleContent>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {items.map((item) => (
+                    <SidebarMenuItem key={item.href}>
+                      <SidebarMenuButton asChild>
+                        <a href={item.href} className="flex items-center gap-2">
+                          <item.icon className="size-4" />
+                          <span>{item.label}</span>
+                        </a>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </CollapsibleContent>
+          </SidebarGroup>
+        </Collapsible>
       ))}
     </SidebarContent>
   )

--- a/hooks/useDashboardRoute.ts
+++ b/hooks/useDashboardRoute.ts
@@ -1,0 +1,35 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  Home,
+  ShoppingCart,
+  Package,
+  ClipboardList,
+  List,
+  BarChart3,
+  Target,
+  Lock,
+  Database,
+} from "lucide-react"
+
+export interface DashboardRoute {
+  label: string
+  href: string
+  category: string
+  icon: LucideIcon
+}
+
+const routes: DashboardRoute[] = [
+  { category: "General", label: "Dashboard", icon: Home, href: "/dashboard" },
+  { category: "General", label: "Orders", icon: ShoppingCart, href: "/orders" },
+  { category: "Inventory", label: "Products", icon: Package, href: "/products" },
+  { category: "Inventory", label: "Stock", icon: ClipboardList, href: "/dashboard/stock" },
+  { category: "System", label: "Access Log", icon: List, href: "/dashboard/logs/access" },
+  { category: "System", label: "Performance", icon: BarChart3, href: "/dashboard/insight/performance" },
+  { category: "System", label: "Campaigns", icon: Target, href: "/dashboard/campaigns" },
+  { category: "System", label: "Lock", icon: Lock, href: "/dashboard/settings/lock" },
+  { category: "System", label: "Backup", icon: Database, href: "/dashboard/settings/system-backup" },
+]
+
+export function useDashboardRoute() {
+  return routes
+}


### PR DESCRIPTION
## Summary
- build new `useDashboardRoute` hook for sidebar menu categories
- use the new hook inside the sidebar and render collapsible groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687be107ba988325b11f16d68cd4da32