### PR TITLE
Implement billing go-live checklist

### DIFF
--- a/app/admin/billing/checklist/page.tsx
+++ b/app/admin/billing/checklist/page.tsx
@@ -1,0 +1,91 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/cards/card"
+import { Button } from "@/components/ui/buttons/button"
+import {
+  billingChecklist,
+  loadBillingChecklist,
+  setBillingChecklistItem,
+  allBillingReady,
+  getReadyTimestamp,
+  setReadyTimestamp,
+  generateMockBills,
+} from "@/lib/mock-billing-checklist"
+
+export default function BillingChecklistPage() {
+  const [items, setItems] = useState(billingChecklist)
+  const [readyAt, setReadyAt] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadBillingChecklist()
+    setItems([...billingChecklist])
+    setReadyAt(getReadyTimestamp())
+  }, [])
+
+  const toggle = (id: string, val: boolean) => {
+    setBillingChecklistItem(id, val)
+    setItems([...billingChecklist])
+    if (allBillingReady() && !readyAt) {
+      setReadyTimestamp()
+      setReadyAt(getReadyTimestamp())
+    }
+  }
+
+  const handleGenerate = () => {
+    generateMockBills(3)
+    alert("Generated mock bills")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <h1 className="text-3xl font-bold">Billing Go-Live Checklist</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>System Readiness</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {items.map((item) => (
+              <label key={item.id} className="flex items-start gap-2">
+                <Checkbox
+                  checked={item.done}
+                  onCheckedChange={(v) => toggle(item.id, v as boolean)}
+                />
+                <span>
+                  {item.label}
+                  <span className="block text-muted-foreground text-sm">
+                    {item.description}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Manual Test Steps</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <ol className="list-decimal ml-4 space-y-1">
+              <li>Create a test order</li>
+              <li>Generate a bill and send notification</li>
+              <li>Confirm payment and verify status</li>
+            </ol>
+            <Button variant="outline" onClick={handleGenerate}>
+              Generate Mock Bills
+            </Button>
+          </CardContent>
+        </Card>
+        {readyAt && (
+          <div className="p-4 border rounded bg-green-50">
+            <p className="font-medium">Ready to Go Live</p>
+            <p className="text-sm text-gray-500">
+              Completed {new Date(readyAt).toLocaleString()}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/mock-billing-checklist.ts
+++ b/lib/mock-billing-checklist.ts
@@ -1,0 +1,97 @@
+export interface BillingChecklistItem {
+  id: string
+  label: string
+  description: string
+  done: boolean
+}
+
+const STORAGE_KEY = 'billingChecklist'
+const READY_KEY = 'billingReadyTime'
+
+export let billingChecklist: BillingChecklistItem[] = [
+  {
+    id: 'templates',
+    label: 'Templates configured',
+    description: 'Email/SMS templates set up',
+    done: false,
+  },
+  {
+    id: 'notifications',
+    label: 'Notification settings',
+    description: 'Bill notifications enabled',
+    done: false,
+  },
+  {
+    id: 'backup',
+    label: 'Backup completed',
+    description: 'System config exported',
+    done: false,
+  },
+  {
+    id: 'permissions',
+    label: 'Permissions reviewed',
+    description: 'Admin roles verified',
+    done: false,
+  },
+]
+
+export function loadBillingChecklist() {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const obj = JSON.parse(stored) as Record<string, boolean>
+      billingChecklist = billingChecklist.map((c) => ({
+        ...c,
+        done: obj[c.id] ?? c.done,
+      }))
+    }
+  }
+}
+
+function saveBillingChecklist() {
+  if (typeof window !== 'undefined') {
+    const obj: Record<string, boolean> = {}
+    billingChecklist.forEach((c) => {
+      obj[c.id] = c.done
+    })
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(obj))
+  }
+}
+
+export function setBillingChecklistItem(id: string, val: boolean) {
+  const item = billingChecklist.find((c) => c.id === id)
+  if (item) {
+    item.done = val
+    saveBillingChecklist()
+  }
+}
+
+export function allBillingReady(): boolean {
+  return billingChecklist.every((c) => c.done)
+}
+
+export function getReadyTimestamp(): string | null {
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem(READY_KEY)
+  }
+  return null
+}
+
+export function setReadyTimestamp() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(READY_KEY, new Date().toISOString())
+  }
+}
+
+import { addBill } from '@/mock/bills'
+
+export function generateMockBills(count = 3) {
+  for (let i = 0; i < count; i++) {
+    addBill({
+      customer: `Test Customer ${i + 1}`,
+      items: [{ name: 'Service Fee', quantity: 1, price: 100 }],
+      shipping: 0,
+      note: 'mock',
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add mock checklist state for billing readiness
- create billing checklist page at `/admin/billing/checklist`
- include manual test steps and mock data generator

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d28d161d8832583d7b5efd0d5a45b