### PR TITLE
Add admin reconciliation page

### DIFF
--- a/app/admin/reconcile/page.tsx
+++ b/app/admin/reconcile/page.tsx
@@ -1,0 +1,88 @@
+"use client"
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/buttons/button"
+import { listPayments, verifyPayment, rejectPayment } from "@/lib/mock/payment"
+import type { Payment } from "@/types/payment"
+
+export default function ReconcilePage() {
+  const [payments, setPayments] = useState<Payment[]>([...listPayments()])
+
+  const pending = payments.filter(p => !p.verified && !p.rejected)
+
+  const grouped: Record<string, Payment[]> = {}
+  for (const p of pending) {
+    const key = `${p.date}_${p.method || 'unknown'}`
+    grouped[key] = grouped[key] ? [...grouped[key], p] : [p]
+  }
+
+  const refresh = () => setPayments([...listPayments()])
+
+  const handleVerify = (id: string) => {
+    verifyPayment(id)
+    refresh()
+  }
+
+  const handleReject = (id: string) => {
+    rejectPayment(id)
+    refresh()
+  }
+
+  const exportCsv = () => {
+    const rows = listPayments().map(p => [p.orderId, p.date, p.method, p.amount, p.verified ? "verified" : p.rejected ? "rejected" : "pending"].join(','))
+    const header = "orderId,date,method,amount,status"
+    const blob = new Blob([header + "\n" + rows.join("\n")], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'reconciliation.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Payment Reconciliation</h1>
+        <Button variant="outline" onClick={exportCsv}>Export CSV</Button>
+      </div>
+      {Object.entries(grouped).map(([key, items]) => {
+        const [date, method] = key.split('_')
+        return (
+          <Card key={key}>
+            <CardHeader>
+              <CardTitle>{date} - {method}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Order</TableHead>
+                    <TableHead>Amount</TableHead>
+                    <TableHead>Slip</TableHead>
+                    <TableHead className="text-right">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map(p => (
+                    <TableRow key={p.orderId}>
+                      <TableCell>{p.orderId}</TableCell>
+                      <TableCell>฿{p.amount.toLocaleString()}</TableCell>
+                      <TableCell>{p.slip || '-'}</TableCell>
+                      <TableCell className="text-right space-x-2">
+                        <Button size="sm" onClick={() => handleVerify(p.orderId)}>Mark as Verified</Button>
+                        <Button size="sm" variant="outline" onClick={() => handleReject(p.orderId)}>Reject Slip</Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )
+      })}
+      {pending.length === 0 && <p>No pending payments</p>}
+    </div>
+  )
+}

--- a/app/bill/[id]/payment/page.tsx
+++ b/app/bill/[id]/payment/page.tsx
@@ -31,6 +31,7 @@ export default function PaymentPage({ params }: { params: { id: string } }) {
       date,
       amount: parseFloat(amount) || 0,
       slip: slip?.name,
+      method: 'bank_transfer',
     })
     if (p) {
       toast.success("บันทึกการแจ้งโอนแล้ว")

--- a/lib/mock/payment.ts
+++ b/lib/mock/payment.ts
@@ -1,6 +1,6 @@
 import type { Payment } from '@/types/payment'
 
-const payments: Payment[] = []
+export const payments: Payment[] = []
 
 export function getPayment(orderId: string): Payment | undefined {
   return payments.find(p => p.orderId === orderId)
@@ -16,4 +16,13 @@ export function addPayment(orderId: string, data: Omit<Payment, 'orderId' | 'ver
 export function verifyPayment(orderId: string) {
   const p = getPayment(orderId)
   if (p) p.verified = true
+}
+
+export function rejectPayment(orderId: string) {
+  const p = getPayment(orderId)
+  if (p) p.rejected = true
+}
+
+export function listPayments() {
+  return payments
 }

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -3,5 +3,7 @@ export interface Payment {
   date: string
   amount: number
   slip?: string
+  method?: string
   verified?: boolean
+  rejected?: boolean
 }


### PR DESCRIPTION
## Summary
- extend `Payment` type to include `method` and `rejected`
- expose helpers to list/reject payments
- capture payment method when uploading slip
- add `/admin/reconcile` page for pending payments with CSV export

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687cdf4e6bac832594983dfc6e5dd642