### PR TITLE
Add public receipt view

### DIFF
--- a/app/receipt/[billId]/ReceiptPageClient.tsx
+++ b/app/receipt/[billId]/ReceiptPageClient.tsx
@@ -1,0 +1,25 @@
+"use client"
+import ReceiptLayout from '@/components/receipt/ReceiptLayout'
+import type { BillData } from '@/lib/hooks/useBillData'
+import { Button } from '@/components/ui/buttons/button'
+import { Copy } from 'lucide-react'
+
+export default function ReceiptPageClient({ bill }: { bill: BillData }) {
+  const copyLink = () => {
+    if (typeof window !== 'undefined') {
+      navigator.clipboard.writeText(window.location.href)
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-4 flex flex-col items-center space-y-4">
+      <h1 className="text-lg font-semibold">ใบเสร็จคำสั่งซื้อของคุณ</h1>
+      <Button variant="outline" size="sm" onClick={copyLink} className="print:hidden">
+        <Copy className="w-4 h-4 mr-2" /> คัดลอกลิงก์
+      </Button>
+      <div className="w-full max-w-xl">
+        <ReceiptLayout bill={bill} />
+      </div>
+    </div>
+  )
+}

--- a/app/receipt/[billId]/page.tsx
+++ b/app/receipt/[billId]/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import ReceiptPageClient from './ReceiptPageClient'
+import { getBills } from '@/core/mock/store'
+
+export async function generateMetadata({ params }: { params: { billId: string } }): Promise<Metadata> {
+  const bill = getBills().find(b => b.id === params.billId)
+  const title = bill ? `ใบเสร็จ ${bill.id}` : 'ไม่พบใบเสร็จ'
+  const description = 'ใบเสร็จคำสั่งซื้อของคุณ'
+  return {
+    title,
+    description,
+    openGraph: { title, description },
+    robots: { index: false },
+  }
+}
+
+export default function ReceiptPage({ params }: { params: { billId: string } }) {
+  const bill = getBills().find(b => b.id === params.billId)
+  if (!bill) {
+    return <div className="min-h-screen flex items-center justify-center">ไม่พบใบเสร็จ</div>
+  }
+  return <ReceiptPageClient bill={bill} />
+}

--- a/components/receipt/ReceiptLayout.tsx
+++ b/components/receipt/ReceiptLayout.tsx
@@ -1,0 +1,22 @@
+import BillPrintLayout from '@/components/bill/BillPrintLayout'
+import BillHeader from '@/components/bill/BillHeader'
+import BillItemTable from '@/components/bill/BillItemTable'
+import BillSummaryTotals from '@/components/bill/BillSummaryTotals'
+import BillPaymentQR from '@/components/bill/BillPaymentQR'
+import BillNoteBox from '@/components/bill/BillNoteBox'
+import BillPrintDate from '@/components/bill/BillPrintDate'
+import type { BillData } from '@/lib/hooks/useBillData'
+
+export default function ReceiptLayout({ bill }: { bill: BillData }) {
+  const subtotal = bill.items.reduce((s, it) => s + it.price * it.quantity, 0)
+  return (
+    <BillPrintLayout>
+      <BillHeader />
+      <BillPrintDate id={bill.id} />
+      <BillItemTable items={bill.items} />
+      <BillSummaryTotals subtotal={subtotal} discount={bill.discount} shipping={bill.shipping} />
+      <BillPaymentQR value={bill.id} />
+      <BillNoteBox note={bill.note} />
+    </BillPrintLayout>
+  )
+}


### PR DESCRIPTION
## Summary
- add ReceiptLayout component using existing print components
- show public receipt page with copy link button
- dynamic metadata for receipt pages

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687dfe01de1883259c346705d14a8da1