### PR TITLE
Add printable receipt page and admin print link

### DIFF
--- a/app/receipt/[billId]/ReceiptPageClient.tsx
+++ b/app/receipt/[billId]/ReceiptPageClient.tsx
@@ -23,7 +23,7 @@ export default function ReceiptPageClient({ bill }: { bill: BillData }) {
       <div className="w-full max-w-xl">
         <ReceiptLayout bill={bill} />
         {!bill.feedback && bill.status === 'delivered' && (
-          <div id="feedback" className="mt-4">
+          <div id="feedback" className="mt-4 print:hidden">
             {showFb ? (
               <FeedbackForm billId={bill.id} onSubmitted={() => setShowFb(false)} />
             ) : (

--- a/app/receipt/[billId]/print/page.tsx
+++ b/app/receipt/[billId]/print/page.tsx
@@ -1,0 +1,14 @@
+import ReceiptLayout from '@/components/receipt/ReceiptLayout'
+import { getBills } from '@/core/mock/store'
+
+export default function ReceiptPrintPage({ params }: { params: { billId: string } }) {
+  const bill = getBills().find(b => b.id === params.billId)
+  if (!bill) {
+    return <div className="p-4 text-center">ไม่พบใบเสร็จ</div>
+  }
+  return (
+    <div className="p-4 print:p-0">
+      <ReceiptLayout bill={bill as any} />
+    </div>
+  )
+}

--- a/components/admin/BillItemActions.tsx
+++ b/components/admin/BillItemActions.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link'
 import { Button } from '@/components/ui/buttons/button'
 import { Badge } from '@/components/ui/badge'
-import { FileText, Gift, Check, Eye, Edit } from 'lucide-react'
+import { FileText, Gift, Check, Eye, Edit, Printer } from 'lucide-react'
 import { toast } from 'sonner'
 import type { AdminBill } from '@/mock/bills'
 
@@ -27,6 +27,11 @@ export default function BillItemActions({ bill, onEdit }: BillItemActionsProps) 
       <Link href={`/bill/${bill.id}`} className="no-underline">
         <Button variant="outline" size="sm">
           <Eye className="h-4 w-4" /> ดูบิล
+        </Button>
+      </Link>
+      <Link href={`/receipt/${bill.id}/print`} className="no-underline" title="พิมพ์ใบเสร็จ">
+        <Button variant="outline" size="sm">
+          <Printer className="h-4 w-4" />
         </Button>
       </Link>
       <Button variant="outline" size="sm" onClick={onEdit}>

--- a/components/bill/BillHeader.tsx
+++ b/components/bill/BillHeader.tsx
@@ -8,7 +8,8 @@ export default function BillHeader() {
         <img src={company.logo} alt={company.name} className="w-12 h-12" />
       )}
       <div className="text-sm">
-        <h1 className="text-xl font-bold leading-none">{company.name}</h1>
+        <h1 className="text-2xl font-bold mb-1">ใบเสร็จรับเงิน</h1>
+        <h2 className="text-xl font-semibold leading-none">{company.name}</h2>
         <p className="whitespace-pre-line">{formatAddress(company.address)}</p>
         <p>โทร: {company.phone}</p>
       </div>


### PR DESCRIPTION
## Summary
- enhance bill header with Thai receipt title
- hide receipt feedback section when printing
- add `/receipt/[billId]/print` route for clean printable layout
- link to printable receipt from admin bills table

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687ea7d93e348325a27e903b21847883