### PR TITLE
Add admin bill print page

### DIFF
--- a/app/admin/bill/print/[id]/page.tsx
+++ b/app/admin/bill/print/[id]/page.tsx
@@ -8,11 +8,20 @@ import BillNoteBox from '@/components/bill/BillNoteBox'
 import BillPrintDate from '@/components/bill/BillPrintDate'
 import BillPrintActions from '@/components/bill/BillPrintActions'
 import { useBillData } from '@/lib/hooks/useBillData'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 export default function BillPrintPage({ params }: { params: { id: string } }) {
+  const router = useRouter()
   const bill = useBillData(params.id)
 
-  if (!bill) {
+  useEffect(() => {
+    if (bill === null) {
+      router.replace('/admin/bills')
+    }
+  }, [bill, router])
+
+  if (bill === undefined) {
     return <div className="p-4 text-center">Loading...</div>
   }
 

--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -276,6 +276,9 @@ export default function AdminBillsPage() {
                       <Link href={`/bill/${b.id}`} className="underline text-sm">
                         ดูบิล
                       </Link>
+                      <Link href={`/admin/bill/print/${b.id}`} target="_blank">
+                        <Button variant="outline" size="sm">📄 พิมพ์ใบแจ้งหนี้</Button>
+                      </Link>
                       <Button
                         variant="outline"
                         size="sm"

--- a/components/ui/PrintActionBar.tsx
+++ b/components/ui/PrintActionBar.tsx
@@ -3,7 +3,7 @@ import { Button } from './buttons/button'
 export default function PrintActionBar({ onPrint, onDownload }: { onPrint: () => void; onDownload: () => void }) {
   return (
     <div className="print:hidden flex gap-2 mb-4">
-      <Button onClick={onPrint}>พิมพ์</Button>
+      <Button onClick={onPrint}>พิมพ์หน้านี้</Button>
       <Button onClick={onDownload}>ดาวน์โหลด PDF</Button>
     </div>
   )

--- a/lib/hooks/useBillData.ts
+++ b/lib/hooks/useBillData.ts
@@ -12,12 +12,16 @@ export interface BillData {
 }
 
 export function useBillData(id: string) {
-  const [bill, setBill] = useState<BillData | null>(null)
+  const [bill, setBill] = useState<BillData | null | undefined>(undefined)
 
   useEffect(() => {
+    setBill(undefined)
     fetch(`/api/mock/bill/${id}`)
       .then((r) => r.json())
-      .then(setBill)
+      .then((data) => {
+        if (data && data.id) setBill(data)
+        else setBill(null)
+      })
       .catch(() => setBill(null))
   }, [id])
 


### PR DESCRIPTION
## Summary
- link to new bill print route in bill table
- load bill data with explicit loading/null states
- add redirect protection when bill id invalid
- update print action button text

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687d6b6e5c848325ab8c960134469d0f