### PR TITLE
Refactor order types

### DIFF
--- a/components/admin/OrderTable.tsx
+++ b/components/admin/OrderTable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/table"
 import { Button } from "@/components/ui/buttons/button"
 import OrderStatusDropdown from "./orders/OrderStatusDropdown"
-import type { OrderStatus } from "@/types/order"
+import type { OrderStatus } from "@/types/order-status"
 import {
   Dialog,
   DialogContent,

--- a/components/admin/orders/OrderStatusDropdown.tsx
+++ b/components/admin/orders/OrderStatusDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { orderStatusOptions, type OrderStatus } from "@/types/order"
+import { orderStatusOptions, type OrderStatus } from "@/types/order-status"
 import {
   getOrderStatusBadgeVariant,
   getOrderStatusText,

--- a/components/order/OrderTimeline.tsx
+++ b/components/order/OrderTimeline.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/buttons/button"
 import { Input } from "@/components/ui/inputs/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import type { OrderStatus } from "@/types/order"
+import type { OrderStatus } from "@/types/order-status"
 import { orderStatusOptions } from "@/types/order"
 import {
   getOrderStatusBadgeVariant,

--- a/components/order/bulk-actions.tsx
+++ b/components/order/bulk-actions.tsx
@@ -10,7 +10,7 @@ import { Download, Trash2, Archive, CheckCircle, XCircle, Mail, Printer } from "
 import { useToast } from "@/hooks/use-toast"
 import { ConfirmationDialog } from "./confirmation-dialog"
 import type { Order } from "@/types/order"
-import type { OrderStatus } from "@/types/order"
+import type { OrderStatus } from "@/types/order-status"
 
 interface BulkActionsProps {
   orders: Order[]

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -1,30 +1,5 @@
-export interface Customer {
-  id: string
-  name: string
-  email: string
-  phone?: string
-  address?: string
-  city?: string
-  postalCode?: string
-  avatar?: string
-  tags?: string[]
-  note?: string
-  /** mock reward points */
-  points?: number
-  /** membership tier */
-  tier?: "Silver" | "Gold" | "VIP"
-  /** mute notifications */
-  muted?: boolean
-  /** point change history */
-  pointHistory?: PointLog[]
-  createdAt: string
-}
-
-export interface PointLog {
-  timestamp: string
-  change: number
-  reason?: string
-}
+import type { Customer, PointLog } from '@/types/customer'
+export type { Customer }
 
 import { mockOrders } from "./mock-orders"
 

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -1,4 +1,5 @@
-import type { OrderStatus, ShippingStatus, Order, PackingStatus } from "@/types/order"
+import type { ShippingStatus, Order } from "@/types/order"
+import type { OrderStatus, PackingStatus } from "@/types/order-status"
 
 import { supabase } from "./supabase"
 import { addChatMessage } from "./mock-chat-messages"
@@ -7,7 +8,9 @@ import { addAdminLog } from "./mock-admin-logs"
 const initialMockOrders: Order[] = [
   {
     id: "ORD-001",
+    orderNumber: "ORD-001",
     customerId: "2",
+    customerInfo: { id: "2", name: "John Doe", email: "john@example.com" },
     customerName: "John Doe",
     customerEmail: "john@example.com",
     items: [
@@ -21,6 +24,7 @@ const initialMockOrders: Order[] = [
       },
     ],
     total: 2990,
+    totalAmount: 2990,
     status: "depositPaid",
     depositPercent: 50,
     note: "Deposit received",
@@ -60,7 +64,9 @@ const initialMockOrders: Order[] = [
   },
   {
     id: "ORD-002",
+    orderNumber: "ORD-002",
     customerId: "3",
+    customerInfo: { id: "3", name: "Jane Smith", email: "jane@example.com" },
     customerName: "Jane Smith",
     customerEmail: "jane@example.com",
     items: [
@@ -74,6 +80,7 @@ const initialMockOrders: Order[] = [
       },
     ],
     total: 3980,
+    totalAmount: 3980,
     status: "paid",
     depositPercent: 100,
     chatNote: "",

--- a/lib/mock/payment.ts
+++ b/lib/mock/payment.ts
@@ -1,10 +1,4 @@
-export interface Payment {
-  orderId: string
-  date: string
-  amount: number
-  slip?: string
-  verified?: boolean
-}
+import type { Payment } from '@/types/payment'
 
 const payments: Payment[] = []
 

--- a/types/address.ts
+++ b/types/address.ts
@@ -1,0 +1,7 @@
+export interface Address {
+  name: string
+  address: string
+  city: string
+  postalCode: string
+  phone: string
+}

--- a/types/customer-info.ts
+++ b/types/customer-info.ts
@@ -1,0 +1,9 @@
+import type { Address } from './address'
+
+export interface CustomerInfo {
+  id: string
+  name: string
+  email?: string
+  phone?: string
+  address?: Address
+}

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -1,0 +1,26 @@
+export interface Customer {
+  id: string
+  name: string
+  email: string
+  phone?: string
+  address?: string
+  city?: string
+  postalCode?: string
+  avatar?: string
+  tags?: string[]
+  note?: string
+  points?: number
+  tier?: 'Silver' | 'Gold' | 'VIP'
+  muted?: boolean
+  pointHistory?: PointLog[]
+  createdAt: string
+  totalOrders?: number
+  totalSpent?: number
+  lastOrderDate?: string
+}
+
+export interface PointLog {
+  timestamp: string
+  change: number
+  reason?: string
+}

--- a/types/order-status.ts
+++ b/types/order-status.ts
@@ -1,0 +1,42 @@
+export type OrderStatus =
+  | 'draft'
+  | 'pending'
+  | 'confirmed'
+  | 'processing'
+  | 'producing'
+  | 'done'
+  | 'packed'
+  | 'shipped'
+  | 'delivered'
+  | 'cancelled'
+  | 'pendingPayment'
+  | 'depositPaid'
+  | 'paid'
+  | 'completed'
+  | 'archived'
+
+export const orderStatusOptions: { value: OrderStatus; label: string }[] = [
+  { value: 'draft', label: 'ร่าง' },
+  { value: 'pending', label: 'รอยืนยัน' },
+  { value: 'confirmed', label: 'ยืนยันแล้ว' },
+  { value: 'processing', label: 'กำลังดำเนินการ' },
+  { value: 'producing', label: 'กำลังผลิต' },
+  { value: 'done', label: 'ผลิตเสร็จแล้ว' },
+  { value: 'packed', label: 'แพ็กของแล้ว' },
+  { value: 'shipped', label: 'จัดส่งแล้ว' },
+  { value: 'delivered', label: 'ส่งมอบแล้ว' },
+  { value: 'cancelled', label: 'ยกเลิก' },
+  { value: 'pendingPayment', label: 'รอชำระเงิน' },
+  { value: 'depositPaid', label: 'มัดจำแล้ว' },
+  { value: 'paid', label: 'ชำระแล้ว' },
+  { value: 'completed', label: 'เสร็จสิ้น' },
+  { value: 'archived', label: 'เก็บถาวร' },
+]
+
+export type PackingStatus = 'packing' | 'done' | 'ready'
+
+export const packingStatusOptions: { value: PackingStatus; label: string }[] = [
+  { value: 'packing', label: 'กำลังแพ็ก' },
+  { value: 'done', label: 'แพ็กเสร็จ' },
+  { value: 'ready', label: 'พร้อมส่ง' },
+]

--- a/types/order.ts
+++ b/types/order.ts
@@ -12,23 +12,12 @@ export interface OrderItem {
   image?: string
 }
 
-export type OrderStatus =
-  | "draft"
-  | "pending"
-  | "confirmed"
-  | "processing"
-  | "producing"
-  | "done"
-  | "packed"
-  | "shipped"
-  | "delivered"
-  | "cancelled"
-  | "pendingPayment"
-  | "depositPaid"
-  | "paid"
-  | "completed"
-  | "archived"
-
+import type { OrderStatus, PackingStatus } from './order-status'
+import { orderStatusOptions, packingStatusOptions } from './order-status'
+import type { Address } from './address'
+import type { CustomerInfo } from './customer-info'
+import type { Payment } from './payment'
+export type { OrderStatus, PackingStatus } from './order-status'
 export type ShippingStatus = "pending" | "shipped" | "delivered"
 
 export const shippingStatusOptions: { value: ShippingStatus; label: string }[] = [
@@ -37,58 +26,23 @@ export const shippingStatusOptions: { value: ShippingStatus; label: string }[] =
   { value: "delivered", label: "ส่งมอบแล้ว" },
 ]
 
-export type PackingStatus = "packing" | "done" | "ready"
-
-export const packingStatusOptions: { value: PackingStatus; label: string }[] = [
-  { value: "packing", label: "กำลังแพ็ก" },
-  { value: "done", label: "แพ็กเสร็จ" },
-  { value: "ready", label: "พร้อมส่ง" },
-]
-
-export const orderStatusOptions: { value: OrderStatus; label: string }[] = [
-  { value: "draft", label: "ร่าง" },
-  { value: "pending", label: "รอยืนยัน" },
-  { value: "confirmed", label: "ยืนยันแล้ว" },
-  { value: "processing", label: "กำลังดำเนินการ" },
-  { value: "producing", label: "กำลังผลิต" },
-  { value: "done", label: "ผลิตเสร็จแล้ว" },
-  { value: "packed", label: "แพ็กของแล้ว" },
-  { value: "shipped", label: "จัดส่งแล้ว" },
-  { value: "delivered", label: "ส่งมอบแล้ว" },
-  { value: "cancelled", label: "ยกเลิก" },
-  { value: "pendingPayment", label: "รอชำระเงิน" },
-  { value: "depositPaid", label: "มัดจำแล้ว" },
-  { value: "paid", label: "ชำระแล้ว" },
-  { value: "completed", label: "เสร็จสิ้น" },
-  { value: "archived", label: "เก็บถาวร" },
-]
-
 export interface Order {
   id: string
+  orderNumber: string
   customerId: string
+  customerInfo: CustomerInfo
   customerName: string
   customerEmail: string
-  items: Array<{
-    productId: string
-    productName: string
-    quantity: number
-    price: number
-    size?: string
-    color?: string
-  }>
+  items: OrderItem[]
   total: number
+  /** duplicate of total for new structure */
+  totalAmount?: number
   status: OrderStatus
   depositPercent?: number
   note?: string
   chatNote?: string
   createdAt: string
-  shippingAddress: {
-    name: string
-    address: string
-    city: string
-    postalCode: string
-    phone: string
-  }
+  shippingAddress: Address
   delivery_method: string
   tracking_number: string
   shipping_fee: number
@@ -133,13 +87,7 @@ export interface ManualOrder {
   total: number
   status: OrderStatus
   paymentStatus: "unpaid" | "partial" | "paid" | "refunded"
-  payments?: Array<{
-    id: string
-    date: string
-    amount: number
-    bank: string
-    confirmed?: boolean
-  }>
+  payments?: Payment[]
   notes?: string
   attachments: string[]
   publicLink: string

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -1,0 +1,7 @@
+export interface Payment {
+  orderId: string
+  date: string
+  amount: number
+  slip?: string
+  verified?: boolean
+}


### PR DESCRIPTION
## Summary
- introduce Address, CustomerInfo, Payment interfaces
- add combined enums in `types/order-status.ts`
- update `Order` interface to include orderNumber, customerInfo and totalAmount
- sync mock data and components with new types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c08b426b483258ff93e0cda0ef1f6