### PR TITLE
Fix server build by marking BillDetail as client

### DIFF
--- a/components/bill/BillDetail.tsx
+++ b/components/bill/BillDetail.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { useBill } from '@/libs/hooks/useBill'
 
 export default function BillDetail({ id }: { id: string }) {


### PR DESCRIPTION
## Summary
- mark `BillDetail` with the `"use client"` directive so server build doesn't execute browser-only code

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687e8f29ca04832587ff843040845bbe