### PR TITLE
Add bill footer actions

### DIFF
--- a/components/admin/bill/BillSummary.tsx
+++ b/components/admin/bill/BillSummary.tsx
@@ -1,0 +1,54 @@
+"use client"
+import type { OrderItem } from "@/types/order"
+import { formatCurrencyTHB } from "@/lib/format/currency"
+
+export function getSubtotal(items: OrderItem[]): number {
+  return items.reduce((sum, it) => sum + it.price * it.quantity, 0)
+}
+
+export function applyDiscount(subtotal: number, discount: number): number {
+  return subtotal - discount
+}
+
+export function calculateTotal(
+  items: OrderItem[],
+  shipping: number,
+  discount: number,
+): number {
+  return applyDiscount(getSubtotal(items), discount) + shipping
+}
+
+interface BillSummaryProps {
+  items: OrderItem[]
+  discount: number
+  shipping: number
+}
+
+export default function BillSummary({
+  items,
+  discount,
+  shipping,
+}: BillSummaryProps) {
+  const subtotal = getSubtotal(items)
+  const total = calculateTotal(items, shipping, discount)
+  return (
+    <div className="bg-white rounded border text-sm divide-y">
+      <div className="flex justify-between p-2">
+        <span>รายการ</span>
+        <span>{formatCurrencyTHB(subtotal)}</span>
+      </div>
+      <div className="flex justify-between p-2">
+        <span>ค่าจัดส่ง</span>
+        <span>{formatCurrencyTHB(shipping)}</span>
+      </div>
+      <div className="flex justify-between p-2">
+        <span>ส่วนลด</span>
+        <span>-{formatCurrencyTHB(discount)}</span>
+      </div>
+      <div className="flex justify-between p-2 font-semibold">
+        <span>รวมทั้งหมด</span>
+        <span>{formatCurrencyTHB(total)}</span>
+      </div>
+    </div>
+  )
+}

--- a/components/bill/BillFooterActions.tsx
+++ b/components/bill/BillFooterActions.tsx
@@ -1,0 +1,69 @@
+"use client"
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/buttons/button"
+import { ConfirmationDialog } from "@/components/order/confirmation-dialog"
+
+interface BillFooterActionsProps {
+  validate: () => boolean
+  onSubmit: () => Promise<void> | void
+  onClear: () => void
+  submitting?: boolean
+}
+
+export default function BillFooterActions({
+  validate,
+  onSubmit,
+  onClear,
+  submitting = false,
+}: BillFooterActionsProps) {
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "Enter") {
+        e.preventDefault()
+        handleSubmit()
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  })
+
+  const handleSubmit = () => {
+    if (!validate()) return
+    setShowConfirm(true)
+  }
+
+  const handleClear = () => {
+    if (confirm("ต้องการล้างข้อมูลทั้งหมดหรือไม่?")) {
+      onClear()
+    }
+  }
+
+  const confirmSubmit = async () => {
+    await onSubmit()
+    setShowConfirm(false)
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 space-x-2 flex">
+      <Button onClick={handleSubmit} disabled={submitting} className="px-4">
+        ยืนยันบิล
+      </Button>
+      <Button variant="outline" onClick={handleClear} className="px-4">
+        ล้างฟอร์ม
+      </Button>
+      <Link href="/admin/bills" className="no-underline">
+        <Button variant="outline" className="px-4">กลับไปหน้ารายการ</Button>
+      </Link>
+      <ConfirmationDialog
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="ยืนยันการสร้างบิล"
+        description="ต้องการยืนยันการสร้างบิลหรือไม่?"
+        onConfirm={confirmSubmit}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `<BillFooterActions>` component for confirming bill creation
- integrate footer actions into manual bill creation page
- add `BillSummary` module
- resolve merge conflicts in `app/admin/bill/create/page.tsx`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687d96b96a648325a77ffc09752ea648