### PR TITLE
Implement PageWrapper for admin

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/mock/mock-db"
 import { conversations } from "@/lib/mock-conversations"
 import { useAuth } from "@/contexts/auth-context"
+import PageWrapper from "@/components/admin/PageWrapper"
 
 interface OrderData {
   id: string
@@ -81,10 +82,10 @@ export default function AdminDashboard() {
   )
 
   return (
-    <div className="p-4 space-y-6">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">แดชบอร์ดแอดมินหลัก</h1>
-      </header>
+    <PageWrapper
+      title="แดชบอร์ดแอดมินหลัก"
+      breadcrumb={[{ title: "แดชบอร์ด" }]}
+    >
 
       <section className="space-y-2">
         <div className="flex items-center justify-between">
@@ -243,7 +244,7 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
       </section>
-    </div>
+    </PageWrapper>
   )
 }
 

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -56,7 +56,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             )}
             <div className="flex flex-1 flex-col">
               <Topbar onMenuClick={() => setSidebarOpen(true)} />
-              <main className="flex-1 p-4 pb-20 md:pb-4">{children}</main>
+              <main className="flex-1 pb-20 md:pb-4">{children}</main>
               <AdminToast />
               <QuickActionBar />
             </div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -9,6 +9,7 @@ import { mockOrders, updateOrderStatus } from "@/lib/mock/orders";
 import { mockNotifications } from "@/lib/mock-notifications";
 import { chatNotifications } from "@/lib/mock/chat-notify";
 import DebugPanel from "@/components/admin/DebugPanel";
+import PageWrapper from "@/components/admin/PageWrapper";
 import { logEvent } from "@/lib/logs";
 import type { Order } from "@/types/order";
 import { toast } from "sonner";
@@ -77,7 +78,10 @@ export default function AdminIndex() {
   };
 
   return (
-    <div className="p-4 space-y-6">
+    <PageWrapper
+      title="แดชบอร์ด"
+      breadcrumb={[{ title: "แดชบอร์ด" }]}
+    >
       <div className="flex flex-col gap-4 mb-4">
         <Button
           variant="default"
@@ -214,6 +218,6 @@ export default function AdminIndex() {
       </CardContent>
       </Card>
       {debugOpen && <DebugPanel />}
-    </div>
+    </PageWrapper>
   );
 }

--- a/components/admin/PageWrapper.tsx
+++ b/components/admin/PageWrapper.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import type { ReactNode } from "react"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+export interface BreadcrumbEntry {
+  title: string
+  href?: string
+}
+
+interface PageWrapperProps {
+  title: string
+  description?: string
+  breadcrumb?: BreadcrumbEntry[]
+  children: ReactNode
+}
+
+export default function PageWrapper({
+  title,
+  description,
+  breadcrumb,
+  children,
+}: PageWrapperProps) {
+  return (
+    <div className="space-y-4">
+      {breadcrumb && breadcrumb.length > 0 && (
+        <Breadcrumb>
+          <BreadcrumbList>
+            {breadcrumb.map((b, idx) => (
+              <>
+                <BreadcrumbItem key={idx}>
+                  {b.href ? (
+                    <BreadcrumbLink href={b.href}>{b.title}</BreadcrumbLink>
+                  ) : (
+                    <BreadcrumbPage>{b.title}</BreadcrumbPage>
+                  )}
+                </BreadcrumbItem>
+                {idx < breadcrumb.length - 1 && <BreadcrumbSeparator key={`s-${idx}`} />}
+              </>
+            ))}
+          </BreadcrumbList>
+        </Breadcrumb>
+      )}
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {description && <p className="text-muted-foreground">{description}</p>}
+      </header>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new `PageWrapper` admin component for heading and breadcrumbs
- update admin layout padding
- wrap `/admin/page` and `/admin/dashboard/page` with `PageWrapper`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d5eea4380832587416996a182a725