### PR TITLE
Fix missing order option exports

### DIFF
--- a/types/order.ts
+++ b/types/order.ts
@@ -14,6 +14,8 @@ export interface OrderItem {
 
 import type { OrderStatus, PackingStatus } from './order-status'
 import { orderStatusOptions, packingStatusOptions } from './order-status'
+
+export { orderStatusOptions, packingStatusOptions } from './order-status'
 import type { Address } from './address'
 import type { CustomerInfo } from './customer-info'
 import type { Payment } from './payment'


### PR DESCRIPTION
## Summary
- re-export `orderStatusOptions` and `packingStatusOptions` from `types/order.ts`

## Testing
- `npm test`
- `npm run build` *(fails to show full output but no import warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687e3760d5648325af11f769d270bac5