### PR TITLE
Implement customer creation flow

### DIFF
--- a/app/admin/customers/create/page.tsx
+++ b/app/admin/customers/create/page.tsx
@@ -1,0 +1,31 @@
+"use client"
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import CustomerForm, { CustomerFormData } from "@/components/admin/customers/CustomerForm"
+import { useCustomerStore } from "@/core/store"
+
+export default function CreateCustomerPage() {
+  const router = useRouter()
+  const create = useCustomerStore(s => s.create)
+  const customers = useCustomerStore(s => s.customers)
+  const [loading, setLoading] = useState(false)
+
+  const handleSave = (data: CustomerFormData) => {
+    if (customers.some(c => c.phone === data.phone)) {
+      toast.error("เบอร์โทรนี้มีอยู่แล้ว")
+      return
+    }
+    setLoading(true)
+    create(data)
+    toast.success("เพิ่มลูกค้าแล้ว")
+    router.push("/admin/customers")
+  }
+
+  return (
+    <div className="container mx-auto max-w-md py-8">
+      <h1 className="text-2xl font-bold mb-4">เพิ่มลูกค้าใหม่</h1>
+      <CustomerForm onSubmit={handleSave} loading={loading} />
+    </div>
+  )
+}

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
 import CustomerPopup from "@/core/ui/CustomerPopup"
 import { useCustomerGroups, CustomerGroup } from "@/hooks/useCustomerGroups"
+import CustomerListEmptyState from "@/components/admin/customers/CustomerListEmptyState"
 
 export default function AdminCustomersPage() {
   const { groups, topTags } = useCustomerGroups()
@@ -12,6 +13,10 @@ export default function AdminCustomersPage() {
   const filtered = groups.filter(g =>
     !filter || g.tags.some(t => t.tag === filter)
   )
+
+  if (groups.length === 0) {
+    return <CustomerListEmptyState />
+  }
 
   return (
     <div className="p-4">

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   MailQuestion,
   Megaphone,
   MessageCircle,
+  UserPlus,
   Percent,
   Settings,
   Target,
@@ -46,6 +47,7 @@ const groups = [
     label: "Customers",
     items: [
       { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "customers" },
+      { href: "/admin/customers/create", label: "เพิ่มลูกค้าใหม่", icon: UserPlus, feature: "customers" },
     ],
   },
   {

--- a/components/admin/customers/CustomerForm.tsx
+++ b/components/admin/customers/CustomerForm.tsx
@@ -1,0 +1,105 @@
+"use client"
+import { useEffect, useRef, useState } from "react"
+import { Input } from "@/components/ui/inputs/input"
+import { Button } from "@/components/ui/buttons/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+
+export interface CustomerFormData {
+  name: string
+  phone: string
+  tags: string[]
+  note: string
+}
+
+export default function CustomerForm({
+  onSubmit,
+  loading = false,
+}: {
+  onSubmit: (data: CustomerFormData) => void
+  loading?: boolean
+}) {
+  const [name, setName] = useState("")
+  const [phone, setPhone] = useState("")
+  const [tagInput, setTagInput] = useState("")
+  const [tags, setTags] = useState<string[]>([])
+  const [note, setNote] = useState("")
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    nameRef.current?.focus()
+  }, [])
+
+  const addTag = () => {
+    const t = tagInput.trim()
+    if (t && !tags.includes(t)) {
+      setTags([...tags, t])
+    }
+    setTagInput("")
+  }
+
+  const removeTag = (tag: string) => setTags(tags.filter(t => t !== tag))
+
+  const disabled = !name.trim() || !phone.trim() || loading
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (disabled) return
+    onSubmit({ name: name.trim(), phone: phone.trim(), tags, note })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input
+        ref={nameRef}
+        placeholder="ชื่อลูกค้า"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <Input
+        placeholder="เบอร์โทร"
+        value={phone}
+        onChange={e => setPhone(e.target.value)}
+      />
+      <div className="space-y-2">
+        <div className="flex space-x-2">
+          <Input
+            placeholder="เพิ่มแท็ก"
+            value={tagInput}
+            onChange={e => setTagInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                addTag()
+              }
+            }}
+          />
+          <Button type="button" onClick={addTag} disabled={!tagInput.trim()}>
+            เพิ่ม
+          </Button>
+        </div>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {tags.map(tag => (
+              <Badge
+                key={tag}
+                className="cursor-pointer"
+                onClick={() => removeTag(tag)}
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+      <Textarea
+        placeholder="หมายเหตุ"
+        value={note}
+        onChange={e => setNote(e.target.value)}
+      />
+      <Button type="submit" disabled={disabled} className="w-full">
+        บันทึก
+      </Button>
+    </form>
+  )
+}

--- a/components/admin/customers/CustomerListEmptyState.tsx
+++ b/components/admin/customers/CustomerListEmptyState.tsx
@@ -1,0 +1,20 @@
+"use client"
+import Link from "next/link"
+import { UserPlus } from "lucide-react"
+import { Button } from "@/components/ui/buttons/button"
+import EmptyState from "@/components/ui/EmptyState"
+
+export default function CustomerListEmptyState() {
+  return (
+    <EmptyState
+      icon={<UserPlus className="h-10 w-10 text-muted-foreground" />}
+      title="ยังไม่มีลูกค้า"
+      description="เพิ่มลูกค้าเพื่อเริ่มต้นใช้งานระบบ"
+      action={
+        <Link href="/admin/customers/create">
+          <Button>เพิ่มลูกค้าใหม่</Button>
+        </Link>
+      }
+    />
+  )
+}

--- a/core/store/customers.ts
+++ b/core/store/customers.ts
@@ -6,6 +6,10 @@ interface CustomerStore {
   customers: Customer[]
   addCustomer: (c: Customer) => void
   updateCustomer: (id: string, data: Partial<Customer>) => void
+  /**
+   * Create a new customer with automatic id and timestamp
+   */
+  create: (data: Omit<Customer, 'id' | 'createdAt'>) => Customer
   refresh: () => void
 }
 
@@ -18,6 +22,16 @@ export const useCustomerStore = create<CustomerStore>((set) => ({
   updateCustomer: (id, data) => {
     update(id, data)
     set({ customers: getCustomers() })
+  },
+  create: (data) => {
+    const customer: Customer = {
+      id: Date.now().toString(),
+      createdAt: new Date().toISOString(),
+      ...data,
+    }
+    add(customer)
+    set({ customers: getCustomers() })
+    return customer
   },
   refresh: () => set({ customers: getCustomers() }),
 }))


### PR DESCRIPTION
## Summary
- add CustomerForm and empty state components
- add admin customer creation page
- show empty state when no customers
- extend CustomerStore with create method and update sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d89575b188325baf84296e5b59aa3