### PR TITLE
Add shipping method selection

### DIFF
--- a/components/BillPreview.tsx
+++ b/components/BillPreview.tsx
@@ -64,6 +64,7 @@ export default function BillPreview({ order }: BillPreviewProps) {
             <p>
               {order.shippingAddress.city} {order.shippingAddress.postalCode}
             </p>
+            <p>วิธีจัดส่ง: {order.delivery_method || '-'}</p>
           </div>
         </div>
       </div>
@@ -113,7 +114,7 @@ export default function BillPreview({ order }: BillPreviewProps) {
               <span>฿{tax.toLocaleString()}</span>
             </div>
             <div className="flex justify-between">
-              <span>ค่าจัดส่ง:</span>
+              <span>ค่าจัดส่ง ({order.delivery_method || '-'}):</span>
               <span>฿{order.shipping_fee.toLocaleString()}</span>
             </div>
             {depositPercent < 100 && (

--- a/mock/shippingMethods.ts
+++ b/mock/shippingMethods.ts
@@ -1,0 +1,15 @@
+export interface ShippingMethod {
+  id: string;
+  name: string;
+  fee: number;
+}
+
+export const shippingMethods: ShippingMethod[] = [
+  { id: 'standard', name: 'ไปรษณีย์ไทย', fee: 80 },
+  { id: 'kerry', name: 'Kerry Express', fee: 100 },
+  { id: 'pickup', name: 'รับสินค้าที่ร้าน', fee: 0 },
+];
+
+export function getShippingMethods(): ShippingMethod[] {
+  return shippingMethods;
+}


### PR DESCRIPTION
## Summary
- add mock shipping methods dataset
- support selecting shipping method during checkout
- store selected method on order
- show shipping method on bill preview

## Testing
- `npm test` *(fails: ERR_REQUIRE_ESM)*

------
https://chatgpt.com/codex/tasks/task_e_687cf08828948325b3c9641d616965fa