### PR TITLE
Implement shipping sync

### DIFF
--- a/app/admin/shipping/sync/page.tsx
+++ b/app/admin/shipping/sync/page.tsx
@@ -1,0 +1,93 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/buttons/button"
+import { Badge } from "@/components/ui/badge"
+import { shippingOrders } from "@/mock/shipping"
+import ShippingStatusBadge from "@/components/shipping/ShippingStatusBadge"
+import { loadShippingSyncLogs, runShippingSync, shippingSyncLogs, type ShippingSyncLog } from "@/lib/shipping-sync"
+import { toast } from "sonner"
+
+export default function ShippingSyncPage() {
+  const [orders, setOrders] = useState(() => shippingOrders.map(o => ({ ...o })))
+  const [logs, setLogs] = useState<ShippingSyncLog[]>([])
+
+  useEffect(() => {
+    loadShippingSyncLogs()
+    setLogs([...shippingSyncLogs])
+    const interval = setInterval(() => {
+      const log = runShippingSync()
+      setOrders(shippingOrders.map(o => ({ ...o })))
+      setLogs([...shippingSyncLogs])
+      if (log.result !== "Updated 0 orders") toast.success(log.result)
+    }, 60000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const sync = () => {
+    const log = runShippingSync()
+    setOrders(shippingOrders.map(o => ({ ...o })))
+    setLogs([...shippingSyncLogs])
+    toast.success(log.result)
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Shipping Sync</h1>
+        <Button onClick={sync}>Sync Now</Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Delivery</TableHead>
+            <TableHead>Tracking</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map(o => (
+            <TableRow key={o.id}>
+              <TableCell>{o.id}</TableCell>
+              <TableCell>
+                <Badge variant={o.status === 'returned' ? 'destructive' : o.status === 'shipped' ? 'secondary' : 'outline'}>
+                  {o.status}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                {o.deliveryStatus === 'delivered' ? (
+                  <ShippingStatusBadge status="delivered" />
+                ) : (
+                  <ShippingStatusBadge status="shipped" />
+                )}
+              </TableCell>
+              <TableCell>{o.tracking || '-'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <h2 className="text-xl font-bold">Sync Logs</h2>
+      {logs.length ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Result</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map(l => (
+              <TableRow key={l.id}>
+                <TableCell>{new Date(l.time).toLocaleString()}</TableCell>
+                <TableCell>{l.result}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <p className="text-sm">no logs</p>
+      )}
+    </div>
+  )
+}

--- a/components/shipping/ShippingStatusBadge.tsx
+++ b/components/shipping/ShippingStatusBadge.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import type { ShippingStatus } from "@/types/order"
+import { shippingStatusOptions } from "@/types/order"
+
+export function getShippingStatusBadgeVariant(status: ShippingStatus): BadgeProps["variant"] {
+  switch (status) {
+    case "delivered":
+      return "default"
+    case "shipped":
+      return "secondary"
+    case "pending":
+      return "outline"
+    default:
+      return "secondary"
+  }
+}
+
+export default function ShippingStatusBadge({ status }: { status: ShippingStatus }) {
+  const label = shippingStatusOptions.find(o => o.value === status)?.label || status
+  return (
+    <Badge variant={getShippingStatusBadgeVariant(status)}>{label}</Badge>
+  )
+}

--- a/lib/shipping-sync.ts
+++ b/lib/shipping-sync.ts
@@ -1,0 +1,49 @@
+import { shippingOrders, updateDeliveryStatus } from '@/mock/shipping'
+import { mockNotificationService } from './mock-notification-service'
+
+export interface ShippingSyncLog {
+  id: string
+  time: string
+  result: string
+}
+
+const LOG_KEY = 'shipping_sync_logs'
+
+export let shippingSyncLogs: ShippingSyncLog[] = []
+
+export function loadShippingSyncLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(LOG_KEY)
+    if (stored) shippingSyncLogs = JSON.parse(stored)
+  }
+}
+
+function saveLogs() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(LOG_KEY, JSON.stringify(shippingSyncLogs))
+  }
+}
+
+export function runShippingSync(): ShippingSyncLog {
+  let updated = 0
+  shippingOrders.forEach(o => {
+    if (o.deliveryStatus === 'shipping' && Math.random() > 0.6) {
+      updateDeliveryStatus(o.id, 'delivered')
+      mockNotificationService.sendNotification({
+        type: 'order_updated',
+        recipient: { phone: o.phone },
+        data: { orderId: o.id, status: 'delivered' },
+        priority: 'normal',
+      })
+      updated++
+    }
+  })
+  const log: ShippingSyncLog = {
+    id: Date.now().toString(),
+    time: new Date().toISOString(),
+    result: `Updated ${updated} orders`,
+  }
+  shippingSyncLogs.unshift(log)
+  saveLogs()
+  return log
+}


### PR DESCRIPTION
## Summary
- create ShippingStatusBadge to visualize shipping status
- add auto-sync utilities for shipping orders
- expose `/admin/shipping/sync` page with manual sync button and log display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cf32811308325943941f7e57640fb