### PR TITLE
Implement bill notify helpers

### DIFF
--- a/lib/__tests__/mock-bill-notify.test.ts
+++ b/lib/__tests__/mock-bill-notify.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { sendBillNotify, billNotifyLog, setBillNotifySettings, validateBillNotifySettings } from '../mock-bill-notify'
+import {
+  sendBillNotify,
+  billNotifyLog,
+  setBillNotifySettings,
+  validateBillNotifySettings,
+  billNotifySettings,
+  billNotifyTemplates,
+  billNotifyHistory,
+  setChannel,
+  setTemplate,
+  sendPreview,
+  loadBillNotifyData,
+} from '../mock-bill-notify'
 
 beforeEach(() => {
   for (const k in billNotifyLog) delete billNotifyLog[k]
   setBillNotifySettings({})
+  for (const k in billNotifyTemplates) delete (billNotifyTemplates as any)[k]
+  billNotifyHistory.length = 0
+  localStorage.clear()
 })
 
 describe('mock-bill-notify', () => {
@@ -21,5 +36,36 @@ describe('mock-bill-notify', () => {
     const invalid = { b: { foo: 'bar' } }
     expect(validateBillNotifySettings(valid)).toBe(true)
     expect(validateBillNotifySettings(invalid)).toBe(false)
+  })
+
+  it('setChannel and setTemplate persist to localStorage', () => {
+    setChannel('dueSoon', 'email', true)
+    setTemplate('dueSoon', 'hello {{billId}}')
+    expect(billNotifySettings.dueSoon.email).toBe(true)
+    const storedSettings = JSON.parse(localStorage.getItem('billNotifySettings') || '{}')
+    expect(storedSettings.dueSoon.email).toBe(true)
+    const storedTemplate = JSON.parse(localStorage.getItem('billNotifyTemplates') || '{}')
+    expect(storedTemplate.dueSoon).toBe('hello {{billId}}')
+  })
+
+  it('sendPreview adds history using template', () => {
+    setChannel('dueSoon', 'email', true)
+    setTemplate('dueSoon', 'msg {{billId}}')
+    sendPreview('B1', 'dueSoon')
+    expect(billNotifyHistory.length).toBe(1)
+    expect(billNotifyHistory[0].message).toBe('msg B1')
+    const stored = JSON.parse(localStorage.getItem('billNotifyHistory') || '[]')
+    expect(stored.length).toBe(1)
+  })
+
+  it('loadBillNotifyData restores state from storage', () => {
+    localStorage.setItem('billNotifyTemplates', JSON.stringify({ dueSoon: 'x' }))
+    localStorage.setItem(
+      'billNotifyHistory',
+      JSON.stringify([{ id: '1', billId: 'b', status: 'dueSoon', channel: 'email', message: 'x', timestamp: 't' }]),
+    )
+    loadBillNotifyData()
+    expect(billNotifyTemplates.dueSoon).toBe('x')
+    expect(billNotifyHistory.length).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- expand bill notify settings to cover in-app notifications
- provide bill notify templates and history utilities
- expose helpers to load data, set channels/templates, and send preview notifications
- test new mock-bill-notify helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e915b7c288325853367d32ff39ae3