### PR TITLE
Add SYSTEM_NOTES.md policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,35 @@ pnpm test:watch
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+---
+
+## 🧱 Block-Based Dev Flow Guideline (SYSTEM_NOTES.md)
+
+This project uses block-based feature development.
+
+Each feature must be tracked in `SYSTEM_NOTES.md` using the Dev Block format:
+
+### Block XXX–XXX | [Feature Name] | route: /your/feature/path
+
+1. Clear task description  
+2. ...  
+3. ...  
+4. ...  
+5. ...
+
+Status: planned | in progress | done
+
+### 🔒 Required Before PR
+
+Before submitting any PR:
+
+✅ Update `SYSTEM_NOTES.md` with the Block(s) you worked on  
+✅ Follow the format exactly  
+✅ Commit the file with your code
+
+Failure to do so may result in PR rejection or rework request.
+
+---
+
+Status: planned


### PR DESCRIPTION
## Summary
- add block-based development policy for SYSTEM_NOTES.md

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d324fe5708325a393896c391578e0