### PR TITLE
Implement bill status and tag UI

### DIFF
--- a/lib/mock-billing-checklist.ts
+++ b/lib/mock-billing-checklist.ts
@@ -92,6 +92,7 @@ export function generateMockBills(count = 3) {
       items: [{ name: 'Service Fee', quantity: 1, price: 100 }],
       shipping: 0,
       note: 'mock',
+      tags: [],
     })
   }
 }

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -12,7 +12,8 @@ export interface AdminBill {
   items: BillItem[]
   shipping: number
   note: string
-  status: 'pending' | 'unpaid' | 'paid' | 'cancelled'
+  status: 'pending' | 'unpaid' | 'paid' | 'shipped' | 'cancelled'
+  tags: string[]
   createdAt: string
   archived?: boolean
 }
@@ -28,6 +29,7 @@ export const mockBills: AdminBill[] = [
     shipping: 50,
     note: '',
     status: 'pending',
+    tags: ['COD', 'VIP'],
     createdAt: new Date().toISOString(),
     archived: false,
   },


### PR DESCRIPTION
## Summary
- extend admin bills data with `tags` and `shipped` status
- display tag and status badges in admin bills list
- add dropdown filters for status and tags
- support tags when generating mock bills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d60a953f48325825f03c1e76173a7