### PR TITLE
Add simple customer management

### DIFF
--- a/app/admin/customers/edit/[id].tsx
+++ b/app/admin/customers/edit/[id].tsx
@@ -1,0 +1,60 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import CustomerForm, { CustomerFormValues } from '@/components/admin/customers/CustomerForm'
+import { CustomerStore, loadMockCustomers } from '@/core/store/customer'
+import { mockCustomers } from '@/lib/mock-customers'
+import type { CustomerSchema } from '@/lib/schema/customer'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function EditCustomerPage({ params }: { params: { id: string } }) {
+  const router = useRouter()
+  const { id } = params
+  const [customer, setCustomer] = useState<CustomerSchema | undefined>()
+
+  useEffect(() => {
+    loadMockCustomers(mockCustomers as unknown as CustomerSchema[])
+    if (id !== 'new') {
+      setCustomer(CustomerStore.getById(id))
+    }
+  }, [id])
+
+  const handleSubmit = (values: CustomerFormValues & { tags: string[] }) => {
+    if (id === 'new') {
+      CustomerStore.create(values as Omit<CustomerSchema, 'id' | 'createdAt'>)
+    } else {
+      CustomerStore.update(id, values)
+    }
+    router.push('/admin/customers')
+  }
+
+  if (id !== 'new' && !customer) {
+    return <div className="p-4">ไม่พบข้อมูลลูกค้า</div>
+  }
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center space-x-4 mb-4">
+        <Link href="/admin/customers">
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h1 className="text-lg font-bold">{id === 'new' ? 'สร้างลูกค้า' : 'แก้ไขลูกค้า'}</h1>
+      </div>
+      <div className="max-w-md">
+        <CustomerForm
+          defaultValues={{
+            name: customer?.name,
+            phone: customer?.phone,
+            tags: customer?.tags?.join(', '),
+            note: customer?.note,
+          }}
+          onSubmit={handleSubmit}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/buttons/button"
+import { Edit, Plus } from "lucide-react"
 import CustomerPopup from "@/core/ui/CustomerPopup"
 import { useCustomerGroups, CustomerGroup } from "@/hooks/useCustomerGroups"
 
@@ -15,7 +18,14 @@ export default function AdminCustomersPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-lg font-bold mb-4">กลุ่มลูกค้าตามแท็ก</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-bold">กลุ่มลูกค้าตามแท็ก</h1>
+        <Link href="/admin/customers/edit/new">
+          <Button size="sm">
+            <Plus className="w-4 h-4 mr-1" /> สร้างลูกค้าใหม่
+          </Button>
+        </Link>
+      </div>
       <div className="mb-4">
         <select
           className="border rounded px-2 py-1 text-sm"
@@ -34,6 +44,7 @@ export default function AdminCustomersPage() {
             <th className="text-left font-medium p-2">ชื่อลูกค้า</th>
             <th className="text-left font-medium p-2">แท็กยอดนิยม</th>
             <th className="text-left font-medium p-2">จำนวนบิล</th>
+            <th className="text-left font-medium p-2">การจัดการ</th>
           </tr>
         </thead>
         <tbody>
@@ -68,6 +79,13 @@ function CustomerRow({ group }: { group: CustomerGroup }) {
         ))}
       </td>
       <td className="p-2">{group.totalBills}</td>
+      <td className="p-2">
+        <Link href={`/admin/customers/edit/${group.customer.id}`}>
+          <Button variant="outline" size="icon">
+            <Edit className="w-4 h-4" />
+          </Button>
+        </Link>
+      </td>
     </tr>
   )
 }

--- a/components/admin/customers/CustomerForm.tsx
+++ b/components/admin/customers/CustomerForm.tsx
@@ -1,0 +1,97 @@
+"use client"
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/inputs/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/buttons/button'
+
+const schema = z.object({
+  name: z.string().min(1, 'กรุณากรอกชื่อ'),
+  phone: z.string().min(1, 'กรุณากรอกเบอร์โทร'),
+  tags: z.string().optional(),
+  note: z.string().optional(),
+})
+
+export type CustomerFormValues = z.infer<typeof schema>
+
+export default function CustomerForm({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues?: Partial<CustomerFormValues>
+  onSubmit: (values: CustomerFormValues & { tags: string[] }) => void
+}) {
+  const form = useForm<CustomerFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: defaultValues?.name ?? '',
+      phone: defaultValues?.phone ?? '',
+      tags: defaultValues?.tags ?? '',
+      note: defaultValues?.note ?? '',
+    },
+  })
+
+  const handleSubmit = (values: CustomerFormValues) => {
+    onSubmit({ ...values, tags: values.tags ? values.tags.split(',').map(t => t.trim()).filter(Boolean) : [] })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+        <FormField
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>ชื่อ</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>เบอร์โทร</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="tags"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>แท็ก (คั่นด้วย comma)</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          name="note"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>หมายเหตุ</FormLabel>
+              <FormControl>
+                <Textarea rows={3} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="pt-2 flex justify-end">
+          <Button type="submit">บันทึก</Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/core/store/customer.ts
+++ b/core/store/customer.ts
@@ -1,0 +1,51 @@
+import type { CustomerSchema } from '@/lib/schema/customer'
+
+const mockData: CustomerSchema[] = [
+  {
+    id: '1',
+    name: 'John Doe',
+    phone: '0812345678',
+    address: '123 Main St',
+    tags: ['VIP'],
+    createdAt: new Date().toISOString(),
+    email: 'john@example.com',
+    note: 'Frequent buyer',
+  },
+]
+
+let customers = [...mockData]
+
+export const CustomerStore = {
+  getById(id: string) {
+    return customers.find(c => c.id === id)
+  },
+
+  searchByName(name: string) {
+    return customers.filter(c => c.name.toLowerCase().includes(name.toLowerCase()))
+  },
+
+  filterByTag(tag: string) {
+    return customers.filter(c => c.tags.includes(tag))
+  },
+
+  create(data: Omit<CustomerSchema, 'id' | 'createdAt'>) {
+    const customer: CustomerSchema = {
+      id: Date.now().toString(),
+      createdAt: new Date().toISOString(),
+      ...data,
+    }
+    customers.push(customer)
+    return customer
+  },
+
+  update(id: string, data: Partial<Omit<CustomerSchema, 'id' | 'createdAt'>>) {
+    const idx = customers.findIndex(c => c.id === id)
+    if (idx === -1) return undefined
+    customers[idx] = { ...customers[idx], ...data }
+    return customers[idx]
+  },
+}
+
+export function loadMockCustomers(data: CustomerSchema[]) {
+  customers = [...data]
+}

--- a/lib/schema/customer.ts
+++ b/lib/schema/customer.ts
@@ -1,0 +1,10 @@
+export interface CustomerSchema {
+  id: string
+  name: string
+  phone: string
+  address: string
+  tags: string[]
+  createdAt: string
+  email?: string
+  note?: string
+}


### PR DESCRIPTION
## Summary
- define `CustomerSchema` to outline fields for a customer
- implement a basic in-memory `CustomerStore`
- create reusable `CustomerForm` using react-hook-form and zod
- add customer edit page with form
- update customer list with create button and edit actions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d871df7d48325a5670489a18c7459