### PR TITLE
Add fabric selection pixel event

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -98,7 +98,7 @@ export default async function CollectionDetailPage({ params }: { params: { slug:
           </a>
           <CopyPageLinkButton />
         </div>
-        <FabricsList fabrics={fabrics} />
+        <FabricsList fabrics={fabrics} trackSelect />
         <div className="space-y-4">
           <h2 className="text-xl font-semibold">รีวิวจากลูกค้าที่สั่งลายนี้</h2>
           {reviews.length === 0 ? (

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
+import { trackPixel } from "@/lib/pixel"
 
 interface Fabric {
   id: string
@@ -17,9 +18,21 @@ interface Fabric {
   image_urls?: string[] | null
 }
 
-export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
+export function FabricsList({
+  fabrics,
+  trackSelect = false,
+}: {
+  fabrics: Fabric[]
+  trackSelect?: boolean
+}) {
   const { items, toggleCompare } = useCompare()
   const router = useRouter()
+
+  const handleSelect = (slug: string) => {
+    if (trackSelect) {
+      trackPixel("เลือกผ้า", { slug })
+    }
+  }
 
   const handleCompare = () => {
     router.push(`/compare`)
@@ -47,7 +60,7 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                 onCheckedChange={() => toggleCompare(slug)}
                 className="absolute top-2 left-2 z-10 bg-white/80"
               />
-              <Link href={`/fabrics/${slug}`}>
+              <Link href={`/fabrics/${slug}`} onClick={() => handleSelect(slug)}>
                 <div className="relative aspect-square">
                   <Image
                     src={

--- a/lib/pixel.ts
+++ b/lib/pixel.ts
@@ -1,0 +1,11 @@
+export function trackPixel(event: string, params: Record<string, any> = {}): void {
+  if (typeof window === 'undefined') return
+
+  if (typeof (window as any).gtag === 'function') {
+    ;(window as any).gtag('event', event, params)
+  }
+
+  if (typeof (window as any).fbq === 'function') {
+    ;(window as any).fbq('trackCustom', event, params)
+  }
+}


### PR DESCRIPTION
## Summary
- add GA/FB pixel helper
- track "เลือกผ้า" event when a fabric is clicked in collections

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687c42734a6083259fb260e35888bcab