### PR TITLE
Add Terms and Privacy pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,17 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { LegalAccordion } from "@/components/LegalAccordion"
+import { privacy, loadPrivacy } from "@/lib/mock-privacy"
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <h1 className="text-3xl font-bold mb-6 text-center">นโยบายความเป็นส่วนตัว</h1>
+        <LegalAccordion items={privacy} loader={loadPrivacy} />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,17 @@
+import { Navbar } from "@/components/navbar"
+import { Footer } from "@/components/footer"
+import { LegalAccordion } from "@/components/LegalAccordion"
+import { terms, loadTerms } from "@/lib/mock-terms"
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1">
+        <h1 className="text-3xl font-bold mb-6 text-center">เงื่อนไขการใช้งาน</h1>
+        <LegalAccordion items={terms} loader={loadTerms} />
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/LegalAccordion.tsx
+++ b/components/LegalAccordion.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import type { LegalSection } from "@/types/legal"
+
+export function LegalAccordion({ items, loader }: { items: LegalSection[]; loader?: () => void }) {
+  const [sections, setSections] = useState(items)
+
+  useEffect(() => {
+    if (loader) {
+      loader()
+      setSections([...items])
+    }
+  }, [loader, items])
+
+  return (
+    <Accordion type="single" collapsible className="w-full">
+      {sections.map((s) => (
+        <AccordionItem key={s.id} value={s.id}>
+          <AccordionTrigger>{s.title}</AccordionTrigger>
+          <AccordionContent className="space-y-2">
+            {s.paragraphs.map((p, idx) => (
+              <p key={idx}>{p}</p>
+            ))}
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  )
+}

--- a/lib/mock-privacy.ts
+++ b/lib/mock-privacy.ts
@@ -1,0 +1,34 @@
+import type { LegalSection } from "@/types/legal"
+
+export let privacy: LegalSection[] = [
+  {
+    id: "1",
+    title: "การเก็บรวบรวมข้อมูล",
+    paragraphs: [
+      "เราเก็บข้อมูลที่จำเป็นต่อการให้บริการ เช่น ชื่อ และที่อยู่",
+    ],
+  },
+  {
+    id: "2",
+    title: "การใช้ข้อมูล",
+    paragraphs: [
+      "ข้อมูลของคุณจะใช้เพื่อประมวลผลคำสั่งซื้อและบริการลูกค้าเท่านั้น",
+    ],
+  },
+]
+
+const STORAGE_KEY = "privacy"
+
+export function loadPrivacy() {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) privacy = JSON.parse(stored)
+  }
+}
+
+export function savePrivacy(list: LegalSection[]) {
+  privacy = list
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list))
+  }
+}

--- a/lib/mock-terms.ts
+++ b/lib/mock-terms.ts
@@ -1,0 +1,35 @@
+import type { LegalSection } from "@/types/legal"
+
+export let terms: LegalSection[] = [
+  {
+    id: "1",
+    title: "การใช้งานเว็บไซต์",
+    paragraphs: [
+      "เว็บไซต์นี้จัดทำขึ้นเพื่อให้ข้อมูลและจำหน่ายสินค้าเท่านั้น",
+      "ผู้ใช้ต้องไม่คัดลอกหรือแจกจ่ายเนื้อหาโดยไม่ได้รับอนุญาต",
+    ],
+  },
+  {
+    id: "2",
+    title: "สิทธิ์และความรับผิดชอบ",
+    paragraphs: [
+      "ผู้ใช้ต้องปฏิบัติตามกฎหมายและไม่ละเมิดสิทธิ์ของผู้อื่น",
+    ],
+  },
+]
+
+const STORAGE_KEY = "terms"
+
+export function loadTerms() {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) terms = JSON.parse(stored)
+  }
+}
+
+export function saveTerms(list: LegalSection[]) {
+  terms = list
+  if (typeof window !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list))
+  }
+}

--- a/types/legal.ts
+++ b/types/legal.ts
@@ -1,0 +1,5 @@
+export interface LegalSection {
+  id: string
+  title: string
+  paragraphs: string[]
+}


### PR DESCRIPTION
## Summary
- introduce `LegalAccordion` component for displaying legal text
- provide mock Terms and Privacy data
- add new Terms and Privacy pages using mock data
- define `LegalSection` type

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687ccec412448325895bb4b67f395db2