### PR TITLE
Implement admin shipping orders page

### DIFF
--- a/app/admin/shipping/orders/page.tsx
+++ b/app/admin/shipping/orders/page.tsx
@@ -1,0 +1,113 @@
+"use client"
+import { useState } from "react"
+import {
+  shippingOrders,
+  setShippingInfo,
+  updateShippingOrderStatus,
+  updateDeliveryStatus,
+} from "@/mock/shipping"
+import type {
+  ShippingOrderStatus,
+  DeliveryStatus,
+  ShippingProvider,
+  shippingOrderStatusLabel,
+  deliveryStatusLabel,
+} from "@/types/shipping"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export default function AdminShippingOrdersPage() {
+  const [orders, setOrders] = useState(() => shippingOrders.map(o => ({ ...o })))
+
+  const handleSave = (id: string, tracking: string, provider: ShippingProvider) => {
+    setShippingInfo(id, tracking, provider)
+    setOrders(shippingOrders.map(o => ({ ...o })))
+  }
+
+  const handleStatus = (id: string, status: ShippingOrderStatus) => {
+    updateShippingOrderStatus(id, status)
+    setOrders(shippingOrders.map(o => ({ ...o })))
+  }
+
+  const handleDelivery = (id: string, status: DeliveryStatus) => {
+    updateDeliveryStatus(id, status)
+    setOrders(shippingOrders.map(o => ({ ...o })))
+  }
+
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Fulfilled Orders</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Delivery</TableHead>
+            <TableHead>Tracking</TableHead>
+            <TableHead>Provider</TableHead>
+            <TableHead />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map(o => (
+            <TableRow key={o.id}>
+              <TableCell>{o.id}</TableCell>
+              <TableCell>{o.name}</TableCell>
+              <TableCell>
+                <Select value={o.status} onValueChange={(v) => handleStatus(o.id, v as ShippingOrderStatus)}>
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(shippingOrderStatusLabel).map(([val, label]) => (
+                      <SelectItem key={val} value={val}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </TableCell>
+              <TableCell>
+                <Select value={o.deliveryStatus} onValueChange={(v) => handleDelivery(o.id, v as DeliveryStatus)}>
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(deliveryStatusLabel).map(([val, label]) => (
+                      <SelectItem key={val} value={val}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </TableCell>
+              <TableCell>
+                <Input
+                  value={o.tracking}
+                  onChange={e => {
+                    const val = e.target.value
+                    setOrders(prev => prev.map(p => p.id === o.id ? { ...p, tracking: val } : p))
+                  }}
+                  className="w-36"
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  value={o.provider || ""}
+                  onChange={e => {
+                    const val = e.target.value as ShippingProvider
+                    setOrders(prev => prev.map(p => p.id === o.id ? { ...p, provider: val } : p))
+                  }}
+                  placeholder="Provider"
+                  className="w-24"
+                />
+              </TableCell>
+              <TableCell>
+                <Button size="sm" onClick={() => handleSave(o.id, o.tracking, o.provider as ShippingProvider)}>Save</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import Link from "next/link"
 import { ArrowLeft, Download, PrinterIcon as Print, Copy } from "lucide-react"
 import { Button } from "@/components/ui/buttons/button"
-import { Card, CardContent } from "@/components/ui/cards/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Input } from "@/components/ui/inputs/input"
 import { Label } from "@/components/ui/label"
 import BillPreview from "@/components/BillPreview"
@@ -203,6 +203,16 @@ export default function BillPage({ params }: { params: { id: string } }) {
             <div className="flex justify-center">
               <div className="w-40 h-40 bg-gray-200 flex items-center justify-center">QR</div>
             </div>
+            <Card>
+              <CardHeader>
+                <CardTitle>สถานะการจัดส่ง</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-1">
+                <p>ผู้ให้บริการ: {order.delivery_method || '-'}</p>
+                <p>เลขติดตามพัสดุ: {order.tracking_number || '-'}</p>
+                <p>สถานะ: {order.shipping_status}</p>
+              </CardContent>
+            </Card>
             <OrderTimeline timeline={order.timeline} />
             <div className="space-y-2">
               <Label htmlFor="amt">จำนวนเงินที่โอน</Label>

--- a/lib/mock-orders.ts
+++ b/lib/mock-orders.ts
@@ -147,6 +147,25 @@ export function setOrderStatus(orderId: string, status: OrderStatus) {
   }
 }
 
+export function setOrderShippingInfo(
+  orderId: string,
+  tracking: string,
+  provider: string,
+  status?: ShippingStatus,
+) {
+  const order = mockOrders.find((o) => o.id === orderId)
+  if (!order) return
+  order.tracking_number = tracking
+  order.delivery_method = provider
+  if (status) {
+    order.shipping_status = status
+    order.shipping_date = new Date().toISOString()
+  } else if (tracking && order.shipping_status === 'pending') {
+    order.shipping_status = 'shipped'
+    order.shipping_date = new Date().toISOString()
+  }
+}
+
 export async function fetchOrders(): Promise<Order[]> {
   if (!supabase) {
     return Promise.resolve(mockOrders)

--- a/mock/shipping.ts
+++ b/mock/shipping.ts
@@ -1,6 +1,7 @@
 import type {
   ShippingOrderStatus,
   DeliveryStatus,
+  ShippingProvider,
 } from '@/types/shipping'
 
 export interface ShippingOrder {
@@ -11,6 +12,7 @@ export interface ShippingOrder {
   tracking: string
   status: ShippingOrderStatus
   deliveryStatus: DeliveryStatus
+  provider?: ShippingProvider
 }
 
 export const shippingOrders: ShippingOrder[] = [
@@ -22,6 +24,7 @@ export const shippingOrders: ShippingOrder[] = [
     tracking: 'TH1234567890',
     status: 'shipped',
     deliveryStatus: 'delivered',
+    provider: 'Kerry',
   },
   {
     id: 'SHIP-002',
@@ -31,6 +34,7 @@ export const shippingOrders: ShippingOrder[] = [
     tracking: '',
     status: 'pendingPrint',
     deliveryStatus: 'shipping',
+    provider: 'Kerry',
   },
   {
     id: 'SHIP-003',
@@ -40,6 +44,7 @@ export const shippingOrders: ShippingOrder[] = [
     tracking: 'TH5555555555',
     status: 'returned',
     deliveryStatus: 'shipping',
+    provider: 'Flash',
   },
 ]
 
@@ -53,6 +58,29 @@ export function addTrackingNumber(
     if (order.status === 'pendingPrint') order.status = 'shipped'
   }
   return order
+}
+
+export function setShippingInfo(
+  id: string,
+  tracking: string,
+  provider: ShippingProvider,
+) {
+  const order = shippingOrders.find((o) => o.id === id)
+  if (order) {
+    order.tracking = tracking
+    order.provider = provider
+    if (order.status === 'pendingPrint' && tracking) order.status = 'shipped'
+  }
+}
+
+export function updateShippingOrderStatus(id: string, status: ShippingOrderStatus) {
+  const order = shippingOrders.find((o) => o.id === id)
+  if (order) order.status = status
+}
+
+export function updateDeliveryStatus(id: string, status: DeliveryStatus) {
+  const order = shippingOrders.find((o) => o.id === id)
+  if (order) order.deliveryStatus = status
 }
 
 export function getShippingOrder(id: string) {

--- a/types/shipping.ts
+++ b/types/shipping.ts
@@ -10,3 +10,5 @@ export const deliveryStatusLabel: Record<DeliveryStatus, string> = {
   shipping: 'กำลังจัดส่ง',
   delivered: 'ถึงแล้ว',
 }
+
+export type ShippingProvider = 'Kerry' | 'Flash' | 'ปณ.'


### PR DESCRIPTION
## Summary
- add ShippingProvider type
- expand mock shipping data with provider field and update helpers
- add helper to update order shipping info
- display shipping status on customer bill page
- implement `/admin/shipping/orders` for admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ceb76425c83259816eed3cbc224eb