### PR TITLE
Implement billing notification admin page

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,3 +9,14 @@
 5. Add automation log UI with timestamp, status, rule name
 
 Status: in progress
+
+
+## Block 341–345 | Billing Notification System | route: /admin/notify/bills
+
+1. Create /admin/notify/bills to manage notifications for billing events
+2. Add toggle options for email, LINE, in-app notification per bill status
+3. Allow custom message templates (due soon, overdue, paid)
+4. Show notification history per bill with timestamp and channel
+5. Simulate/send notification preview from admin panel (mock only)
+
+Status: done

--- a/app/admin/notify/bills/page.tsx
+++ b/app/admin/notify/bills/page.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/buttons/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/inputs/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ArrowLeft, Send } from "lucide-react"
+import {
+  loadBillNotifyData,
+  billNotifySettings,
+  billNotifyTemplates,
+  billNotifyHistory,
+  setChannel,
+  setTemplate,
+  sendPreview,
+} from "@/lib/mock-bill-notify"
+
+export default function BillNotifyPage() {
+  const [settings, setSettings] = useState(billNotifySettings)
+  const [templates, setTemplates] = useState(billNotifyTemplates)
+  const [history, setHistory] = useState(billNotifyHistory)
+  const [previewId, setPreviewId] = useState("")
+  const [previewStatus, setPreviewStatus] = useState<"dueSoon" | "overdue" | "paid">("dueSoon")
+
+  useEffect(() => {
+    loadBillNotifyData()
+    setSettings({ ...billNotifySettings })
+    setTemplates({ ...billNotifyTemplates })
+    setHistory([...billNotifyHistory])
+  }, [])
+
+  const toggle = (
+    status: "dueSoon" | "overdue" | "paid",
+    channel: "email" | "line" | "inApp",
+    value: boolean,
+  ) => {
+    setChannel(status, channel, value)
+    setSettings({ ...billNotifySettings })
+  }
+
+  const updateTemplate = (status: "dueSoon" | "overdue" | "paid", value: string) => {
+    setTemplate(status, value)
+    setTemplates({ ...billNotifyTemplates })
+  }
+
+  const handlePreview = () => {
+    if (!previewId) return
+    sendPreview(previewId, previewStatus)
+    setHistory([...billNotifyHistory])
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-8">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/dashboard">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">ตั้งค่าการแจ้งเตือนบิล</h1>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>ช่องทางแจ้งเตือน</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>สถานะบิล</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>LINE</TableHead>
+                  <TableHead>In-App</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(
+                  [
+                    { key: "dueSoon", label: "ใกล้ครบกำหนด" },
+                    { key: "overdue", label: "เลยกำหนด" },
+                    { key: "paid", label: "ชำระแล้ว" },
+                  ] as { key: "dueSoon" | "overdue" | "paid"; label: string }[]
+                ).map((row) => (
+                  <TableRow key={row.key}>
+                    <TableCell>{row.label}</TableCell>
+                    {( ["email", "line", "inApp"] as const ).map((ch) => (
+                      <TableCell key={ch} className="text-center">
+                        <Switch
+                          checked={settings[row.key][ch]}
+                          onCheckedChange={(v) => toggle(row.key, ch, v)}
+                        />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>ข้อความแจ้งเตือน</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {(
+              [
+                { key: "dueSoon", label: "ใกล้ครบกำหนด" },
+                { key: "overdue", label: "เลยกำหนด" },
+                { key: "paid", label: "ชำระแล้ว" },
+              ] as { key: "dueSoon" | "overdue" | "paid"; label: string }[]
+            ).map((t) => (
+              <div key={t.key} className="space-y-1">
+                <label className="font-medium">{t.label}</label>
+                <Textarea
+                  value={templates[t.key]}
+                  onChange={(e) => updateTemplate(t.key, e.target.value)}
+                />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>ส่งตัวอย่าง</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input
+              placeholder="รหัสบิล"
+              value={previewId}
+              onChange={(e) => setPreviewId(e.target.value)}
+            />
+            <Select value={previewStatus} onValueChange={(v) => setPreviewStatus(v as any)}>
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="dueSoon">ใกล้ครบกำหนด</SelectItem>
+                <SelectItem value="overdue">เลยกำหนด</SelectItem>
+                <SelectItem value="paid">ชำระแล้ว</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button onClick={handlePreview} disabled={!previewId}>
+              <Send className="h-4 w-4 mr-2" /> ส่งตัวอย่าง
+            </Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>ประวัติการแจ้งเตือน</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>เวลาส่ง</TableHead>
+                  <TableHead>บิล</TableHead>
+                  <TableHead>สถานะ</TableHead>
+                  <TableHead>ช่องทาง</TableHead>
+                  <TableHead>ข้อความ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.map((h) => (
+                  <TableRow key={h.id}>
+                    <TableCell>{new Date(h.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>{h.billId}</TableCell>
+                    <TableCell>{h.status}</TableCell>
+                    <TableCell>{h.channel}</TableCell>
+                    <TableCell className="whitespace-pre-wrap">{h.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-bill-notify.ts
+++ b/lib/mock-bill-notify.ts
@@ -1,0 +1,108 @@
+export type BillNotifyStatus = 'dueSoon' | 'overdue' | 'paid'
+export type BillNotifyChannel = 'email' | 'line' | 'inApp'
+
+export interface BillNotifySettings {
+  [key in BillNotifyStatus]: { email: boolean; line: boolean; inApp: boolean }
+}
+
+export interface BillNotifyTemplates {
+  dueSoon: string
+  overdue: string
+  paid: string
+}
+
+export interface BillNotifyHistoryItem {
+  id: string
+  billId: string
+  status: BillNotifyStatus
+  channel: BillNotifyChannel
+  message: string
+  timestamp: string
+}
+
+const SETTINGS_KEY = 'billNotifySettings'
+const TEMPLATE_KEY = 'billNotifyTemplates'
+const HISTORY_KEY = 'billNotifyHistory'
+
+export let billNotifySettings: BillNotifySettings = {
+  dueSoon: { email: true, line: true, inApp: true },
+  overdue: { email: true, line: true, inApp: true },
+  paid: { email: true, line: false, inApp: true },
+}
+
+export let billNotifyTemplates: BillNotifyTemplates = {
+  dueSoon: 'บิล {{billId}} กำลังจะครบกำหนดชำระ',
+  overdue: 'บิล {{billId}} เลยกำหนดชำระ',
+  paid: 'บิล {{billId}} ชำระเรียบร้อยแล้ว',
+}
+
+export let billNotifyHistory: BillNotifyHistoryItem[] = []
+
+export function loadBillNotifyData() {
+  if (typeof window !== 'undefined') {
+    const s = localStorage.getItem(SETTINGS_KEY)
+    if (s) billNotifySettings = JSON.parse(s)
+    const t = localStorage.getItem(TEMPLATE_KEY)
+    if (t) billNotifyTemplates = JSON.parse(t)
+    const h = localStorage.getItem(HISTORY_KEY)
+    if (h) billNotifyHistory = JSON.parse(h)
+  }
+}
+
+function saveSettings() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(billNotifySettings))
+  }
+}
+
+function saveTemplates() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(TEMPLATE_KEY, JSON.stringify(billNotifyTemplates))
+  }
+}
+
+function saveHistory() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(billNotifyHistory))
+  }
+}
+
+export function setChannel(status: BillNotifyStatus, channel: BillNotifyChannel, value: boolean) {
+  billNotifySettings[status][channel] = value
+  saveSettings()
+}
+
+export function setTemplate(status: BillNotifyStatus, message: string) {
+  billNotifyTemplates[status] = message
+  saveTemplates()
+}
+
+export function addHistory(
+  billId: string,
+  status: BillNotifyStatus,
+  channel: BillNotifyChannel,
+  message: string,
+) {
+  billNotifyHistory.unshift({
+    id: Date.now().toString(),
+    billId,
+    status,
+    channel,
+    message,
+    timestamp: new Date().toISOString(),
+  })
+  saveHistory()
+}
+
+export function getHistory(billId: string) {
+  return billNotifyHistory.filter((h) => h.billId === billId)
+}
+
+export function sendPreview(billId: string, status: BillNotifyStatus) {
+  const msg = billNotifyTemplates[status].replace(/{{billId}}/g, billId)
+  ;(['email', 'line', 'inApp'] as BillNotifyChannel[]).forEach((ch) => {
+    if (billNotifySettings[status][ch]) {
+      addHistory(billId, status, ch, msg)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- add Billing Notification System block in backlog
- create bill notification mock utilities
- add `/admin/notify/bills` route for managing billing notifications

## Testing
- `npm test`
- `npm run -s eslint`


------
https://chatgpt.com/codex/tasks/task_e_687d0fa5b11c83259cba00d4e62c3807