### PR TITLE
Add grouped dashboard preview

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,6 +1,17 @@
+"use client"
 import type React from "react"
+import { useSearchParams } from "next/navigation"
 import Guard from "@/components/Guard"
+import GroupedPreview from "@/components/dashboard/GroupedPreview"
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-  return <Guard role={["admin", "staff"]}>{children}</Guard>
+  const searchParams = useSearchParams()
+  const grouped = searchParams.get("preview") === "grouped"
+
+  return (
+    <Guard role={["admin", "staff"]}>
+      {grouped && <GroupedPreview />}
+      {children}
+    </Guard>
+  )
 }

--- a/components/DevBar.tsx
+++ b/components/DevBar.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@/contexts/auth-context'
 import { setEnv, getEnv, EnvMode } from '@/lib/system-config'
 import { useFeatureFlags } from '@/contexts/feature-flag-context'
@@ -13,6 +14,19 @@ export default function DevBar() {
   const { toggle } = useFeatureFlags()
   const { toggle: toggleDemo } = useDemo()
   const [env, setEnvState] = useState<EnvMode>(getEnv())
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const grouped = searchParams.get('preview') === 'grouped'
+
+  const toggleGrouped = () => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (grouped) {
+      params.delete('preview')
+    } else {
+      params.set('preview', 'grouped')
+    }
+    router.replace(`?${params.toString()}`)
+  }
 
   useEffect(() => {
     setEnv(env)
@@ -28,6 +42,7 @@ export default function DevBar() {
       <button onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}>Toggle Theme</button>
       <button onClick={() => toggle('review')}>Toggle Review</button>
       <button onClick={toggleDemo}>Demo Mode</button>
+      <button onClick={toggleGrouped}>{grouped ? 'Ungroup' : 'Group'} View</button>
       <select value={env} onChange={e => setEnvState(e.target.value as EnvMode)} className="border ml-2">
         <option value="development">dev</option>
         <option value="preview">preview</option>

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -8,76 +8,13 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion"
-import {
-  BarChart3,
-  Bolt,
-  FileText,
-  Folder,
-  HelpCircle,
-  Layers,
-  MailQuestion,
-  Megaphone,
-  MessageCircle,
-  Percent,
-  Settings,
-  Target,
-  Users,
-} from "lucide-react"
+import type { FeatureGroup } from "@/lib/feature-map"
+import { featureMap } from "@/lib/feature-map"
 import clsx from "clsx"
 import { useAuth } from "@/contexts/auth-context"
 import { canAccess } from "@/lib/mock-roles"
 
-const groups = [
-  {
-    label: "Orders",
-    items: [
-      { href: "/admin/bills", label: "บิลทั้งหมด", icon: FileText, feature: "bills" },
-      { href: "/admin/bills/fast", label: "เปิดบิลด่วน", icon: Bolt, feature: "bills" },
-    ],
-  },
-  {
-    label: "Fabrics",
-    items: [
-      { href: "/admin/fabrics", label: "ผ้า", icon: Layers, feature: "fabrics" },
-      { href: "/admin/collections", label: "คอลเลกชัน", icon: Folder, feature: "collections" },
-    ],
-  },
-  {
-    label: "Customers",
-    items: [
-      { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "customers" },
-    ],
-  },
-  {
-    label: "Analytics",
-    items: [
-      { href: "/admin/dashboard", label: "แดชบอร์ด", icon: BarChart3, feature: "dashboard" },
-      { href: "/admin/analytics", label: "สถิติ", icon: BarChart3, feature: "analytics" },
-    ],
-  },
-  {
-    label: "Chat",
-    items: [
-      { href: "/admin/chat", label: "แชท", icon: MessageCircle, feature: "chat" },
-      { href: "/admin/broadcast", label: "บรอดแคสต์", icon: Megaphone, feature: "broadcast" },
-    ],
-  },
-  {
-    label: "Campaign",
-    items: [
-      { href: "/admin/campaigns", label: "แคมเปญ", icon: Target, feature: "campaigns" },
-      { href: "/admin/coupons", label: "คูปอง", icon: Percent, feature: "campaigns" },
-    ],
-  },
-  {
-    label: "Settings",
-    items: [
-      { href: "/admin/feature-map", label: "แผนที่ฟีเจอร์", icon: Settings, feature: "settings" },
-      { href: "/admin/faq", label: "คำถามพบบ่อย", icon: HelpCircle, feature: "settings" },
-      { href: "/admin/feedback", label: "ความคิดเห็น", icon: MailQuestion, feature: "settings" },
-    ],
-  },
-]
+const groups: FeatureGroup[] = featureMap
 
 
 export default function Sidebar({ className = "" }: { className?: string }) {

--- a/components/dashboard/GroupedPreview.tsx
+++ b/components/dashboard/GroupedPreview.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import DashboardQuickCard from '@/components/dashboard/DashboardQuickCard'
+import { featureMap } from '@/lib/feature-map'
+
+export default function GroupedPreview() {
+  const [tab, setTab] = useState(featureMap[0]?.label ?? '')
+
+  return (
+    <Tabs value={tab} onValueChange={setTab} className="mb-4">
+      <TabsList className="mb-2">
+        {featureMap.map(group => (
+          <TabsTrigger key={group.label} value={group.label}>
+            {group.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {featureMap.map(group => (
+        <TabsContent key={group.label} value={group.label}>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {group.items.map(item => (
+              <DashboardQuickCard
+                key={item.href}
+                title={item.label}
+                link={item.href}
+                icon={<item.icon className="h-4 w-4" />}
+              />
+            ))}
+          </div>
+        </TabsContent>
+      ))}
+    </Tabs>
+  )
+}

--- a/lib/feature-map.ts
+++ b/lib/feature-map.ts
@@ -1,0 +1,63 @@
+import { BarChart3, Bolt, FileText, Folder, HelpCircle, Layers, MailQuestion, Megaphone, MessageCircle, Percent, Settings, Target, Users } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export interface FeatureItem {
+  href: string
+  label: string
+  icon: LucideIcon
+}
+
+export interface FeatureGroup {
+  label: string
+  items: FeatureItem[]
+}
+
+export const featureMap: FeatureGroup[] = [
+  {
+    label: 'Orders',
+    items: [
+      { href: '/admin/bills', label: 'บิลทั้งหมด', icon: FileText },
+      { href: '/admin/bills/fast', label: 'เปิดบิลด่วน', icon: Bolt },
+    ],
+  },
+  {
+    label: 'Fabrics',
+    items: [
+      { href: '/admin/fabrics', label: 'ผ้า', icon: Layers },
+      { href: '/admin/collections', label: 'คอลเลกชัน', icon: Folder },
+    ],
+  },
+  {
+    label: 'Customers',
+    items: [{ href: '/admin/customers', label: 'ลูกค้า', icon: Users }],
+  },
+  {
+    label: 'Analytics',
+    items: [
+      { href: '/admin/dashboard', label: 'แดชบอร์ด', icon: BarChart3 },
+      { href: '/admin/analytics', label: 'สถิติ', icon: BarChart3 },
+    ],
+  },
+  {
+    label: 'Chat',
+    items: [
+      { href: '/admin/chat', label: 'แชท', icon: MessageCircle },
+      { href: '/admin/broadcast', label: 'บรอดแคสต์', icon: Megaphone },
+    ],
+  },
+  {
+    label: 'Campaign',
+    items: [
+      { href: '/admin/campaigns', label: 'แคมเปญ', icon: Target },
+      { href: '/admin/coupons', label: 'คูปอง', icon: Percent },
+    ],
+  },
+  {
+    label: 'Settings',
+    items: [
+      { href: '/admin/feature-map', label: 'แผนที่ฟีเจอร์', icon: Settings },
+      { href: '/admin/faq', label: 'คำถามพบบ่อย', icon: HelpCircle },
+      { href: '/admin/feedback', label: 'ความคิดเห็น', icon: MailQuestion },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- create a shared `featureMap` describing dashboard groups
- reuse the feature map in the admin sidebar
- add `GroupedPreview` component to display grouped cards
- show grouped preview in dashboard layout when `preview=grouped`
- add developer toggle in `DevBar` to enable/disable the grouped preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687beab65a708325b15d23cccc988ccb