### PR TITLE
Add bill summary component

### DIFF
--- a/app/admin/bill/create/page.tsx
+++ b/app/admin/bill/create/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/buttons/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { OrderItemsRepeater } from "@/components/OrderItemsRepeater"
 import { OrderSummary } from "@/components/order/order-summary"
+import BillSummary, { getSubtotal, calculateTotal } from "@/components/admin/bill/BillSummary"
 import { orderDb } from "@/lib/order-database"
 import { createBill } from "@/lib/mock-bills"
 import type { OrderItem } from "@/types/order"
@@ -20,11 +21,8 @@ export default function AdminBillCreatePage() {
   const [loading, setLoading] = useState(false)
   const [billLink, setBillLink] = useState<string | null>(null)
 
-  const subtotal = items.reduce(
-    (sum, item) => sum + item.price * item.quantity * (1 - (item.discount ?? 0) / 100),
-    0,
-  )
-  const total = subtotal - discount + shippingCost + tax
+  const subtotal = getSubtotal(items)
+  const total = calculateTotal(items, shippingCost, discount) + tax
 
   const create = async () => {
     if (items.length === 0) {
@@ -109,13 +107,16 @@ export default function AdminBillCreatePage() {
                 )}
               </CardContent>
             </Card>
-          </div>
         </div>
-        <div className="sm:hidden fixed bottom-0 left-0 right-0 p-4 bg-white border-t">
-          <Button className="w-full" onClick={create} disabled={loading}>
-            บันทึกบิล
-          </Button>
-        </div>
+      </div>
+      <div className="max-w-md mx-auto lg:max-w-none">
+        <BillSummary items={items} discount={discount} shipping={shippingCost} />
+      </div>
+      <div className="sm:hidden fixed bottom-0 left-0 right-0 p-4 bg-white border-t">
+        <Button className="w-full" onClick={create} disabled={loading}>
+          บันทึกบิล
+        </Button>
+      </div>
       </div>
     </div>
   )

--- a/components/admin/bill/BillSummary.tsx
+++ b/components/admin/bill/BillSummary.tsx
@@ -1,0 +1,54 @@
+"use client"
+import type { OrderItem } from "@/types/order"
+import { formatCurrencyTHB } from "@/lib/format/currency"
+
+export function getSubtotal(items: OrderItem[]): number {
+  return items.reduce((sum, it) => sum + it.price * it.quantity, 0)
+}
+
+export function applyDiscount(subtotal: number, discount: number): number {
+  return subtotal - discount
+}
+
+export function calculateTotal(
+  items: OrderItem[],
+  shipping: number,
+  discount: number,
+): number {
+  return applyDiscount(getSubtotal(items), discount) + shipping
+}
+
+interface BillSummaryProps {
+  items: OrderItem[]
+  discount: number
+  shipping: number
+}
+
+export default function BillSummary({
+  items,
+  discount,
+  shipping,
+}: BillSummaryProps) {
+  const subtotal = getSubtotal(items)
+  const total = calculateTotal(items, shipping, discount)
+  return (
+    <div className="bg-white rounded border text-sm divide-y">
+      <div className="flex justify-between p-2">
+        <span>รายการ</span>
+        <span>{formatCurrencyTHB(subtotal)}</span>
+      </div>
+      <div className="flex justify-between p-2">
+        <span>ค่าจัดส่ง</span>
+        <span>{formatCurrencyTHB(shipping)}</span>
+      </div>
+      <div className="flex justify-between p-2">
+        <span>ส่วนลด</span>
+        <span>-{formatCurrencyTHB(discount)}</span>
+      </div>
+      <div className="flex justify-between p-2 font-semibold">
+        <span>รวมทั้งหมด</span>
+        <span>{formatCurrencyTHB(total)}</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `<BillSummary />` with subtotal, discount, shipping and total
- use `BillSummary` in admin bill create page
- compute totals via helper functions

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687d8ff6aa2483258a99586b6b62d8a7