### PR TITLE
Add simple blog section with mock data

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { getPostBySlug } from '@/lib/mock-posts'
+import { PostContent } from '@/components/blog/PostContent'
+
+interface BlogPostPageProps {
+  params: { slug: string }
+}
+
+export default function BlogPostPage({ params }: BlogPostPageProps) {
+  const post = getPostBySlug(params.slug)
+  if (!post) return notFound()
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-10 flex-1">
+        <PostContent post={post} />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,21 @@
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { mockPosts } from '@/lib/mock-posts'
+import { PostCard } from '@/components/blog/PostCard'
+
+export default function BlogPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-10 flex-1">
+        <h1 className="text-3xl font-bold mb-8">บทความล่าสุด</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {mockPosts.map(post => (
+            <PostCard key={post.slug} post={post} />
+          ))}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import type { BlogPost } from '@/types/blog'
+import { Card, CardContent } from '@/components/ui/cards/card'
+
+interface PostCardProps {
+  post: BlogPost
+}
+
+export function PostCard({ post }: PostCardProps) {
+  return (
+    <Card className="overflow-hidden hover:shadow-lg transition-shadow">
+      <Link href={`/blog/${post.slug}`}
+        className="block">
+        <CardContent className="p-0">
+          <div className="relative h-48 w-full overflow-hidden">
+            <Image
+              src={post.image || '/placeholder.svg'}
+              alt={post.title}
+              fill
+              className="object-cover"
+            />
+          </div>
+          <div className="p-4">
+            <h3 className="font-semibold mb-2 line-clamp-2">{post.title}</h3>
+            <p className="text-sm text-gray-600 line-clamp-2">{post.excerpt}</p>
+          </div>
+        </CardContent>
+      </Link>
+    </Card>
+  )
+}

--- a/components/blog/PostContent.tsx
+++ b/components/blog/PostContent.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image'
+import type { BlogPost } from '@/types/blog'
+
+interface PostContentProps {
+  post: BlogPost
+}
+
+export function PostContent({ post }: PostContentProps) {
+  return (
+    <article className="prose mx-auto">
+      {post.image && (
+        <Image
+          src={post.image}
+          alt={post.title}
+          width={800}
+          height={400}
+          className="w-full rounded-lg mb-6"
+        />
+      )}
+      <h1>{post.title}</h1>
+      <p className="text-sm text-gray-500 mb-4">
+        {new Date(post.publishedAt).toLocaleDateString('th-TH')}
+      </p>
+      {post.content.split(/\n\n+/).map((paragraph, idx) => (
+        <p key={idx}>{paragraph}</p>
+      ))}
+    </article>
+  )
+}

--- a/lib/mock-posts.ts
+++ b/lib/mock-posts.ts
@@ -1,0 +1,32 @@
+import type { BlogPost } from '@/types/blog'
+
+export const mockPosts: BlogPost[] = [
+  {
+    slug: 'choose-right-cover',
+    title: 'เลือกผ้าคลุมโซฟาให้เหมาะกับบ้านของคุณ',
+    excerpt: 'เคล็ดลับในการเลือกผ้าคลุมโซฟาที่ทั้งสวยและใช้งานได้จริง',
+    content: `ผ้าคลุมโซฟามีหลายประเภทให้เลือก ทั้งแบบกันน้ำ กันฝุ่น หรือเน้นความนุ่มสบาย\n\nการเลือกให้เหมาะสมกับสไตล์บ้านและการใช้งานจะช่วยยืดอายุการใช้งานของโซฟาได้`,
+    image: '/placeholder.svg?height=400&width=600',
+    publishedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    slug: 'care-tips',
+    title: 'วิธีดูแลผ้าคลุมโซฟาให้ใช้งานได้นาน',
+    excerpt: 'รวมเทคนิคการซักและการเก็บรักษาผ้าคลุมโซฟาอย่างถูกวิธี',
+    content: `ควรซักผ้าคลุมโซฟาเป็นประจำเพื่อป้องกันการสะสมของฝุ่นและไร\n\nเลือกใช้ผงซักฟอกที่อ่อนโยนและตากในที่ร่มจะช่วยรักษาสีสันให้สดใส`,
+    image: '/placeholder.svg?height=400&width=600',
+    publishedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    slug: 'trending-styles',
+    title: 'อัปเดตเทรนด์ผ้าคลุมโซฟายอดนิยมปี 2025',
+    excerpt: 'พาชมลายผ้าคลุมโซฟาที่กำลังมาแรง พร้อมไอเดียแต่งบ้านสวยๆ',
+    content: `ปี 2025 แนวโน้มผ้าคลุมโซฟาเน้นลวดลายธรรมชาติและสีเอิร์ธโทน\n\nจับคู่กับของตกแต่งแนวมินิมอลจะช่วยให้ห้องดูอบอุ่นทันสมัย`,
+    image: '/placeholder.svg?height=400&width=600',
+    publishedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+]
+
+export function getPostBySlug(slug: string) {
+  return mockPosts.find(p => p.slug === slug)
+}

--- a/types/blog.ts
+++ b/types/blog.ts
@@ -1,0 +1,8 @@
+export interface BlogPost {
+  slug: string
+  title: string
+  excerpt: string
+  content: string
+  image?: string
+  publishedAt: string
+}


### PR DESCRIPTION
## Summary
- implement a `BlogPost` type
- add `mock-posts.ts` with sample blog data and getter
- add `PostCard` and `PostContent` components
- create `/blog` listing page and dynamic `[slug]` page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687ccdccd278832597a112dc0bfc66af