### PR TITLE
Implement shipping sync feature

### DIFF
--- a/app/admin/shipping/sync/page.tsx
+++ b/app/admin/shipping/sync/page.tsx
@@ -1,0 +1,78 @@
+"use client"
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/buttons/button"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import ShippingStatusBadge from "@/components/ShippingStatusBadge"
+import useShippingSync from "@/hooks/use-shipping-sync"
+import { shippingSyncLogs, loadShippingSyncLogs, syncShippingStatus } from "@/lib/mock-shipping-sync"
+import { mockOrders } from "@/lib/mock-orders"
+
+export default function ShippingSyncPage() {
+  const [logs, setLogs] = useState(shippingSyncLogs)
+  const [processing, setProcessing] = useState(false)
+
+  useShippingSync(30000)
+
+  useEffect(() => {
+    loadShippingSyncLogs()
+    setLogs([...shippingSyncLogs])
+  }, [])
+
+  const handleSync = async () => {
+    setProcessing(true)
+    await syncShippingStatus()
+    setLogs([...shippingSyncLogs])
+    setProcessing(false)
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 py-8">
+      <h1 className="text-2xl font-bold">Shipping Auto Sync</h1>
+      <Button onClick={handleSync} disabled={processing}>
+        {processing ? "Syncing..." : "Sync Now"}
+      </Button>
+      <div className="space-y-4">
+        <h2 className="font-semibold">Current Orders</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {mockOrders.map(o => (
+              <TableRow key={o.id}>
+                <TableCell>{o.id}</TableCell>
+                <TableCell><ShippingStatusBadge status={o.shipping_status} /></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="space-y-2">
+        <h2 className="font-semibold">Sync Logs</h2>
+        {logs.length ? (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Time</TableHead>
+                <TableHead>Result</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {logs.map(l => (
+                <TableRow key={l.id}>
+                  <TableCell>{new Date(l.timestamp).toLocaleString()}</TableCell>
+                  <TableCell>{l.result}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <p className="text-sm text-muted-foreground">No logs</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/ShippingStatusBadge.tsx
+++ b/components/ShippingStatusBadge.tsx
@@ -1,0 +1,13 @@
+"use client"
+import { Badge } from "@/components/ui/badge"
+import type { ShippingStatus } from "@/types/order"
+import { shippingStatusOptions } from "@/types/order"
+
+export default function ShippingStatusBadge({ status }: { status: ShippingStatus }) {
+  const label = shippingStatusOptions.find(s => s.value === status)?.label || status
+  const color =
+    status === "delivered" ? "bg-green-100 text-green-800" :
+    status === "shipped" ? "bg-blue-100 text-blue-800" :
+    "bg-gray-100 text-gray-800"
+  return <Badge className={color}>{label}</Badge>
+}

--- a/hooks/use-shipping-sync.ts
+++ b/hooks/use-shipping-sync.ts
@@ -1,0 +1,12 @@
+"use client"
+import { useEffect } from "react"
+import { syncShippingStatus } from "@/lib/mock-shipping-sync"
+
+export default function useShippingSync(intervalMs = 30000) {
+  useEffect(() => {
+    const id = setInterval(() => {
+      syncShippingStatus()
+    }, intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+}

--- a/lib/__tests__/mock-shipping-sync.test.ts
+++ b/lib/__tests__/mock-shipping-sync.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { syncShippingStatus, shippingSyncLogs } from '../mock-shipping-sync'
+import { regenerateMockOrders } from '../mock-orders'
+
+describe('shipping sync', () => {
+  beforeEach(() => {
+    shippingSyncLogs.length = 0
+    regenerateMockOrders()
+  })
+
+  it('adds a log entry after sync', async () => {
+    await syncShippingStatus()
+    expect(shippingSyncLogs.length).toBe(1)
+  })
+})

--- a/lib/mock-shipping-sync.ts
+++ b/lib/mock-shipping-sync.ts
@@ -1,0 +1,58 @@
+export interface ShippingSyncLog {
+  id: string
+  timestamp: string
+  result: string
+}
+
+import { mockOrders } from './mock-orders'
+import { mockNotificationService } from './mock-notification-service'
+
+export let shippingSyncLogs: ShippingSyncLog[] = []
+
+const KEY = 'shippingSyncLogs'
+
+export function loadShippingSyncLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(KEY)
+    if (stored) shippingSyncLogs = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(shippingSyncLogs))
+  }
+}
+
+export async function syncShippingStatus() {
+  const updates: string[] = []
+  for (const order of mockOrders) {
+    if (order.shipping_status === 'pending') {
+      order.shipping_status = 'shipped'
+      updates.push(`${order.id} -> shipped`)
+      await mockNotificationService.sendNotification({
+        type: 'order_updated',
+        recipient: { email: order.customerEmail || undefined },
+        data: { orderId: order.id, status: 'shipped' },
+        priority: 'normal',
+      })
+    } else if (order.shipping_status === 'shipped') {
+      order.shipping_status = 'delivered'
+      updates.push(`${order.id} -> delivered`)
+      await mockNotificationService.sendNotification({
+        type: 'order_updated',
+        recipient: { email: order.customerEmail || undefined },
+        data: { orderId: order.id, status: 'delivered' },
+        priority: 'normal',
+      })
+    }
+  }
+  const result = updates.length ? updates.join(', ') : 'No change'
+  shippingSyncLogs.unshift({
+    id: Date.now().toString(),
+    timestamp: new Date().toISOString(),
+    result,
+  })
+  if (shippingSyncLogs.length > 100) shippingSyncLogs = shippingSyncLogs.slice(0, 100)
+  save()
+}


### PR DESCRIPTION
## Summary
- create `ShippingStatusBadge` component
- add mock shipping sync library and test
- schedule sync with `useShippingSync` hook
- implement `/admin/shipping/sync` admin page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687cee7720048325892bb33ca2882d6e