### PR TITLE
Add payment method selector for bills

### DIFF
--- a/components/PaymentMethodSelector.tsx
+++ b/components/PaymentMethodSelector.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import type { FC } from "react"
+
+export type PaymentMethod =
+  | "cod"
+  | "bank_transfer"
+  | "promptpay"
+  | "credit_card"
+
+interface Props {
+  value: PaymentMethod | null
+  onChange: (method: PaymentMethod) => void
+}
+
+const labels: Record<PaymentMethod, string> = {
+  cod: "COD",
+  bank_transfer: "โอนเงิน",
+  promptpay: "พร้อมเพย์",
+  credit_card: "บัตร",
+}
+
+const icons: Record<PaymentMethod, string> = {
+  cod: "💵",
+  bank_transfer: "🏦",
+  promptpay: "📱",
+  credit_card: "💳",
+}
+
+const PaymentMethodSelector: FC<Props> = ({ value, onChange }) => {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value ?? undefined}
+      onValueChange={(v) => v && onChange(v as PaymentMethod)}
+      className="flex"
+    >
+      {Object.keys(labels).map((m) => (
+        <ToggleGroupItem key={m} value={m} className="flex items-center gap-1">
+          {icons[m as PaymentMethod]} {labels[m as PaymentMethod]}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}
+
+export default PaymentMethodSelector

--- a/components/bill/BillForm.tsx
+++ b/components/bill/BillForm.tsx
@@ -9,7 +9,7 @@ export default function BillForm() {
     customerName: '',
     customerPhone: '',
     note: '',
-    paymentMethod: 'cash',
+    paymentMethod: 'bank_transfer',
     total: 0,
     items: [{ name: '', quantity: 1, price: 0 }],
   })

--- a/lib/mock-bills.ts
+++ b/lib/mock-bills.ts
@@ -12,6 +12,7 @@ export function createBill(
   orderId: string,
   status: BillStatus = "unpaid",
   dueDate?: string,
+  paymentMethod: 'cod' | 'bank_transfer' | 'promptpay' | 'credit_card' = 'bank_transfer',
 ): Bill {
   const order = mockOrders.find((o) => o.id === orderId)
   const customer = order && mockCustomers.find((c) => c.id === order.customerId)
@@ -23,6 +24,7 @@ export function createBill(
     payments: [],
     createdAt: new Date().toISOString(),
     dueDate,
+    paymentMethod,
   }
   if (customer?.muted) {
     bill.hidden = true

--- a/libs/schema/bill.ts
+++ b/libs/schema/bill.ts
@@ -11,7 +11,7 @@ export const BillSchema = z.object({
   customerPhone: z.string().optional(),
   items: z.array(BillItemSchema),
   note: z.string().optional(),
-  paymentMethod: z.enum(['cash', 'promptpay', 'transfer']),
+  paymentMethod: z.enum(['cod', 'bank_transfer', 'promptpay', 'credit_card']),
   total: z.number(),
 })
 

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -12,6 +12,7 @@ export interface AdminBill {
   items: BillItem[]
   shipping: number
   note: string
+  paymentMethod: 'cod' | 'bank_transfer' | 'promptpay' | 'credit_card'
   status: 'pending' | 'unpaid' | 'paid' | 'shipped' | 'cancelled'
   tags: string[]
   createdAt: string
@@ -28,6 +29,7 @@ export const mockBills: AdminBill[] = [
     ],
     shipping: 50,
     note: '',
+    paymentMethod: 'bank_transfer',
     status: 'pending',
     tags: ['COD', 'VIP'],
     createdAt: new Date().toISOString(),

--- a/types/bill.ts
+++ b/types/bill.ts
@@ -13,6 +13,7 @@ export interface Bill {
   orderId: string
   phone?: string
   pin?: string
+  paymentMethod?: 'cod' | 'bank_transfer' | 'promptpay' | 'credit_card'
   status: BillStatus
   payments: BillPayment[]
   createdAt: string


### PR DESCRIPTION
## Summary
- extend bill schema with `paymentMethod` enum
- store payment method on mock bills
- update mock API for creating bills
- add `<PaymentMethodSelector/>` component
- allow choosing payment method when creating a bill
- adjust sample BillForm defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d914251f083258d17c5700aa59782