### PR TITLE
Normalize shipping enums

### DIFF
--- a/app/dashboard/orders/page.tsx
+++ b/app/dashboard/orders/page.tsx
@@ -2,14 +2,28 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { orders as mockOrders, type SimpleOrder } from '@/mock/orders'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { Button } from '@/components/ui/buttons/button'
 import EmptyState from '@/components/EmptyState'
+import { orderStatusOptions, type OrderStatus } from '@/types/order'
+
+const statusLabel = Object.fromEntries(
+  orderStatusOptions.map((o) => [o.value, o.label]),
+) as Record<OrderStatus, string>
 
 export default function DashboardOrdersPage() {
-  const [status, setStatus] = useState('all')
+  const [status, setStatus] = useState<'all' | OrderStatus>('all')
 
-  const filtered = mockOrders.filter(o => status === 'all' || o.status === status)
+  const filtered = mockOrders.filter(
+    (o) => status === 'all' || o.status === status,
+  )
 
   return (
     <div className="container mx-auto py-8 space-y-4">
@@ -20,9 +34,13 @@ export default function DashboardOrdersPage() {
         onChange={e => setStatus(e.target.value)}
       >
         <option value="all">ทั้งหมด</option>
-        <option value="pendingPayment">รอชำระ</option>
-        <option value="processing">กำลังแพ็ค</option>
-        <option value="shipped">ส่งแล้ว</option>
+        {(['pendingPayment', 'processing', 'shipped'] as OrderStatus[]).map(
+          (s) => (
+            <option key={s} value={s}>
+              {statusLabel[s]}
+            </option>
+          ),
+        )}
       </select>
 
       {filtered.length > 0 ? (
@@ -42,7 +60,7 @@ export default function DashboardOrdersPage() {
               <TableRow key={order.id}>
                 <TableCell>{order.id}</TableCell>
                 <TableCell>{order.customer}</TableCell>
-                <TableCell>{order.status}</TableCell>
+                <TableCell>{statusLabel[order.status]}</TableCell>
                 <TableCell className="text-right">฿{order.total.toLocaleString()}</TableCell>
                 <TableCell className="text-right">{new Date(order.date).toLocaleDateString('th-TH')}</TableCell>
                 <TableCell className="text-right">

--- a/app/dashboard/shipping/page.tsx
+++ b/app/dashboard/shipping/page.tsx
@@ -1,22 +1,31 @@
 "use client"
 import { useState } from "react"
 import { shippingOrders } from "@/mock/shipping"
+import { shippingOrderStatusLabel, type ShippingOrderStatus } from "@/types/shipping"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import EmptyState from "@/components/EmptyState"
 
 export default function ShippingListPage() {
-  const [status, setStatus] = useState("all")
+  const [status, setStatus] = useState<"all" | ShippingOrderStatus>("all")
 
-  const filtered = shippingOrders.filter(o => status === "all" || o.status === status)
+  const filtered = shippingOrders.filter(
+    (o) => status === "all" || o.status === status,
+  )
 
   return (
     <div className="container mx-auto space-y-4 py-8">
       <h1 className="text-2xl font-bold">รายการจัดส่ง</h1>
-      <select value={status} onChange={e=>setStatus(e.target.value)} className="border rounded p-2">
+      <select
+        value={status}
+        onChange={(e) => setStatus(e.target.value as ShippingOrderStatus | 'all')}
+        className="border rounded p-2"
+      >
         <option value="all">ทั้งหมด</option>
-        <option value="รอพิมพ์">รอพิมพ์</option>
-        <option value="ส่งแล้ว">ส่งแล้ว</option>
-        <option value="ตีกลับ">ตีกลับ</option>
+        {Object.entries(shippingOrderStatusLabel).map(([value, label]) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
       </select>
       {filtered.length > 0 ? (
         <Table>
@@ -33,7 +42,7 @@ export default function ShippingListPage() {
               <TableRow key={o.id}>
                 <TableCell>{o.id}</TableCell>
                 <TableCell>{o.name}</TableCell>
-                <TableCell>{o.status}</TableCell>
+                <TableCell>{shippingOrderStatusLabel[o.status]}</TableCell>
                 <TableCell>{o.tracking || '-'}</TableCell>
               </TableRow>
             ))}

--- a/app/dashboard/shipping/status/page.tsx
+++ b/app/dashboard/shipping/status/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 import { shippingOrders } from "@/mock/shipping"
 import { CheckCircle, Truck } from "lucide-react"
+import { deliveryStatusLabel, type DeliveryStatus } from "@/types/shipping"
 
-const statusMap: Record<string, { icon: any; color: string }> = {
-  "กำลังจัดส่ง": { icon: Truck, color: "text-orange-600" },
-  "ถึงแล้ว": { icon: CheckCircle, color: "text-green-600" },
+const statusMap: Record<DeliveryStatus, { icon: any; color: string }> = {
+  shipping: { icon: Truck, color: "text-orange-600" },
+  delivered: { icon: CheckCircle, color: "text-green-600" },
 }
 
 export default function DeliveryStatusPage() {
@@ -12,13 +13,15 @@ export default function DeliveryStatusPage() {
     <div className="container mx-auto space-y-4 py-8">
       <h1 className="text-2xl font-bold">สถานะการจัดส่ง</h1>
       <div className="space-y-2">
-        {shippingOrders.map(o => {
+        {shippingOrders.map((o) => {
           const Info = statusMap[o.deliveryStatus]
           const Icon = Info.icon
           return (
             <div key={o.id} className="flex items-center gap-2">
               <Icon className={`h-5 w-5 ${Info.color}`} />
-              <span>{o.id} – {o.deliveryStatus}</span>
+              <span>
+                {o.id} – {deliveryStatusLabel[o.deliveryStatus]}
+              </span>
             </div>
           )
         })}

--- a/mock/shipping.ts
+++ b/mock/shipping.ts
@@ -1,11 +1,16 @@
+import type {
+  ShippingOrderStatus,
+  DeliveryStatus,
+} from '@/types/shipping'
+
 export interface ShippingOrder {
   id: string
   name: string
   address: string
   phone: string
   tracking: string
-  status: 'รอพิมพ์' | 'ส่งแล้ว' | 'ตีกลับ'
-  deliveryStatus: 'กำลังจัดส่ง' | 'ถึงแล้ว'
+  status: ShippingOrderStatus
+  deliveryStatus: DeliveryStatus
 }
 
 export const shippingOrders: ShippingOrder[] = [
@@ -15,8 +20,8 @@ export const shippingOrders: ShippingOrder[] = [
     address: '123 ถนนสุขุมวิท, กรุงเทพฯ 10110',
     phone: '081-234-5678',
     tracking: 'TH1234567890',
-    status: 'ส่งแล้ว',
-    deliveryStatus: 'ถึงแล้ว',
+    status: 'shipped',
+    deliveryStatus: 'delivered',
   },
   {
     id: 'SHIP-002',
@@ -24,8 +29,8 @@ export const shippingOrders: ShippingOrder[] = [
     address: '456 ถนนพหลโยธิน, กรุงเทพฯ 10400',
     phone: '082-345-6789',
     tracking: '',
-    status: 'รอพิมพ์',
-    deliveryStatus: 'กำลังจัดส่ง',
+    status: 'pendingPrint',
+    deliveryStatus: 'shipping',
   },
   {
     id: 'SHIP-003',
@@ -33,16 +38,19 @@ export const shippingOrders: ShippingOrder[] = [
     address: '789 ถนนเจริญกรุง, กรุงเทพฯ 10500',
     phone: '083-456-7890',
     tracking: 'TH5555555555',
-    status: 'ตีกลับ',
-    deliveryStatus: 'กำลังจัดส่ง',
+    status: 'returned',
+    deliveryStatus: 'shipping',
   },
 ]
 
-export function addTrackingNumber(id: string, tracking: string): ShippingOrder | undefined {
-  const order = shippingOrders.find(o => o.id === id)
+export function addTrackingNumber(
+  id: string,
+  tracking: string,
+): ShippingOrder | undefined {
+  const order = shippingOrders.find((o) => o.id === id)
   if (order) {
     order.tracking = tracking
-    if (order.status === 'รอพิมพ์') order.status = 'ส่งแล้ว'
+    if (order.status === 'pendingPrint') order.status = 'shipped'
   }
   return order
 }

--- a/types/shipping.ts
+++ b/types/shipping.ts
@@ -1,0 +1,12 @@
+export type ShippingOrderStatus = 'pendingPrint' | 'shipped' | 'returned'
+export const shippingOrderStatusLabel: Record<ShippingOrderStatus, string> = {
+  pendingPrint: 'รอพิมพ์',
+  shipped: 'ส่งแล้ว',
+  returned: 'ตีกลับ',
+}
+
+export type DeliveryStatus = 'shipping' | 'delivered'
+export const deliveryStatusLabel: Record<DeliveryStatus, string> = {
+  shipping: 'กำลังจัดส่ง',
+  delivered: 'ถึงแล้ว',
+}


### PR DESCRIPTION
## Summary
- use a shared shipping status enum and labels
- render labels in shipping pages from the enum
- use status labels for dashboard order filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c161d74cc8325b2a66fbe592271d9