### PR TITLE
Add customer insights popup

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -12,8 +12,10 @@ import { Badge } from '@/components/ui/badge'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import BillItemActions from '@/components/admin/BillItemActions'
+import CustomerPopup from '@/components/admin/CustomerPopup'
 import type { AdminBill, BillItem } from '@/mock/bills'
 import { useBillStore } from '@/core/store'
+import { mockCustomers } from '@/lib/mock-customers'
 import { toast } from 'sonner'
 
 export default function AdminBillsPage() {
@@ -243,7 +245,20 @@ export default function AdminBillsPage() {
                 {filteredBills.map((b) => (
                   <TableRow key={b.id}>
                   <TableCell>{b.id}</TableCell>
-                  <TableCell>{b.customer}</TableCell>
+                  <TableCell>
+                    {(() => {
+                      const c = mockCustomers.find((m) => m.name === b.customer)
+                      return c ? (
+                        <CustomerPopup customer={c}>
+                          <span className="cursor-pointer underline">
+                            {b.customer}
+                          </span>
+                        </CustomerPopup>
+                      ) : (
+                        b.customer
+                      )
+                    })()}
+                  </TableCell>
                   <TableCell className="space-x-1">
                     {b.tags.map((t) => (
                       <Badge key={t} variant="secondary">

--- a/components/admin/CustomerPopup.tsx
+++ b/components/admin/CustomerPopup.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/modals/dialog'
+import { Badge } from '@/components/ui/badge'
+import type { Customer } from '@/lib/mock-customers'
+import { useCustomerInsights } from '@/hooks/useCustomerInsights'
+
+export default function CustomerPopup({ customer, children }:{ customer: Customer; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const insight = useCustomerInsights(customer.name)
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{customer.name}</DialogTitle>
+        </DialogHeader>
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div className="space-y-1">
+            {customer.phone && <p>📞 {customer.phone}</p>}
+            {customer.email && <p>📧 {customer.email}</p>}
+            {customer.tags?.length && (
+              <div className="flex flex-wrap gap-1">
+                {customer.tags.map(t => (
+                  <Badge key={t} variant="secondary">{t}</Badge>
+                ))}
+              </div>
+            )}
+            {customer.note && <p className="text-muted-foreground">{customer.note}</p>}
+          </div>
+          <div className="space-y-1">
+            <p>บิลทั้งหมด <Badge variant="secondary">{insight.billCount}</Badge></p>
+            {insight.lastPurchase && (
+              <p>ล่าสุด {new Date(insight.lastPurchase).toLocaleDateString('th-TH')}</p>
+            )}
+            {insight.commonTags.length > 0 && (
+              <p className="flex flex-wrap gap-1">{insight.commonTags.map(t => (
+                <Badge key={t} variant="outline">{t}</Badge>
+              ))}</p>
+            )}
+            {insight.commonStatus && (
+              <p>สถานะบ่อยสุด <Badge variant="secondary">{insight.commonStatus}</Badge></p>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/hooks/useCustomerInsights.tsx
+++ b/hooks/useCustomerInsights.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react'
+import { mockBills, type AdminBill } from '@/mock/bills'
+
+export interface CustomerInsights {
+  billCount: number
+  lastPurchase?: string
+  commonTags: string[]
+  commonStatus?: AdminBill['status']
+}
+
+const cache = new Map<string, CustomerInsights>()
+
+export function useCustomerInsights(name: string): CustomerInsights {
+  return useMemo(() => {
+    if (cache.has(name)) return cache.get(name)!
+    const bills = mockBills.filter(b => b.customer === name)
+    const billCount = bills.length
+    let lastPurchase: string | undefined
+    const tagCount: Record<string, number> = {}
+    const statusCount: Record<AdminBill['status'], number> = {
+      unpaid: 0,
+      paid: 0,
+      pending: 0,
+      shipped: 0,
+      cancelled: 0,
+    }
+    for (const b of bills) {
+      if (!lastPurchase || new Date(b.createdAt) > new Date(lastPurchase)) {
+        lastPurchase = b.createdAt
+      }
+      for (const t of b.tags) {
+        tagCount[t] = (tagCount[t] || 0) + 1
+      }
+      statusCount[b.status] = (statusCount[b.status] || 0) + 1
+    }
+    const commonTags = Object.entries(tagCount)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([t]) => t)
+    const commonStatus = (Object.entries(statusCount)
+      .sort((a, b) => b[1] - a[1])[0]?.[0] as AdminBill['status']) || undefined
+    const insight = { billCount, lastPurchase, commonTags, commonStatus }
+    cache.set(name, insight)
+    return insight
+  }, [name])
+}


### PR DESCRIPTION
## Summary
- add `useCustomerInsights` hook for computing bill insights
- show insights in new `CustomerPopup`
- integrate popup on admin bills page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d7039d4a08325ac81ec77df2c8181