### PR TITLE
Add internal admin tools and logs enhancements

### DIFF
--- a/app/admin/checkin/page.tsx
+++ b/app/admin/checkin/page.tsx
@@ -1,0 +1,35 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+async function loadCheckin() {
+  const file = join(process.cwd(), 'mock', 'store', 'checkin.json')
+  try {
+    const text = await fs.readFile(file, 'utf8')
+    return JSON.parse(text) as any[]
+  } catch {
+    return []
+  }
+}
+
+export default async function AdminCheckinPage() {
+  const logs = await loadCheckin()
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Daily Check-in</h1>
+      <ul className="space-y-2">
+        {logs.map((l, i) => (
+          <li key={i} className="border rounded p-2 flex items-center gap-2">
+            <span>{l.date}</span>
+            <span className="text-sm text-gray-500">login {l.loginTime}</span>
+            <span className="text-sm text-gray-500">tasks {l.tasks}</span>
+            <span className="text-sm text-gray-500">exports {l.exports}</span>
+            <label className="ml-auto text-sm flex items-center gap-1">
+              <input type="checkbox" defaultChecked={l.done} /> I'm done for today
+            </label>
+          </li>
+        ))}
+        {logs.length === 0 && <p>No logs</p>}
+      </ul>
+    </div>
+  )
+}

--- a/app/admin/dev/flags/page.tsx
+++ b/app/admin/dev/flags/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+import { useFeatureFlags } from '@/contexts/feature-flag-context'
+
+export default function FlagsPage() {
+  const { isEnabled, toggle } = useFeatureFlags()
+  const flags = ['review', 'newSystem'] as const
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Feature Flags</h1>
+      <ul className="space-y-2">
+        {flags.map((f) => (
+          <li key={f} className="flex items-center gap-2">
+            <label className="capitalize">{f}</label>
+            <input type="checkbox" checked={isEnabled(f)} onChange={() => toggle(f)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/admin/dev/switch-user/page.tsx
+++ b/app/admin/dev/switch-user/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useAuthStore } from '@/contexts/auth-store'
+
+interface AdminUser {
+  id: string
+  name: string
+  email: string
+  role: string
+}
+
+export default function SwitchUserPage() {
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const { setUser } = useAuthStore()
+
+  useEffect(() => {
+    fetch('/mock/store/users.json')
+      .then(r => r.json())
+      .then(setUsers)
+      .catch(console.error)
+  }, [])
+
+  const handleSelect = (id: string) => {
+    const u = users.find(user => user.id === id)
+    if (u) setUser(u as any)
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Switch Admin User</h1>
+      <Select onValueChange={handleSelect}>
+        <SelectTrigger className="w-64">
+          <SelectValue placeholder="Choose user" />
+        </SelectTrigger>
+        <SelectContent>
+          {users.map(u => (
+            <SelectItem key={u.id} value={u.id}>
+              {u.name} ({u.role})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/app/admin/devtools/page.tsx
+++ b/app/admin/devtools/page.tsx
@@ -1,0 +1,13 @@
+export default function AdminDevToolsPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Admin DevTools</h1>
+      <ul className="list-disc pl-5 space-y-1">
+        <li><a href="/admin/dev/switch-user" className="text-blue-600 underline">Switch User</a></li>
+        <li><a href="/admin/dev/flags" className="text-blue-600 underline">Hidden Flags</a></li>
+        <li><a href="/admin/wife" className="text-blue-600 underline">WifeMode Dashboard</a></li>
+        <li><a href="/admin/checkin" className="text-blue-600 underline">Daily Check-in</a></li>
+      </ul>
+    </div>
+  )
+}

--- a/app/admin/logs/orders/page.tsx
+++ b/app/admin/logs/orders/page.tsx
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import { join } from 'path'
+import { Badge } from '@/components/ui/badge'
 
 async function loadLogs() {
   const file = join(process.cwd(), 'mock', 'store', 'activity-log.json')
@@ -18,13 +19,29 @@ export default async function OrderLogsPage() {
       <h1 className="text-2xl font-semibold">Order Activity Log</h1>
       <ul className="space-y-2">
         {logs.map((l, i) => (
-          <li key={i} className="border rounded p-2">
-            <p className="text-sm text-gray-500">{l.timestamp} - {l.admin}</p>
-            <p>{l.action}</p>
+          <li key={i} className="border rounded p-2 space-y-1">
+            <p className="text-sm text-gray-500 flex gap-2 items-center">
+              {l.timestamp} - {l.admin}
+              {l.role && <Badge variant="secondary">{l.role}</Badge>}
+            </p>
+            <p className="flex items-center gap-2">
+              {l.action}
+              {actionTag(l.action)}
+            </p>
           </li>
         ))}
         {logs.length === 0 && <p>No logs</p>}
       </ul>
     </div>
   )
+}
+
+function actionTag(action: string) {
+  if (action.toLowerCase().includes('created'))
+    return <Badge variant="outline" className="bg-green-100 text-green-700">Created</Badge>
+  if (action.toLowerCase().includes('paid'))
+    return <Badge variant="outline" className="bg-blue-100 text-blue-700">Paid</Badge>
+  if (action.toLowerCase().includes('export'))
+    return <Badge variant="outline" className="bg-purple-100 text-purple-700">Exported</Badge>
+  return null
 }

--- a/app/admin/wife/page.tsx
+++ b/app/admin/wife/page.tsx
@@ -1,0 +1,19 @@
+export default function WifeModePage() {
+  return (
+    <div className="theme-soft-blush p-4 space-y-4">
+      <h1 className="text-2xl font-bold">ระบบเมีย</h1>
+      <section>
+        <h2 className="font-semibold">สรุปยอดวันนี้</h2>
+        <p>฿0.00</p>
+      </section>
+      <section>
+        <h2 className="font-semibold">ออเดอร์ที่ยังไม่ส่ง</h2>
+        <p>0 รายการ</p>
+      </section>
+      <section>
+        <h2 className="font-semibold">ใบเสร็จยังไม่พิมพ์</h2>
+        <p>0 รายการ</p>
+      </section>
+    </div>
+  )
+}

--- a/mock/store/checkin.json
+++ b/mock/store/checkin.json
@@ -1,0 +1,9 @@
+[
+  {
+    "date": "2024-05-01",
+    "loginTime": "09:00",
+    "tasks": 5,
+    "exports": 2,
+    "done": false
+  }
+]

--- a/mock/store/users.json
+++ b/mock/store/users.json
@@ -1,0 +1,5 @@
+[
+  {"id":"1","name":"Admin User","email":"admin@sofacover.com","role":"admin"},
+  {"id":"2","name":"Staff User","email":"staff@sofacover.com","role":"staff"},
+  {"id":"0","name":"Super Admin","email":"root@sofacover.com","role":"superadmin"}
+]


### PR DESCRIPTION
## Summary
- add Admin DevTools page with links to new utilities
- allow switching between mock admin accounts
- expose feature flags at `/admin/dev/flags`
- show daily check‑in summary
- add WifeMode dashboard
- enhance order logs with action and role badges
- add mock data for users and daily check‑ins

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687edc314fc483259225796e8be086e6