### PR TITLE
Implement billing archive store

### DIFF
--- a/app/admin/billing/archive/page.tsx
+++ b/app/admin/billing/archive/page.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { useEffect } from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/cards/card'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/buttons/button'
+import { useBillStore } from '@/core/store'
+
+export default function BillingArchivePage() {
+  const store = useBillStore()
+
+  useEffect(() => {
+    store.refresh()
+  }, [])
+
+  const bills = store.archived
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <h1 className="text-3xl font-bold mb-4">Archived Bills</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Archived / Expired Bills</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {bills.length ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Customer</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="w-24" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bills.map((b) => (
+                  <TableRow key={b.id}>
+                    <TableCell>{b.id}</TableCell>
+                    <TableCell>{b.customer}</TableCell>
+                    <TableCell>{new Date(b.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" onClick={() => store.restore(b.id)}>
+                        Restore
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-center text-sm text-gray-500">No archived bills</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Plus, Search } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { Button } from '@/components/ui/buttons/button'
@@ -12,11 +12,17 @@ import { Badge } from '@/components/ui/badge'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type { AdminBill, BillItem } from '@/mock/bills'
-import { mockBills, addBill, updateBillStatus, updateBill } from '@/mock/bills'
+import { useBillStore } from '@/core/store'
 import { toast } from 'sonner'
 
 export default function AdminBillsPage() {
-  const [bills, setBills] = useState<AdminBill[]>([...mockBills])
+  const store = useBillStore()
+  const [bills, setBills] = useState<AdminBill[]>(store.bills)
+
+  useEffect(() => {
+    store.refresh()
+    setBills([...store.bills])
+  }, [])
   const [open, setOpen] = useState(false)
   const [customer, setCustomer] = useState('')
   const [items, setItems] = useState<BillItem[]>([])
@@ -39,8 +45,8 @@ export default function AdminBillsPage() {
       toast.error('ต้องมีสินค้าอย่างน้อย 1 รายการ')
       return
     }
-    const bill = addBill({ customer, items, shipping, note })
-    setBills([bill, ...bills])
+    store.addBill({ customer, items, shipping, note } as any)
+    setBills([...store.bills])
     setCustomer('')
     setItems([])
     setNote('')
@@ -221,8 +227,8 @@ export default function AdminBillsPage() {
                       <Select
                         value={b.status}
                         onValueChange={(v) => {
-                          updateBillStatus(b.id, v as AdminBill['status'])
-                          setBills([...mockBills])
+                          store.updateStatus(b.id, v as AdminBill['status'])
+                          setBills([...store.bills])
                         }}
                       >
                         <SelectTrigger className="w-28">
@@ -386,8 +392,8 @@ export default function AdminBillsPage() {
             <Button
               onClick={() => {
                 if (edit && editData) {
-                  updateBill(edit, editData)
-                  setBills([...mockBills])
+                  store.updateBill(edit, editData)
+                  setBills([...store.bills])
                   toast.success('บันทึกแล้ว (mock)')
                 }
                 setEdit(null)

--- a/app/invoice/[id]/page.tsx
+++ b/app/invoice/[id]/page.tsx
@@ -8,7 +8,7 @@ import Link from "next/link"
 import { useOrder } from "@/lib/hooks/useOrder"
 import { Badge } from "@/components/ui/badge"
 import { packingStatusOptions } from "@/types/order"
-import { mockBills } from "@/lib/mock-bills"
+import { useBillStore } from "@/core/store"
 import { loadAutoReminder, autoReminder } from "@/lib/mock-settings"
 import { createClaim } from "@/lib/mock-claims"
 import { toast } from "sonner"
@@ -17,6 +17,7 @@ import { formatDate } from "@/lib/utils"
 export default function InvoicePage({ params }: { params: { id: string } }) {
   const { id } = params
   const { order } = useOrder(id)
+  const store = useBillStore()
 
   if (!order) {
     return (
@@ -53,7 +54,8 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
   useEffect(() => {
     loadAutoReminder()
     if (autoReminder) {
-      const bill = mockBills.find((b) => b.orderId === order.id)
+      store.refresh()
+      const bill = store.bills.find((b) => b.orderId === order.id)
       if (
         bill &&
         (bill.status === "unpaid" || bill.status === "pending") &&

--- a/app/invoice/page.tsx
+++ b/app/invoice/page.tsx
@@ -5,17 +5,19 @@ import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
 import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
-import { mockBills } from "@/lib/mock-bills"
+import { useBillStore } from "@/core/store"
 import { mockOrders } from "@/lib/mock-orders"
 import { loadAutoArchive, autoArchive } from "@/lib/mock-settings"
 import { format } from "date-fns"
 
 export default function InvoiceListPage() {
-  const [bills, setBills] = useState(mockBills)
+  const store = useBillStore()
+  const [bills, setBills] = useState(store.bills)
 
   useEffect(() => {
     loadAutoArchive()
-    setBills([...mockBills])
+    store.refresh()
+    setBills([...store.bills])
   }, [])
 
   const filtered = bills.filter((b) => {

--- a/core/mock/store/bills.ts
+++ b/core/mock/store/bills.ts
@@ -1,0 +1,80 @@
+import type { AdminBill, BillItem } from '@/mock/bills'
+import {
+  mockBills as seedBills,
+  addBill as baseAdd,
+  updateBill as baseUpdate,
+  updateBillStatus as baseStatus,
+  archiveBill as baseArchive,
+  restoreBill as baseRestore,
+  getArchivedBills as baseGetArchived,
+} from '@/mock/bills'
+import { loadFromStorage, saveToStorage } from './persist'
+import { autoArchive } from '@/lib/mock-settings'
+
+const KEY = 'mockStore_bills'
+
+let bills: AdminBill[] = loadFromStorage<AdminBill[]>(KEY, [...seedBills])
+
+function persist() {
+  saveToStorage(KEY, bills)
+}
+
+export function getBills() {
+  return bills
+}
+
+export function getArchivedBills() {
+  return bills.filter((b) => b.archived)
+}
+
+export function addBill(data: Omit<AdminBill, 'id' | 'status' | 'createdAt'>) {
+  const bill = baseAdd(data)
+  bills = [...seedBills]
+  persist()
+  return bill
+}
+
+export function updateBill(id: string, data: Partial<Omit<AdminBill, 'id' | 'createdAt'>>) {
+  baseUpdate(id, data)
+  bills = [...seedBills]
+  persist()
+}
+
+export function updateBillStatus(id: string, status: AdminBill['status']) {
+  baseStatus(id, status)
+  bills = [...seedBills]
+  persist()
+}
+
+export function archiveBill(id: string) {
+  baseArchive(id)
+  bills = [...seedBills]
+  persist()
+}
+
+export function restoreBill(id: string) {
+  baseRestore(id)
+  bills = [...seedBills]
+  persist()
+}
+
+export function autoArchiveBills(days = 14) {
+  if (!autoArchive) return
+  const cutoff = Date.now() - days * 86400000
+  bills.forEach((b) => {
+    if (!b.archived && b.status === 'unpaid' && new Date(b.createdAt).getTime() < cutoff) {
+      b.archived = true
+    }
+  })
+  persist()
+}
+
+export function resetBills() {
+  bills = []
+  persist()
+}
+
+export function regenerateBills() {
+  bills = [...seedBills]
+  persist()
+}

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -3,17 +3,20 @@ export * from './customers'
 export * from './fabrics'
 export * from './products'
 export * from './config'
+export * from './bills'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetCustomers, regenerateCustomers } from './customers'
 import { resetFabrics, regenerateFabrics } from './fabrics'
 import { resetProducts, regenerateProducts } from './products'
+import { resetBills, regenerateBills } from './bills'
 
 export function resetStore() {
   resetOrders()
   resetCustomers()
   resetFabrics()
   resetProducts()
+  resetBills()
 }
 
 export function generateMockData() {
@@ -21,4 +24,5 @@ export function generateMockData() {
   regenerateCustomers()
   regenerateFabrics()
   regenerateProducts()
+  regenerateBills()
 }

--- a/core/store/bills.ts
+++ b/core/store/bills.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import type { AdminBill } from '@/mock/bills'
+import {
+  getBills,
+  getArchivedBills,
+  addBill as add,
+  updateBill as update,
+  updateBillStatus as setStatus,
+  archiveBill as archive,
+  restoreBill as restore,
+  autoArchiveBills,
+} from '@/core/mock/store'
+
+interface BillStore {
+  bills: AdminBill[]
+  archived: AdminBill[]
+  refresh: () => void
+  addBill: (data: Omit<AdminBill, 'id' | 'status' | 'createdAt'>) => void
+  updateBill: (id: string, data: Partial<Omit<AdminBill, 'id' | 'createdAt'>>) => void
+  updateStatus: (id: string, status: AdminBill['status']) => void
+  archive: (id: string) => void
+  restore: (id: string) => void
+}
+
+export const useBillStore = create<BillStore>((set) => ({
+  bills: getBills(),
+  archived: getArchivedBills(),
+  refresh: () => {
+    autoArchiveBills()
+    set({ bills: getBills(), archived: getArchivedBills() })
+  },
+  addBill: (data) => {
+    add(data)
+    set({ bills: getBills() })
+  },
+  updateBill: (id, data) => {
+    update(id, data)
+    set({ bills: getBills() })
+  },
+  updateStatus: (id, status) => {
+    setStatus(id, status)
+    set({ bills: getBills() })
+  },
+  archive: (id) => {
+    archive(id)
+    set({ bills: getBills(), archived: getArchivedBills() })
+  },
+  restore: (id) => {
+    restore(id)
+    set({ bills: getBills(), archived: getArchivedBills() })
+  },
+}))

--- a/core/store/index.ts
+++ b/core/store/index.ts
@@ -1,3 +1,4 @@
 export * from './admin'
 export * from './orders'
 export * from './customers'
+export * from './bills'

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -14,6 +14,7 @@ export interface AdminBill {
   note: string
   status: 'pending' | 'unpaid' | 'paid' | 'cancelled'
   createdAt: string
+  archived?: boolean
 }
 
 export const mockBills: AdminBill[] = [
@@ -28,6 +29,7 @@ export const mockBills: AdminBill[] = [
     note: '',
     status: 'pending',
     createdAt: new Date().toISOString(),
+    archived: false,
   },
 ]
 
@@ -37,6 +39,7 @@ export function addBill(data: Omit<AdminBill, 'id' | 'status' | 'createdAt'>): A
     status: 'unpaid',
     createdAt: new Date().toISOString(),
     ...data,
+    archived: false,
   }
   mockBills.unshift(bill)
   return bill
@@ -45,6 +48,20 @@ export function addBill(data: Omit<AdminBill, 'id' | 'status' | 'createdAt'>): A
 export function updateBillStatus(id: string, status: AdminBill['status']) {
   const bill = mockBills.find((b) => b.id === id)
   if (bill) bill.status = status
+}
+
+export function archiveBill(id: string) {
+  const bill = mockBills.find((b) => b.id === id)
+  if (bill) bill.archived = true
+}
+
+export function restoreBill(id: string) {
+  const bill = mockBills.find((b) => b.id === id)
+  if (bill) bill.archived = false
+}
+
+export function getArchivedBills() {
+  return mockBills.filter((b) => b.archived)
 }
 
 export function getBill(id: string): AdminBill | undefined {


### PR DESCRIPTION
## Summary
- add `core/mock/store/bills` with archive & auto-archive helpers
- expose bill store via Zustand in `core/store`
- update mock data for bills with archived flag
- add `/admin/billing/archive` page for managing archived bills
- refactor invoice and admin bills pages to use central bill store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d3eb85530832587c9550282f91c03