### PR TITLE
Add recent products feature

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { WishlistProvider } from "@/contexts/wishlist-context"
 import { CompareProvider } from "@/contexts/compare-context"
 import { ReviewImagesProvider } from "@/contexts/review-images-context"
 import { FavoritesProvider } from "@/contexts/favorites-context"
+import { RecentProductsProvider } from "@/contexts/recent-products-context"
 import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-context"
 import { validateMockData } from "@/lib/mock-validator"
 import RedirectMobileHome from "@/components/RedirectMobileHome"
@@ -41,19 +42,21 @@ export default function RootLayout({
             <AuthProvider>
               <CartProvider>
                 <WishlistProvider>
-                  <CompareProvider>
-                    <FavoritesProvider>
-                      <AdminProductGroupsProvider>
-                        <ReviewImagesProvider>
+                  <RecentProductsProvider>
+                    <CompareProvider>
+                      <FavoritesProvider>
+                        <AdminProductGroupsProvider>
+                          <ReviewImagesProvider>
                           <RedirectMobileHome />
                           {children}
                           <StoreBottomNav />
                           <DevBar />
                           <Toaster />
-                        </ReviewImagesProvider>
-                      </AdminProductGroupsProvider>
-                    </FavoritesProvider>
-                  </CompareProvider>
+                          </ReviewImagesProvider>
+                        </AdminProductGroupsProvider>
+                      </FavoritesProvider>
+                    </CompareProvider>
+                  </RecentProductsProvider>
                 </WishlistProvider>
               </CartProvider>
             </AuthProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { HeroBannerSection } from "@/components/HeroBannerSection"
 import { mockProducts } from "@/lib/mock-products"
 import { getCollections } from "@/lib/mock-collections"
 import type { Collection } from "@/types/collection"
+import { RecentProductsSection } from "@/components/RecentProductsSection"
 
 export default async function HomePage() {
   const featuredProducts = mockProducts.slice(0, 4)
@@ -216,6 +217,8 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
+
+      <RecentProductsSection />
 
       {/* CTA Section */}
       <section className="py-16 bg-gradient-to-r from-blue-600 to-purple-600 text-white">

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { useAuth } from "@/contexts/auth-context"
 import type { ShippingStatus } from "@/types/order"
 import { loadSocialLinks, socialLinks } from "@/lib/mock-settings"
 import { RecommendedAddons } from "@/components/RecommendedAddons"
+import { useRecentProducts } from "@/contexts/recent-products-context"
 
 export default function ProductDetailPage({ params }: { params: { slug: string } }) {
   const { slug } = params
@@ -40,11 +41,16 @@ export default function ProductDetailPage({ params }: { params: { slug: string }
     (img) => img.productId === product?.id && img.active,
   )
   const [zoomImg, setZoomImg] = useState<string | null>(null)
+  const { addRecent } = useRecentProducts()
 
   useEffect(() => {
     loadSocialLinks()
     setLinks(socialLinks)
   }, [])
+
+  useEffect(() => {
+    addRecent(slug)
+  }, [addRecent, slug])
 
   if (!product) {
     return (

--- a/components/RecentProductsSection.tsx
+++ b/components/RecentProductsSection.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRecentProducts } from '@/contexts/recent-products-context'
+import { mockProducts } from '@/lib/mock-products'
+import { Card, CardContent } from '@/components/ui/cards/card'
+
+export function RecentProductsSection() {
+  const { recents } = useRecentProducts()
+  const products = recents
+    .map(slug => mockProducts.find(p => p.slug === slug))
+    .filter(Boolean) as typeof mockProducts
+
+  if (products.length === 0) return null
+
+  return (
+    <section className="py-16 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <h2 className="text-2xl font-bold mb-8">สินค้าที่คุณดูล่าสุด</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {products.map(p => (
+            <Card key={p!.id} className="group hover:shadow-lg transition-shadow">
+              <CardContent className="p-0">
+                <Link href={`/products/${p!.slug}`}>\
+                  <div className="relative overflow-hidden rounded-t-lg">
+                    <Image
+                      src={p!.images[0] || '/placeholder.svg'}
+                      alt={p!.name}
+                      width={300}
+                      height={300}
+                      className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                    />
+                  </div>
+                  <div className="p-4">
+                    <h3 className="font-semibold line-clamp-2 mb-2">{p!.name}</h3>
+                    <div className="flex items-center space-x-2">
+                      <span className="text-lg font-bold text-primary">฿{p!.price.toLocaleString()}</span>
+                    </div>
+                  </div>
+                </Link>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/contexts/recent-products-context.tsx
+++ b/contexts/recent-products-context.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from 'react'
+import { useLocalStorage } from '@/hooks/use-local-storage'
+
+interface RecentProductsContextValue {
+  recents: string[]
+  addRecent: (slug: string) => void
+}
+
+const RecentProductsContext = createContext<RecentProductsContextValue | null>(null)
+
+export function RecentProductsProvider({ children }: { children: ReactNode }) {
+  const [recents, setRecents] = useLocalStorage<string[]>('recent-products', [])
+
+  const addRecent = (slug: string) => {
+    setRecents(prev => {
+      const updated = [slug, ...prev.filter(s => s !== slug)]
+      return updated.slice(0, 5)
+    })
+  }
+
+  return (
+    <RecentProductsContext.Provider value={{ recents, addRecent }}>
+      {children}
+    </RecentProductsContext.Provider>
+  )
+}
+
+export function useRecentProducts() {
+  const ctx = useContext(RecentProductsContext)
+  if (!ctx) throw new Error('useRecentProducts must be used within RecentProductsProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- track recently viewed products in a new context
- show recently viewed products on the home page
- record visits from product detail pages
- wire provider into the global layout

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687cc8983e348325aeaceb9f6d50c3a4