### PR TITLE
Add printable receipt route

### DIFF
--- a/app/admin/bill/[billId]/print/page.tsx
+++ b/app/admin/bill/[billId]/print/page.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { useRef } from "react"
+import BillPrintLayout from '@/components/bill/BillPrintLayout'
+import BillHeader from '@/components/bill/BillHeader'
+import BillItemTable from '@/components/bill/BillItemTable'
+import BillSummaryTotals from '@/components/bill/BillSummaryTotals'
+import BillPaymentQR from '@/components/bill/BillPaymentQR'
+import BillNoteBox from '@/components/bill/BillNoteBox'
+import BillPrintDate from '@/components/bill/BillPrintDate'
+import BillPrintActions from '@/components/bill/BillPrintActions'
+import { useBillData } from '@/lib/hooks/useBillData'
+
+export default function AdminBillPrint({ params }: { params: { billId: string } }) {
+  const bill = useBillData(params.billId)
+  const printRef = useRef<HTMLDivElement>(null)
+
+  if (!bill) {
+    return <div className="p-4 text-center">Loading...</div>
+  }
+
+  const subtotal = bill.items.reduce((s, it) => s + it.price * it.quantity, 0)
+
+  return (
+    <div ref={printRef} data-printable="bill">
+      <BillPrintLayout>
+        <BillPrintActions />
+        <BillHeader />
+        <BillPrintDate id={bill.id} />
+        <div data-printable="items">
+          <BillItemTable items={bill.items} />
+        </div>
+        <div data-printable="summary">
+          <BillSummaryTotals subtotal={subtotal} discount={bill.discount} shipping={bill.shipping} />
+        </div>
+        <BillPaymentQR value={bill.id} />
+        <BillNoteBox note={bill.note} />
+      </BillPrintLayout>
+    </div>
+  )
+}

--- a/app/admin/bill/[billId]/view/page.tsx
+++ b/app/admin/bill/[billId]/view/page.tsx
@@ -1,0 +1,36 @@
+"use client"
+import Link from 'next/link'
+import { Button } from '@/components/ui/buttons/button'
+import BillHeader from '@/components/bill/BillHeader'
+import BillItemTable from '@/components/bill/BillItemTable'
+import BillSummaryTotals from '@/components/bill/BillSummaryTotals'
+import BillNoteBox from '@/components/bill/BillNoteBox'
+import { useBillData } from '@/lib/hooks/useBillData'
+
+export default function AdminBillView({ params }: { params: { billId: string } }) {
+  const bill = useBillData(params.billId)
+
+  if (!bill) {
+    return <div className="p-4 text-center">Loading...</div>
+  }
+
+  const subtotal = bill.items.reduce((s, it) => s + it.price * it.quantity, 0)
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">บิล {bill.id}</h1>
+        <Button variant="outline" onClick={() => window.open(`/admin/bill/${bill.id}/print`, '_blank')}>
+          พิมพ์ใบเสร็จ
+        </Button>
+      </div>
+      <BillHeader />
+      <BillItemTable items={bill.items} />
+      <BillSummaryTotals subtotal={subtotal} discount={bill.discount} shipping={bill.shipping} />
+      <BillNoteBox note={bill.note} />
+      <Link href="/admin/bills" className="block mt-4">
+        <Button variant="outline">กลับรายการบิล</Button>
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/admin/bill/[billId]/print` for customer receipt printing
- add `/admin/bill/[billId]/view` page with Print button

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687dcd0677788325878b677711c1f045