### PR TITLE
Implement bill audit logs

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,3 +9,14 @@
 5. Add automation log UI with timestamp, status, rule name
 
 Status: in progress
+
+
+## Block 356–360 | Bill Audit Trail & Access Logs | route: /admin/bill/:id/audit
+
+1. Create audit tab in /admin/bill/:id to display bill access history
+2. Log all admin/user actions (view, edit, resend, pay) with timestamp
+3. Store access source: IP, device type, role (mock logic)
+4. Highlight risky or unusual access patterns (e.g. multiple views in short time)
+5. Add export button to download audit trail as CSV
+
+Status: planned

--- a/app/admin/bill/[id]/audit/page.tsx
+++ b/app/admin/bill/[id]/audit/page.tsx
@@ -1,0 +1,74 @@
+"use client"
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { getBillAuditLogs, loadBillAuditLogs, exportBillAuditCsv, BillAuditLog } from '@/lib/mock-bill-audit'
+
+export default function BillAuditPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [logs, setLogs] = useState<BillAuditLog[]>([])
+
+  useEffect(() => {
+    loadBillAuditLogs()
+    setLogs(getBillAuditLogs(id))
+  }, [id])
+
+  const risky = (idx: number) => {
+    const current = logs[idx]
+    if (!current) return false
+    const prev = logs[idx + 1]
+    if (!prev) return false
+    const diff = new Date(current.timestamp).getTime() - new Date(prev.timestamp).getTime()
+    return current.action === 'view' && prev.action === 'view' && diff < 5 * 60 * 1000
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href={`/admin/bills`}>
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">Audit Bill {id}</h1>
+          <Button className="ml-auto" variant="outline" onClick={() => exportBillAuditCsv(logs, `bill-${id}-audit.csv`)}>
+            Export CSV
+          </Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Access Logs ({logs.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>IP</TableHead>
+                  <TableHead>Device</TableHead>
+                  <TableHead>Role</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((log, idx) => (
+                  <TableRow key={log.id} className={risky(idx) ? 'bg-red-100' : ''}>
+                    <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+                    <TableCell>{log.action}</TableCell>
+                    <TableCell>{log.ip}</TableCell>
+                    <TableCell>{log.device}</TableCell>
+                    <TableCell>{log.role}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { ArrowLeft, Download, PrinterIcon as Print, Copy } from "lucide-react"
 import { Button } from "@/components/ui/buttons/button"
@@ -10,6 +10,7 @@ import BillPreview from "@/components/BillPreview"
 import { OrderTimeline } from "@/components/order/OrderTimeline"
 import { mockOrders } from "@/lib/mock-orders"
 import { getBill, addBillPayment } from "@/lib/mock-bills"
+import { logBillAction } from "@/lib/mock-bill-audit"
 import { getBill as getAdminBill } from "@/mock/bills"
 import { getQuickBill, getBillLink } from "@/lib/mock-quick-bills"
 import { billSecurity } from "@/lib/mock-settings"
@@ -29,6 +30,16 @@ export default function BillPage({ params }: { params: { id: string } }) {
   const [amount, setAmount] = useState("")
   const [slip, setSlip] = useState<File | null>(null)
   const [reason, setReason] = useState(bill?.abandonReason || "")
+
+  useEffect(() => {
+    if (bill) {
+      logBillAction(bill.id, 'view', {
+        ip: '127.0.0.1',
+        device: 'browser',
+        role: 'user',
+      })
+    }
+  }, [bill])
 
   if (simpleBill) {
     const sum = simpleBill.items.reduce(

--- a/lib/mock-bill-audit.ts
+++ b/lib/mock-bill-audit.ts
@@ -1,0 +1,58 @@
+export interface BillAuditLog {
+  id: string
+  billId: string
+  action: string
+  timestamp: string
+  ip: string
+  device: string
+  role: string
+}
+
+const STORAGE_KEY = 'billAuditLogs'
+export let billAuditLogs: BillAuditLog[] = []
+
+export function loadBillAuditLogs() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) billAuditLogs = JSON.parse(stored)
+  }
+}
+
+function save() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(billAuditLogs))
+  }
+}
+
+export function logBillAction(
+  billId: string,
+  action: string,
+  source: { ip: string; device: string; role: string },
+) {
+  billAuditLogs.unshift({
+    id: Date.now().toString(),
+    billId,
+    action,
+    timestamp: new Date().toISOString(),
+    ...source,
+  })
+  save()
+}
+
+export function getBillAuditLogs(id: string): BillAuditLog[] {
+  return billAuditLogs.filter((l) => l.billId === id)
+}
+
+export function exportBillAuditCsv(logs: BillAuditLog[], filename: string) {
+  const header = 'timestamp,action,ip,device,role\n'
+  const rows = logs
+    .map((l) => `${l.timestamp},${l.action},${l.ip},${l.device},${l.role}`)
+    .join('\n')
+  const blob = new Blob([header + rows], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -4,6 +4,7 @@ import { mockCustomers } from "./mock-customers"
 import { addAdminLog } from "./mock-admin-logs"
 import { addChatMessage } from "./mock-chat-messages"
 import { mockBills } from "./bills"
+import { logBillAction } from "./mock-bill-audit"
 import { generateMockId } from "./mock-uid"
 export { mockBills } from "./bills"
 
@@ -29,6 +30,7 @@ export function createBill(
   }
   mockBills.push(bill)
   addAdminLog(`create bill ${bill.id}`, 'mockAdminId')
+  logBillAction(bill.id, 'create', { ip: '127.0.0.1', device: 'browser', role: 'admin' })
   addChatMessage(orderId, 'bill_created')
   return bill
 }
@@ -42,6 +44,7 @@ export function confirmBill(id: string) {
   if (b) {
     b.status = "paid"
     addAdminLog(`confirm bill ${id}`, 'mockAdminId')
+    logBillAction(id, 'confirm', { ip: '127.0.0.1', device: 'browser', role: 'admin' })
   }
 }
 
@@ -50,12 +53,16 @@ export function cancelBill(id: string) {
   if (b) {
     b.status = "cancelled"
     addAdminLog(`cancel bill ${id}`, 'mockAdminId')
+    logBillAction(id, 'cancel', { ip: '127.0.0.1', device: 'browser', role: 'admin' })
   }
 }
 
 export function addBillPayment(id: string, payment: BillPayment) {
   const b = getBill(id)
-  if (b) b.payments.push(payment)
+  if (b) {
+    b.payments.push(payment)
+    logBillAction(id, 'pay', { ip: '127.0.0.1', device: 'browser', role: 'user' })
+  }
 }
 
 export function cleanupOldBills(days: number) {


### PR DESCRIPTION
## Summary
- add Bill Audit Trail backlog entry
- track bill actions in mock store
- log bill views from customer page
- new module to store and export bill audit logs
- admin page to view audit trail for a bill

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d1623ba188325a16b733e552e377c