### PR TITLE
Add fabric inventory support

### DIFF
--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -3,8 +3,10 @@
 import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useState } from "react"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
+import { Dialog, DialogContent } from "@/components/ui/modals/dialog"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
 
@@ -20,6 +22,7 @@ interface Fabric {
 export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
   const { items, toggleCompare } = useCompare()
   const router = useRouter()
+  const [preview, setPreview] = useState<string | null>(null)
 
   const handleCompare = () => {
     router.push(`/compare`)
@@ -48,14 +51,14 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
                 className="absolute top-2 left-2 z-10 bg-white/80"
               />
               <Link href={`/fabrics/${slug}`}>
-                <div className="relative aspect-square">
+                <div className="relative aspect-square" onClick={(e) => { e.preventDefault(); setPreview(fabric.image_urls?.[0] || fabric.image_url || '/placeholder.svg') }}>
                   <Image
                     src={
                       fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"
                     }
                     alt={fabric.name}
                     fill
-                    className="object-cover"
+                    className="object-cover cursor-zoom-in"
                   />
                 </div>
                 <div className="p-2 text-center">
@@ -71,6 +74,13 @@ export function FabricsList({ fabrics }: { fabrics: Fabric[] }) {
           <Button onClick={handleCompare}>เปรียบเทียบตอนนี้</Button>
         </div>
       )}
+      <Dialog open={!!preview} onOpenChange={() => setPreview(null)}>
+        <DialogContent className="max-w-xl">
+          {preview && (
+            <Image src={preview} alt="preview" width={600} height={600} className="object-cover" />
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/components/fabrics/FabricTable.tsx
+++ b/components/fabrics/FabricTable.tsx
@@ -56,6 +56,7 @@ export default function FabricTable({ items }: FabricTableProps) {
               <TableHead>Image</TableHead>
               <TableHead>Name</TableHead>
               <TableHead>Code</TableHead>
+              <TableHead>Stock</TableHead>
               <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
@@ -78,6 +79,7 @@ export default function FabricTable({ items }: FabricTableProps) {
                 </TableCell>
                 <TableCell>{f.name}</TableCell>
                 <TableCell>{f.code}</TableCell>
+                <TableCell>{f.stock}</TableCell>
                 <TableCell>{f.status}</TableCell>
               </TableRow>
             ))}

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -5,6 +5,14 @@ import { addAdminLog } from "./mock-admin-logs"
 import { addChatMessage } from "./mock-chat-messages"
 import { mockBills } from "./bills"
 import { generateMockId } from "./mock-uid"
+import { reduceStock, increaseStock } from "@/mock/fabrics"
+
+const productToFabric: Record<string, string> = {
+  '1': 'SL-001',
+  '2': 'CC-002',
+  '3': 'VD-003',
+  '4': 'CS-004',
+}
 export { mockBills } from "./bills"
 
 
@@ -28,6 +36,12 @@ export function createBill(
     bill.hidden = true
   }
   mockBills.push(bill)
+  if (order) {
+    order.items.forEach((it) => {
+      const code = productToFabric[it.productId]
+      if (code) reduceStock(code, it.quantity)
+    })
+  }
   addAdminLog(`create bill ${bill.id}`, 'mockAdminId')
   addChatMessage(orderId, 'bill_created')
   return bill
@@ -49,6 +63,13 @@ export function cancelBill(id: string) {
   const b = getBill(id)
   if (b) {
     b.status = "cancelled"
+    const order = mockOrders.find((o) => o.id === b.orderId)
+    if (order) {
+      order.items.forEach((it) => {
+        const code = productToFabric[it.productId]
+        if (code) increaseStock(code, it.quantity)
+      })
+    }
     addAdminLog(`cancel bill ${id}`, 'mockAdminId')
   }
 }

--- a/mock/fabrics.ts
+++ b/mock/fabrics.ts
@@ -3,6 +3,8 @@ export interface Fabric {
   name: string
   imageUrl: string
   collectionId?: string
+  category?: string
+  tags?: string[]
 }
 
 export const fabrics: Fabric[] = [
@@ -11,12 +13,16 @@ export const fabrics: Fabric[] = [
     name: 'Soft Linen',
     imageUrl: '/images/039.jpg',
     collectionId: 'col-1',
+    category: 'Classic',
+    tags: ['linen', 'soft']
   },
   {
     id: 'fab-2',
     name: 'Cozy Cotton',
     imageUrl: '/images/041.jpg',
     collectionId: 'col-2',
+    category: 'Modern',
+    tags: ['cotton']
   },
 ]
 
@@ -40,12 +46,23 @@ export function removeFabric(id: string) {
   if (idx !== -1) fabrics.splice(idx, 1)
 }
 
+export function reduceStock(code: string, qty: number) {
+  const fab = adminFabrics.find(f => f.code === code)
+  if (fab) fab.stock = Math.max(0, fab.stock - qty)
+}
+
+export function increaseStock(code: string, qty: number) {
+  const fab = adminFabrics.find(f => f.code === code)
+  if (fab) fab.stock += qty
+}
+
 export interface AdminFabric {
   id: string
   name: string
   code: string
   image: string
   status: 'active' | 'archived'
+  stock: number
 }
 
 export const adminFabrics: AdminFabric[] = [
@@ -55,6 +72,7 @@ export const adminFabrics: AdminFabric[] = [
     code: 'SL-001',
     image: '/images/039.jpg',
     status: 'active',
+    stock: 50,
   },
   {
     id: 'af-2',
@@ -62,6 +80,7 @@ export const adminFabrics: AdminFabric[] = [
     code: 'CC-002',
     image: '/images/041.jpg',
     status: 'archived',
+    stock: 0,
   },
   {
     id: 'af-3',
@@ -69,6 +88,7 @@ export const adminFabrics: AdminFabric[] = [
     code: 'VD-003',
     image: '/images/043.jpg',
     status: 'active',
+    stock: 20,
   },
   {
     id: 'af-4',
@@ -76,6 +96,7 @@ export const adminFabrics: AdminFabric[] = [
     code: 'CS-004',
     image: '/images/045.jpg',
     status: 'archived',
+    stock: 5,
   },
 ]
 


### PR DESCRIPTION
## Summary
- extend mock fabric data with categories, tags and stock levels
- update FabricTable to display stock
- sync stock on bill create/cancel
- allow customers to preview fabric images in a modal

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687cdbdd3bc08325b8090f5dc605238b