### PR TITLE
Add mock shipping label page

### DIFF
--- a/app/admin/bill/[billId]/label/page.tsx
+++ b/app/admin/bill/[billId]/label/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+import Link from 'next/link'
+import { useRef } from 'react'
+import { ArrowLeft, PrinterIcon as Print } from 'lucide-react'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent } from '@/components/ui/cards/card'
+import { useBillData } from '@/lib/hooks/useBillData'
+import { getShippingProvider } from '@/mock/shipping'
+import ShippingProviderLogo from '@/components/ShippingProviderLogo'
+
+function genTracking() {
+  const n = Math.floor(100000000 + Math.random() * 900000000)
+  return `TH${n}`
+}
+
+export default function AdminBillLabelPage({ params }: { params: { billId: string } }) {
+  const bill = useBillData(params.billId)
+  const labelRef = useRef<HTMLDivElement>(null)
+
+  if (!bill) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">ไม่พบข้อมูลบิล</div>
+    )
+  }
+
+  const handlePrint = () => {
+    if (typeof window !== 'undefined') window.print()
+  }
+
+  const tracking = (bill as any).tracking || genTracking()
+  const provider = getShippingProvider()
+  const itemCount = bill.items.reduce((sum, it) => sum + it.quantity, 0)
+  const date = new Date().toLocaleDateString('th-TH')
+
+  return (
+    <div className="min-h-screen bg-white p-4">
+      <div className="print:hidden flex items-center justify-between mb-4">
+        <Link href={`/admin/bill/${bill.id}/view`}>
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <Button variant="outline" onClick={handlePrint}>
+          <Print className="mr-2 h-4 w-4" /> พิมพ์
+        </Button>
+      </div>
+      <Card ref={labelRef} className="max-w-sm mx-auto print:border-none">
+        <CardContent className="p-4 space-y-2 text-sm w-[80mm]">
+          <p className="font-bold text-lg">ใบปะหน้า</p>
+          <p>{bill.customer.name}</p>
+          <p className="whitespace-pre-line">{bill.customer.address}</p>
+          <p>โทร {bill.customer.phone}</p>
+          <p className="pt-2">บิล: {bill.id}</p>
+          <p>เลขพัสดุ: {tracking}</p>
+          <ShippingProviderLogo provider={provider} />
+          <p>จำนวน {itemCount} ชิ้น</p>
+          <p>วันที่ส่ง {date}</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/bill/[billId]/view/page.tsx
+++ b/app/admin/bill/[billId]/view/page.tsx
@@ -20,9 +20,14 @@ export default function AdminBillView({ params }: { params: { billId: string } }
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">บิล {bill.id}</h1>
-        <Button variant="outline" onClick={() => window.open(`/admin/bill/${bill.id}/print`, '_blank')}>
-          พิมพ์ใบเสร็จ
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => window.open(`/admin/bill/${bill.id}/print`, '_blank')}>
+            พิมพ์ใบเสร็จ
+          </Button>
+          <Button variant="outline" onClick={() => window.open(`/admin/bill/${bill.id}/label`, '_blank')}>
+            พิมพ์ใบปะหน้า
+          </Button>
+        </div>
       </div>
       <BillHeader />
       <BillItemTable items={bill.items} />

--- a/components/ShippingProviderLogo.tsx
+++ b/components/ShippingProviderLogo.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+export default function ShippingProviderLogo({ provider }: { provider?: string }) {
+  if (provider === 'Kerry') {
+    return (
+      <svg width="80" height="24" viewBox="0 0 80 24" aria-label="Kerry Express">
+        <rect width="80" height="24" fill="#ff6600" />
+        <text
+          x="40"
+          y="17"
+          textAnchor="middle"
+          fontSize="14"
+          fontWeight="bold"
+          fill="#fff"
+        >
+          KERRY
+        </text>
+      </svg>
+    )
+  }
+  if (provider === 'Flash') {
+    return (
+      <svg width="80" height="24" viewBox="0 0 80 24" aria-label="Flash Express">
+        <rect width="80" height="24" fill="#ffe600" />
+        <text
+          x="40"
+          y="17"
+          textAnchor="middle"
+          fontSize="14"
+          fontWeight="bold"
+          fill="#000"
+        >
+          FLASH
+        </text>
+      </svg>
+    )
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add standalone shipping label page with print ref
- remove binary provider logos and replace with inline SVGs
- show print shipping label button on bill view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e0d78d0648325ab8e61ffe11a7d46