### PR TITLE
Add customer popup and global selection store

### DIFF
--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -22,6 +22,9 @@ import {
 import { loadCustomerTags, listCustomerTags } from "@/lib/mock-customer-tags"
 import { loadFlaggedUsers, getFlagStatus } from "@/lib/mock-flagged-users"
 import { downloadCSV, downloadPDF } from "@/lib/mock-export"
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
+import CustomerPopup from "@/components/admin/customers/CustomerPopup"
+import { useCustomerStore } from "@/lib/useCustomerStore"
 
 
 export default function AdminCustomersPage() {
@@ -33,6 +36,7 @@ export default function AdminCustomersPage() {
   const [showAdd, setShowAdd] = useState(false)
   const [newName, setNewName] = useState("")
   const [newEmail, setNewEmail] = useState("")
+  const { selected, setSelected } = useCustomerStore()
 
   useEffect(() => {
     loadCustomerNotes()
@@ -273,7 +277,19 @@ export default function AdminCustomersPage() {
                           <span className="text-sm font-medium">{customer.name.charAt(0).toUpperCase()}</span>
                         </div>
                         <div>
-                          <p className="font-medium">{customer.name}</p>
+                          <TooltipProvider delayDuration={0}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  onClick={() => setSelected(customer)}
+                                  className="text-base font-semibold tracking-wide truncate max-w-[150px] hover:underline"
+                                >
+                                  {customer.name}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>{customer.name}</TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                           <p className="text-sm text-gray-500">ID: {customer.id}</p>
                         </div>
                       </div>
@@ -345,6 +361,7 @@ export default function AdminCustomersPage() {
           </CardContent>
         </Card>
       </div>
+      <CustomerPopup customer={selected} onClose={() => setSelected(null)} />
     </div>
   )
 }

--- a/components/admin/customers/CustomerPopup.tsx
+++ b/components/admin/customers/CustomerPopup.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { useMemo } from 'react'
+import ModalWrapper from '@/components/ui/ModalWrapper'
+import { Button } from '@/components/ui/buttons/button'
+import { mockBills } from '@/lib/bills'
+import { mockOrders } from '@/lib/mock-orders'
+import type { Customer } from '@/lib/mock-customers'
+import { formatThaiDate } from '@/lib/utils'
+
+export default function CustomerPopup({
+  customer,
+  onClose,
+}: {
+  customer: Customer | null
+  onClose: () => void
+}) {
+  const bills = useMemo(() => {
+    if (!customer) return []
+    const orderIds = mockOrders
+      .filter(o => o.customerId === customer.id)
+      .map(o => o.id)
+    return mockBills
+      .filter(b => orderIds.includes(b.orderId))
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 3)
+  }, [customer])
+
+  if (!customer) return null
+
+  return (
+    <ModalWrapper open={!!customer} onClose={onClose}>
+      <div className="w-80 space-y-4">
+        <div className="flex justify-between items-start">
+          <div>
+            <h2 className="text-lg font-bold">{customer.name}</h2>
+            {customer.phone && <p className="text-sm">โทร: {customer.phone}</p>}
+          </div>
+          <Button size="sm" variant="outline" onClick={onClose}>ปิด</Button>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2">บิลล่าสุด</h3>
+          <ul className="text-sm space-y-1">
+            {bills.map(bill => (
+              <li key={bill.id} className="flex justify-between">
+                <span>#{bill.id}</span>
+                <span>{formatThaiDate(bill.createdAt)}</span>
+              </li>
+            ))}
+            {bills.length === 0 && (
+              <li className="text-gray-500">ไม่มีประวัติบิล</li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </ModalWrapper>
+  )
+}

--- a/lib/useCustomerStore.ts
+++ b/lib/useCustomerStore.ts
@@ -1,0 +1,13 @@
+"use client"
+import { create } from 'zustand'
+import type { Customer } from './mock-customers'
+
+interface CustomerSelectionState {
+  selected: Customer | null
+  setSelected: (c: Customer | null) => void
+}
+
+export const useCustomerStore = create<CustomerSelectionState>((set) => ({
+  selected: null,
+  setSelected: (c) => set({ selected: c }),
+}))


### PR DESCRIPTION
## Summary
- improve admin customer table name display with tooltip and modal trigger
- introduce `CustomerPopup` component to view details and recent bills
- add zustand store `useCustomerStore` for global selected customer state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d6dede8388325b011d20cabc4b1ef