### PR TITLE
Implement sales summary reports

### DIFF
--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,11 +1,86 @@
-import FallbackCenter from "@/components/FallbackCenter"
+"use client"
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { mockOrders } from '@/lib/mock-orders'
+import { groupByDay, groupByMonth } from '@/lib/aggregateReports'
+import { formatCurrency } from '@/lib/utils'
 
 export default function AdminReportsPage() {
+  const daily = useMemo(() => groupByDay(mockOrders), [])
+  const monthly = useMemo(() => groupByMonth(mockOrders), [])
+
   return (
-    <FallbackCenter
-      icon="📑"
-      title="Reports ยังไม่พร้อม"
-      subtitle="อยู่ระหว่างการพัฒนา เตรียมพบกันเร็ว ๆ นี้"
-    />
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/menu">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold">สรุปรายวัน / รายเดือน</h1>
+            <p className="text-gray-600">ดูยอดขายรวมแบบรายวันและรายเดือน (mock)</p>
+          </div>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>ยอดขายรายวัน</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>วันที่</TableHead>
+                    <TableHead className="text-right">ยอดขาย</TableHead>
+                    <TableHead className="text-right">ออเดอร์</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {daily.map(d => (
+                    <TableRow key={d.date}>
+                      <TableCell>{d.date}</TableCell>
+                      <TableCell className="text-right">{formatCurrency(d.total)}</TableCell>
+                      <TableCell className="text-right">{d.count}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>ยอดขายรายเดือน</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>เดือน</TableHead>
+                    <TableHead className="text-right">ยอดขาย</TableHead>
+                    <TableHead className="text-right">ออเดอร์</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {monthly.map(m => (
+                    <TableRow key={m.date}>
+                      <TableCell>{m.date}</TableCell>
+                      <TableCell className="text-right">{formatCurrency(m.total)}</TableCell>
+                      <TableCell className="text-right">{m.count}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/lib/__tests__/aggregateReports.test.ts
+++ b/lib/__tests__/aggregateReports.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { groupByDay, groupByMonth } from '../aggregateReports'
+import type { Order } from '@/types/order'
+
+const orders: Order[] = [
+  { id: '1', customerId: 'c1', customerName: '', customerEmail: '', items: [], total: 100, status: 'paid', createdAt: '2024-05-01T10:00:00Z', shippingAddress: { name: '', address: '', city: '', postalCode: '', phone: '' }, delivery_method: '', tracking_number: '', shipping_fee: 0, shipping_status: 'pending', packingStatus: 'packing', shipping_date: '', delivery_note: '', timeline: [] },
+  { id: '2', customerId: 'c1', customerName: '', customerEmail: '', items: [], total: 200, status: 'paid', createdAt: '2024-05-01T12:00:00Z', shippingAddress: { name: '', address: '', city: '', postalCode: '', phone: '' }, delivery_method: '', tracking_number: '', shipping_fee: 0, shipping_status: 'pending', packingStatus: 'packing', shipping_date: '', delivery_note: '', timeline: [] },
+  { id: '3', customerId: 'c1', customerName: '', customerEmail: '', items: [], total: 150, status: 'paid', createdAt: '2024-06-02T09:00:00Z', shippingAddress: { name: '', address: '', city: '', postalCode: '', phone: '' }, delivery_method: '', tracking_number: '', shipping_fee: 0, shipping_status: 'pending', packingStatus: 'packing', shipping_date: '', delivery_note: '', timeline: [] },
+]
+
+describe('aggregateReports', () => {
+  it('groups orders by day', () => {
+    const result = groupByDay(orders)
+    expect(result).toEqual([
+      { date: '2024-05-01', total: 300, count: 2 },
+      { date: '2024-06-02', total: 150, count: 1 },
+    ])
+  })
+
+  it('groups orders by month', () => {
+    const result = groupByMonth(orders)
+    expect(result).toEqual([
+      { date: '2024-05', total: 300, count: 2 },
+      { date: '2024-06', total: 150, count: 1 },
+    ])
+  })
+})

--- a/lib/aggregateReports.ts
+++ b/lib/aggregateReports.ts
@@ -1,0 +1,36 @@
+import type { Order } from '@/types/order'
+
+export interface AggregatedResult {
+  date: string
+  total: number
+  count: number
+}
+
+export function groupByDay(orders: Order[]): AggregatedResult[] {
+  const map = new Map<string, { total: number; count: number }>()
+  for (const o of orders) {
+    const key = o.createdAt.slice(0, 10)
+    const agg = map.get(key) || { total: 0, count: 0 }
+    agg.total += o.total
+    agg.count += 1
+    map.set(key, agg)
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, { total, count }]) => ({ date, total, count }))
+}
+
+export function groupByMonth(orders: Order[]): AggregatedResult[] {
+  const map = new Map<string, { total: number; count: number }>()
+  for (const o of orders) {
+    const d = new Date(o.createdAt)
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    const agg = map.get(key) || { total: 0, count: 0 }
+    agg.total += o.total
+    agg.count += 1
+    map.set(key, agg)
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, { total, count }]) => ({ date, total, count }))
+}


### PR DESCRIPTION
## Summary
- add aggregateReports library for grouping orders
- create unit test for aggregateReports
- implement /admin/reports page showing daily and monthly sales summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c4283da008325a1a28b8a95089ca4