### PR TITLE
Fix missing export

### DIFF
--- a/mock/orders.ts
+++ b/mock/orders.ts
@@ -29,3 +29,6 @@ export const orders: SimpleOrder[] = [
     date: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ]
+
+// Provide mockOrders alias for compatibility with older imports
+export const mockOrders = orders


### PR DESCRIPTION
## Summary
- export `mockOrders` alias from `mock/orders`

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687c1bbff9b483258dccdc5c56bf2a05