### PR TITLE
Add payment confirmation popup

### DIFF
--- a/app/receipt/[billId]/ReceiptPageClient.tsx
+++ b/app/receipt/[billId]/ReceiptPageClient.tsx
@@ -1,10 +1,20 @@
 "use client"
 import ReceiptLayout from '@/components/receipt/ReceiptLayout'
-import type { BillData } from '@/lib/hooks/useBillData'
+import type { AdminBill } from '@/mock/bills'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/buttons/button'
 import { Copy } from 'lucide-react'
+import PaymentConfirmationPopup from '@/components/PaymentConfirmationPopup'
+import { getPaymentConfirmations } from '@/core/mock/store'
 
-export default function ReceiptPageClient({ bill }: { bill: BillData }) {
+export default function ReceiptPageClient({ bill }: { bill: AdminBill }) {
+  const [open, setOpen] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    const exist = getPaymentConfirmations(bill.id)
+    if (exist.length > 0) setSubmitted(true)
+  }, [bill.id])
   const copyLink = () => {
     if (typeof window !== 'undefined') {
       navigator.clipboard.writeText(window.location.href)
@@ -17,9 +27,20 @@ export default function ReceiptPageClient({ bill }: { bill: BillData }) {
       <Button variant="outline" size="sm" onClick={copyLink} className="print:hidden">
         <Copy className="w-4 h-4 mr-2" /> คัดลอกลิงก์
       </Button>
-      <div className="w-full max-w-xl">
+      <div className="w-full max-w-xl space-y-4">
         <ReceiptLayout bill={bill} />
+        {['pending','unpaid'].includes(bill.status) && !submitted && (
+          <div className="text-center">
+            <Button onClick={() => setOpen(true)}>แจ้งชำระเงิน</Button>
+          </div>
+        )}
       </div>
+      <PaymentConfirmationPopup
+        billId={bill.id}
+        open={open}
+        onClose={() => setOpen(false)}
+        onSubmitted={() => setSubmitted(true)}
+      />
     </div>
   )
 }

--- a/components/PaymentConfirmationPopup.tsx
+++ b/components/PaymentConfirmationPopup.tsx
@@ -1,0 +1,101 @@
+"use client"
+import { useState } from 'react'
+import ModalWrapper from '@/components/ui/ModalWrapper'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { addPaymentConfirmation } from '@/core/mock/store'
+import { useToast } from '@/hooks/use-toast'
+
+export default function PaymentConfirmationPopup({
+  billId,
+  open,
+  onClose,
+  onSubmitted,
+}: {
+  billId: string
+  open: boolean
+  onClose: () => void
+  onSubmitted?: () => void
+}) {
+  const { toast } = useToast()
+  const [amount, setAmount] = useState('')
+  const [method, setMethod] = useState('Bank')
+  const [datetime, setDatetime] = useState(() => new Date().toISOString().slice(0,16))
+  const [slip, setSlip] = useState<File | null>(null)
+  const [preview, setPreview] = useState(false)
+
+  const handleSubmit = () => {
+    if (!amount || !method || !datetime) {
+      toast({ title: 'กรุณากรอกข้อมูลให้ครบ', variant: 'destructive' })
+      return
+    }
+    setPreview(true)
+  }
+
+  const handleConfirm = () => {
+    addPaymentConfirmation({
+      billId,
+      amount: parseFloat(amount),
+      method,
+      datetime: new Date(datetime).toISOString(),
+      slip: slip?.name,
+    })
+    toast({ title: 'แจ้งชำระเงินสำเร็จ' })
+    onSubmitted?.()
+    onClose()
+  }
+
+  return (
+    <ModalWrapper open={open} onClose={onClose}>
+      {preview ? (
+        <div className="space-y-4 w-72">
+          <h2 className="text-lg font-bold">ตรวจสอบข้อมูล</h2>
+          <p>จำนวนเงิน: {amount}</p>
+          <p>ช่องทางโอน: {method}</p>
+          <p>วันที่เวลา: {datetime}</p>
+          {slip && <p>สลิป: {slip.name}</p>}
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setPreview(false)}>
+              แก้ไข
+            </Button>
+            <Button onClick={handleConfirm}>ยืนยัน</Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4 w-72">
+          <h2 className="text-lg font-bold">แจ้งชำระเงิน</h2>
+          <div>
+            <label className="text-sm">จำนวนเงินที่โอน</label>
+            <Input type="number" value={amount} onChange={e => setAmount(e.target.value)} />
+          </div>
+          <div>
+            <label className="text-sm">ช่องทางโอน</label>
+            <Select value={method} onValueChange={setMethod}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="เลือกช่องทาง" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Bank">Bank</SelectItem>
+                <SelectItem value="PromptPay">PromptPay</SelectItem>
+                <SelectItem value="Other">Other</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="text-sm">วันที่-เวลาโอน</label>
+            <Input type="datetime-local" value={datetime} onChange={e => setDatetime(e.target.value)} />
+          </div>
+          <div>
+            <label className="text-sm">แนบสลิป (ไม่บังคับ)</label>
+            <Input type="file" onChange={e => setSlip(e.target.files?.[0] ?? null)} />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={onClose}>ยกเลิก</Button>
+            <Button onClick={handleSubmit}>ส่งข้อมูล</Button>
+          </div>
+        </div>
+      )}
+    </ModalWrapper>
+  )
+}

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -4,12 +4,14 @@ export * from './fabrics'
 export * from './products'
 export * from './config'
 export * from './bills'
+export * from './paymentConfirmations'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetCustomers, regenerateCustomers } from './customers'
 import { resetFabrics, regenerateFabrics } from './fabrics'
 import { resetProducts, regenerateProducts } from './products'
 import { resetBills, regenerateBills } from './bills'
+import { resetPaymentConfirmations } from './paymentConfirmations'
 
 export function resetStore() {
   resetOrders()
@@ -17,6 +19,7 @@ export function resetStore() {
   resetFabrics()
   resetProducts()
   resetBills()
+  resetPaymentConfirmations()
 }
 
 export function generateMockData() {

--- a/core/mock/store/paymentConfirmations.ts
+++ b/core/mock/store/paymentConfirmations.ts
@@ -1,0 +1,37 @@
+import { loadFromStorage, saveToStorage } from './persist'
+
+export interface PaymentConfirmation {
+  id: string
+  billId: string
+  amount: number
+  method: string
+  datetime: string
+  slip?: string
+}
+
+const KEY = 'mockStore_paymentConfirmations'
+
+let confirmations: PaymentConfirmation[] = loadFromStorage(KEY, [])
+
+function persist() {
+  saveToStorage(KEY, confirmations)
+}
+
+export function getPaymentConfirmations(billId: string) {
+  return confirmations.filter(c => c.billId === billId)
+}
+
+export function addPaymentConfirmation(data: Omit<PaymentConfirmation, 'id'>) {
+  const confirmation: PaymentConfirmation = {
+    ...data,
+    id: `pc-${Date.now()}`,
+  }
+  confirmations.push(confirmation)
+  persist()
+  return confirmation
+}
+
+export function resetPaymentConfirmations() {
+  confirmations = []
+  persist()
+}


### PR DESCRIPTION
## Summary
- add PaymentConfirmationPopup component
- store confirmations in `mockStore_paymentConfirmations`
- include popup on customer receipt page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e02200190832589f81ea159fb9b9c