### PR TITLE
Add mock data API layer with tests

### DIFF
--- a/app/api/mock/__tests__/orders.test.ts
+++ b/app/api/mock/__tests__/orders.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { GET, POST } from '@/app/api/mock/orders/route'
+import { resetOrders } from '@/core/mock/store'
+import { mockOrders } from '@/lib/mock-orders'
+
+describe('orders API', () => {
+  beforeEach(() => {
+    resetOrders()
+  })
+
+  it('returns orders list', async () => {
+    const res = await GET()
+    const data = await res.json()
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('adds order via POST', async () => {
+    const res = await POST(new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ ...(mockOrders[0]), id: 'API-1' }),
+    }))
+    const out = await res.json()
+    expect(out.success).toBe(true)
+  })
+})

--- a/app/api/mock/login/route.ts
+++ b/app/api/mock/login/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { mockUsers } from '@/lib/mock-users'
+
+export async function POST(req: Request) {
+  try {
+    const { email, password } = await req.json()
+    const user = mockUsers.find(u => u.email === email)
+    if (user && password === 'password') {
+      const res = NextResponse.json({ success: true, user })
+      res.cookies.set('elf_admin_session', '1', { path: '/' })
+      return res
+    }
+    return NextResponse.json({ success: false }, { status: 401 })
+  } catch {
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/app/api/mock/logout/route.ts
+++ b/app/api/mock/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const res = NextResponse.json({ success: true })
+  res.cookies.set('elf_admin_session', '', { path: '/', expires: new Date(0) })
+  return res
+}

--- a/app/api/mock/orders/route.ts
+++ b/app/api/mock/orders/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { getOrders, addOrder } from '@/core/mock/store'
+import type { Order } from '@/types/order'
+
+export async function GET() {
+  return NextResponse.json(getOrders())
+}
+
+export async function POST(req: Request) {
+  try {
+    const data: Order = await req.json()
+    addOrder(data)
+    return NextResponse.json({ success: true })
+  } catch (e) {
+    console.error('Add order error', e)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/app/api/mock/products/route.ts
+++ b/app/api/mock/products/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { getProducts, addProduct } from '@/core/mock/store'
+import type { Product } from '@/lib/mock-products'
+
+export async function GET() {
+  return NextResponse.json(getProducts())
+}
+
+export async function POST(req: Request) {
+  try {
+    const data: Omit<Product, 'id'> = await req.json()
+    const product = addProduct(data)
+    return NextResponse.json({ success: true, product })
+  } catch (e) {
+    console.error('Add product error', e)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/core/mock/store/__tests__/orders.test.ts
+++ b/core/mock/store/__tests__/orders.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getOrders, addOrder, resetOrders } from '@/core/mock/store'
+import { mockOrders } from '@/lib/mock-orders'
+
+describe('orders store', () => {
+  beforeEach(() => {
+    resetOrders()
+    localStorage.clear()
+  })
+
+  it('adds order to store', () => {
+    const initial = getOrders().length
+    addOrder({ ...(mockOrders[0]), id: 'NEW-1' } as any)
+    expect(getOrders().length).toBe(initial + 1)
+  })
+})

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -1,20 +1,24 @@
 export * from './orders'
 export * from './customers'
 export * from './fabrics'
+export * from './products'
 export * from './config'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetCustomers, regenerateCustomers } from './customers'
 import { resetFabrics, regenerateFabrics } from './fabrics'
+import { resetProducts, regenerateProducts } from './products'
 
 export function resetStore() {
   resetOrders()
   resetCustomers()
   resetFabrics()
+  resetProducts()
 }
 
 export function generateMockData() {
   regenerateOrders()
   regenerateCustomers()
   regenerateFabrics()
+  regenerateProducts()
 }

--- a/core/mock/store/products.ts
+++ b/core/mock/store/products.ts
@@ -1,0 +1,40 @@
+import type { Product } from '@/lib/mock-products'
+import { mockProducts as seedProducts } from '@/lib/mock-products'
+import { loadFromStorage, saveToStorage } from './persist'
+
+const KEY = 'mockStore_products'
+
+let products: Product[] = loadFromStorage<Product[]>(KEY, [...seedProducts])
+
+function persist() {
+  saveToStorage(KEY, products)
+}
+
+export function getProducts() {
+  return products
+}
+
+export function addProduct(product: Omit<Product, 'id'>) {
+  const newProduct: Product = { id: `prod-${Date.now()}`, ...product }
+  products.push(newProduct)
+  persist()
+  return newProduct
+}
+
+export function updateProduct(id: string, data: Partial<Omit<Product, 'id'>>) {
+  const idx = products.findIndex(p => p.id === id)
+  if (idx !== -1) {
+    products[idx] = { ...products[idx], ...data }
+    persist()
+  }
+}
+
+export function resetProducts() {
+  products = []
+  persist()
+}
+
+export function regenerateProducts() {
+  products = [...seedProducts]
+  persist()
+}

--- a/hooks/__tests__/use-mock-notification.test.ts
+++ b/hooks/__tests__/use-mock-notification.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useMockNotification } from '../use-mock-notification'
+
+describe('useMockNotification', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ success: true })
+    })) as any)
+  })
+
+  it('calls notification API', async () => {
+    const { result } = renderHook(() => useMockNotification())
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.sendNotification({
+        type: 'order_created',
+        recipient: {},
+        data: {},
+        priority: 'normal'
+      })
+    })
+    expect(ok).toBe(true)
+    expect(fetch).toHaveBeenCalledWith('/api/notifications/send', expect.anything())
+  })
+})


### PR DESCRIPTION
## Summary
- create persistent mock product store and add to store index
- expose `/api/mock` routes for orders, products and auth
- update auth store to use new API endpoints
- add tests for store, API routes and `useMockNotification` hook

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687cd502623c8325a63cbc9439eb431a