### PR TITLE
Implement blocks 291-295

### DIFF
--- a/app/admin/shipping/export/page.tsx
+++ b/app/admin/shipping/export/page.tsx
@@ -1,59 +1,78 @@
-"use client"
-import { useState } from 'react'
-import { useBillStore } from '@/core/store'
-import billDetails from '@/mock/bill.detail.json'
-import { Button } from '@/components/ui/buttons/button'
+"use client";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useBillStore } from "@/core/store";
+import billDetails from "@/mock/bill.detail.json";
+import { Button } from "@/components/ui/buttons/button";
 
 function escapeCSV(v: string | number | undefined) {
-  const s = v === undefined || v === null ? '' : String(v)
-  return '"' + s.replace(/"/g, '""') + '"'
+  const s = v === undefined || v === null ? "" : String(v);
+  return '"' + s.replace(/"/g, '""') + '"';
 }
 
 export default function ShippingExportPage() {
-  const store = useBillStore()
-  const [selected, setSelected] = useState<string[]>([])
+  const store = useBillStore();
+  const [selected, setSelected] = useState<string[]>([]);
 
   const toggle = (id: string) => {
-    setSelected(prev =>
-      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id],
-    )
-  }
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id],
+    );
+  };
 
-  const details = billDetails as any[]
+  const details = billDetails as any[];
   const exportCSV = async () => {
-    const rows = selected.map(id => {
-      const bill = store.bills.find(b => b.id === id)
-      const detail = details.find((d: any) => d.id === id)
+    const rows = selected.map((id) => {
+      const bill = store.bills.find((b) => b.id === id);
+      const detail = details.find((d: any) => d.id === id);
       return [
         detail?.customer.name,
         detail?.customer.address,
         detail?.customer.phone,
         id,
         bill?.shippingMethod,
-      ]
-    })
-    const header = ['Name', 'Address', 'Phone', 'OrderID', 'ShippingType']
+      ];
+    });
+    const header = ["Name", "Address", "Phone", "OrderID", "ShippingType"];
     const csv = [header, ...rows]
-      .map(r => r.map(escapeCSV).join(','))
-      .join('\n')
-    const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'shipping.csv'
-    a.click()
-    URL.revokeObjectURL(url)
-    await fetch('/api/shipping-log', {
-      method: 'POST',
-      body: JSON.stringify({ ids: selected, timestamp: new Date().toISOString() }),
-    })
-  }
+      .map((r) => r.map(escapeCSV).join(","))
+      .join("\n");
+    const blob = new Blob(["\uFEFF" + csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "shipping.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+    const ts = new Date().toISOString();
+    await fetch("/api/shipping-log", {
+      method: "POST",
+      body: JSON.stringify({ ids: selected, timestamp: ts }),
+    });
+    await fetch("/api/undo/save", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "shipping-export",
+        payload: { timestamp: ts },
+      }),
+    });
+    toast("Exported", {
+      action: {
+        label: "Undo",
+        onClick: async () => {
+          await fetch("/api/undo", { method: "POST" });
+          location.reload();
+        },
+      },
+    });
+  };
 
   return (
     <div className="container mx-auto space-y-4 py-8">
       <h1 className="text-2xl font-bold">Export Shipping CSV</h1>
       <div className="space-y-2">
-        {store.bills.map(b => (
+        {store.bills.map((b) => (
           <label key={b.id} className="flex items-center gap-2">
             <input
               type="checkbox"
@@ -64,9 +83,7 @@ export default function ShippingExportPage() {
           </label>
         ))}
       </div>
-      {selected.length > 0 && (
-        <Button onClick={exportCSV}>Export CSV</Button>
-      )}
+      {selected.length > 0 && <Button onClick={exportCSV}>Export CSV</Button>}
     </div>
-  )
+  );
 }

--- a/app/admin/shipping/status/page.tsx
+++ b/app/admin/shipping/status/page.tsx
@@ -1,62 +1,69 @@
-"use client"
-import { useEffect, useState } from "react"
-import { Button } from "@/components/ui/buttons/button"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { toast } from "sonner"
-import { mockBills } from "@/lib/mock-bills"
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/buttons/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "sonner";
+import { mockBills } from "@/lib/mock-bills";
 
 type Record = {
-  billId: string
-  status: string
-  provider: string
-  lastSynced: string
-}
+  billId: string;
+  status: string;
+  provider: string;
+  lastSynced: string;
+};
 
-const LS_KEY = "shipping_status_cache"
+const LS_KEY = "shipping_status_cache";
 
 export default function ShippingStatusPage() {
-  const [records, setRecords] = useState<Record[]>([])
+  const [records, setRecords] = useState<Record[]>([]);
 
-  const billIds = mockBills.map(b => b.id)
+  const billIds = mockBills.map((b) => b.id);
 
   const loadCache = () => {
-    if (typeof window === "undefined") return
-    const stored = localStorage.getItem(LS_KEY)
-    if (stored) setRecords(JSON.parse(stored))
-  }
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem(LS_KEY);
+    if (stored) setRecords(JSON.parse(stored));
+  };
 
   const saveCache = (data: Record[]) => {
-    if (typeof window === "undefined") return
-    localStorage.setItem(LS_KEY, JSON.stringify(data))
-  }
+    if (typeof window === "undefined") return;
+    localStorage.setItem(LS_KEY, JSON.stringify(data));
+  };
 
   const sync = async () => {
-    const res = await fetch("/api/shipping/flash/sync", {
+    const res = await fetch("/api/shipping/sync/auto", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ids: billIds }),
-    }).then(r => r.json())
-    const newRecords: Record[] = res.statuses
-    newRecords.forEach(n => {
-      const prev = records.find(r => r.billId === n.billId)
+    }).then((r) => r.json());
+    const newRecords: Record[] = res.statuses;
+    newRecords.forEach((n) => {
+      const prev = records.find((r) => r.billId === n.billId);
       if (prev && prev.status !== n.status) {
-        toast.message(`Bill ${n.billId} ${n.status}`)
+        toast.message(`Bill ${n.billId} ${n.status}`);
       }
-    })
-    setRecords(newRecords)
-    saveCache(newRecords)
-  }
+    });
+    setRecords(newRecords);
+    saveCache(newRecords);
+  };
 
   useEffect(() => {
-    loadCache()
-  }, [])
+    loadCache();
+  }, []);
 
   useEffect(() => {
     if (process.env.NODE_ENV === "development") {
-      const t = setInterval(sync, 300000)
-      return () => clearInterval(t)
+      const t = setInterval(sync, 300000);
+      return () => clearInterval(t);
     }
-  })
+  });
 
   return (
     <div className="container mx-auto space-y-4 py-8">
@@ -74,7 +81,7 @@ export default function ShippingStatusPage() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {records.map(r => (
+          {records.map((r) => (
             <TableRow key={r.billId}>
               <TableCell>{r.billId}</TableCell>
               <TableCell>{r.status}</TableCell>
@@ -85,5 +92,5 @@ export default function ShippingStatusPage() {
         </TableBody>
       </Table>
     </div>
-  )
+  );
 }

--- a/app/api/og/receipt/[billId]/route.ts
+++ b/app/api/og/receipt/[billId]/route.ts
@@ -1,6 +1,0 @@
-import { NextResponse } from 'next/server'
-
-export function GET(req: Request) {
-  const url = new URL('/placeholder.jpg', req.url)
-  return NextResponse.redirect(url)
-}

--- a/app/api/og/receipt/[billId]/route.tsx
+++ b/app/api/og/receipt/[billId]/route.tsx
@@ -1,0 +1,44 @@
+import { ImageResponse, NextResponse } from "next/server";
+import { getBills } from "@/core/mock/store";
+
+export const runtime = "edge";
+
+export function GET(req: Request, { params }: { params: { billId: string } }) {
+  const bill = getBills().find((b) => b.id === params.billId);
+  if (!bill) {
+    const url = new URL("/placeholder.jpg", req.url);
+    return NextResponse.redirect(url);
+  }
+
+  const total =
+    bill.items.reduce((s, it) => s + it.price * it.quantity, 0) +
+    (bill.shipping || 0) -
+    (bill.discount || 0);
+  const date = new Date(bill.createdAt).toLocaleDateString("th-TH");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 48,
+          color: "#000",
+          background: "#fff",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "40px",
+        }}
+      >
+        <div>Receipt #{bill.id}</div>
+        <div>{date}</div>
+        <div style={{ fontSize: 64, fontWeight: "bold", marginTop: 20 }}>
+          ฿{total.toFixed(2)}
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/app/api/shipping-log/route.ts
+++ b/app/api/shipping-log/route.ts
@@ -1,16 +1,21 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { promises as fs } from 'fs'
-import path from 'path'
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { saveUndo } from "@/lib/undoStore";
 
 export async function POST(req: NextRequest) {
-  const data = await req.json()
-  const file = path.join(process.cwd(), 'mock/store/shipping-log.json')
-  let logs: any[] = []
+  const data = await req.json();
+  const file = path.join(process.cwd(), "mock/store/shipping-log.json");
+  let logs: any[] = [];
   try {
-    const text = await fs.readFile(file, 'utf8')
-    logs = JSON.parse(text)
+    const text = await fs.readFile(file, "utf8");
+    logs = JSON.parse(text);
   } catch {}
-  logs.push({ ...data })
-  await fs.writeFile(file, JSON.stringify(logs, null, 2), 'utf8')
-  return NextResponse.json({ success: true })
+  logs.push({ ...data });
+  await fs.writeFile(file, JSON.stringify(logs, null, 2), "utf8");
+  await saveUndo({
+    type: "shipping-export",
+    payload: { timestamp: data.timestamp },
+  });
+  return NextResponse.json({ success: true });
 }

--- a/app/api/shipping/sync/auto/route.ts
+++ b/app/api/shipping/sync/auto/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getBills } from "@/core/mock/store";
+import { syncShippingStatuses } from "@/lib/shippingStatusStore";
+
+export async function POST() {
+  const ids = getBills().map((b) => b.id);
+  const records = await syncShippingStatuses(ids, "Flash");
+  return NextResponse.json({ statuses: records });
+}

--- a/app/api/undo/route.ts
+++ b/app/api/undo/route.ts
@@ -1,15 +1,25 @@
-import { NextResponse } from 'next/server'
-import { loadUndo, clearUndo } from '@/lib/undoStore'
-import { restoreBill, softDeleteBill } from '@/lib/deletedBills'
+import { NextResponse } from "next/server";
+import { loadUndo, clearUndo } from "@/lib/undoStore";
+import { restoreBill, softDeleteBill } from "@/lib/deletedBills";
+import { readJson, writeJson } from "@/lib/jsonStore";
+import { join } from "path";
 
 export async function POST() {
-  const entry = await loadUndo()
-  if (!entry) return NextResponse.json({ error: 'no action' }, { status: 404 })
-  if (entry.type === 'delete-bill') {
-    await restoreBill(entry.payload.id)
-  } else if (entry.type === 'restore-bill') {
-    await softDeleteBill(entry.payload.id)
+  const entry = await loadUndo();
+  if (!entry) return NextResponse.json({ error: "no action" }, { status: 404 });
+  if (entry.type === "delete-bill") {
+    await restoreBill(entry.payload.id);
+  } else if (entry.type === "restore-bill") {
+    await softDeleteBill(entry.payload.id);
+  } else if (entry.type === "shipping-export") {
+    const file = join(process.cwd(), "mock", "store", "shipping-log.json");
+    const logs = await readJson<any[]>(file, []);
+    const idx = logs.findIndex((l) => l.timestamp === entry.payload.timestamp);
+    if (idx !== -1) {
+      logs.splice(idx, 1);
+      await writeJson(file, logs);
+    }
   }
-  await clearUndo()
-  return NextResponse.json({ success: true })
+  await clearUndo();
+  return NextResponse.json({ success: true });
 }

--- a/app/api/undo/save/route.ts
+++ b/app/api/undo/save/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { saveUndo } from "@/lib/undoStore";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json().catch(() => null);
+  if (!data || !data.type) {
+    return NextResponse.json({ error: "bad request" }, { status: 400 });
+  }
+  await saveUndo(data);
+  return NextResponse.json({ success: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,38 +1,38 @@
-import type React from "react"
-import type { Metadata } from "next"
-import { Inter } from "next/font/google"
-import "./globals.css"
-import { Toaster } from "@/components/ui/toaster"
-import { CartProvider } from "@/contexts/cart-context"
-import { AuthProvider } from "@/contexts/auth-context"
-import { FeatureFlagProvider } from "@/contexts/feature-flag-context"
-import { DemoProvider } from "@/contexts/demo-context"
-import { WishlistProvider } from "@/contexts/wishlist-context"
-import { CompareProvider } from "@/contexts/compare-context"
-import { ReviewImagesProvider } from "@/contexts/review-images-context"
-import { FavoritesProvider } from "@/contexts/favorites-context"
-import { RecentProductsProvider } from "@/contexts/recent-products-context"
-import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-context"
-import { validateMockData } from "@/lib/mock-validator"
-import RedirectMobileHome from "@/components/RedirectMobileHome"
-import DevBar from "@/components/DevBar"
-import StoreBottomNav from "@/components/StoreBottomNav"
+import type React from "react";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import { Toaster } from "@/components/ui/toaster";
+import { CartProvider } from "@/contexts/cart-context";
+import { AuthProvider } from "@/contexts/auth-context";
+import { FeatureFlagProvider } from "@/contexts/feature-flag-context";
+import { DemoProvider } from "@/contexts/demo-context";
+import { WishlistProvider } from "@/contexts/wishlist-context";
+import { CompareProvider } from "@/contexts/compare-context";
+import { ReviewImagesProvider } from "@/contexts/review-images-context";
+import { FavoritesProvider } from "@/contexts/favorites-context";
+import { RecentProductsProvider } from "@/contexts/recent-products-context";
+import { AdminProductGroupsProvider } from "@/contexts/admin-product-groups-context";
+import { validateMockData } from "@/lib/mock-validator";
+import RedirectMobileHome from "@/components/RedirectMobileHome";
+import DevBar from "@/components/DevBar";
+import StoreBottomNav from "@/components/StoreBottomNav";
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "SofaCover Pro - ผ้าคลุมโซฟาคุณภาพพรีเมียม",
   description: "ระบบขายผ้าคลุมโซฟาออนไลน์ที่ทันสมัยและครบครัน",
-    generator: 'v0.dev'
-}
+  generator: "v0.dev",
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   if (process.env.NODE_ENV === "development") {
-    validateMockData()
+    validateMockData();
   }
   return (
     <html lang="th">
@@ -47,11 +47,11 @@ export default function RootLayout({
                       <FavoritesProvider>
                         <AdminProductGroupsProvider>
                           <ReviewImagesProvider>
-                          <RedirectMobileHome />
-                          {children}
-                          <StoreBottomNav />
-                          <DevBar />
-                          <Toaster />
+                            <RedirectMobileHome />
+                            {children}
+                            <StoreBottomNav className="print:hidden" />
+                            <DevBar className="print:hidden" />
+                            <Toaster />
                           </ReviewImagesProvider>
                         </AdminProductGroupsProvider>
                       </FavoritesProvider>
@@ -64,5 +64,5 @@ export default function RootLayout({
         </FeatureFlagProvider>
       </body>
     </html>
-  )
+  );
 }

--- a/app/receipt/[billId]/print/page.tsx
+++ b/app/receipt/[billId]/print/page.tsx
@@ -1,14 +1,21 @@
-import ReceiptLayout from '@/components/receipt/ReceiptLayout'
-import { getBills } from '@/core/mock/store'
+import ReceiptLayout from "@/components/receipt/ReceiptLayout";
+import ReceiptPrintLayout from "@/components/receipt/ReceiptPrintLayout";
+import { getBills } from "@/core/mock/store";
 
-export default function ReceiptPrintPage({ params }: { params: { billId: string } }) {
-  const bill = getBills().find(b => b.id === params.billId)
+export default function ReceiptPrintPage({
+  params,
+}: {
+  params: { billId: string };
+}) {
+  const bill = getBills().find((b) => b.id === params.billId);
   if (!bill) {
-    return <div className="p-4 text-center">ไม่พบใบเสร็จ</div>
+    return <div className="p-4 text-center">ไม่พบใบเสร็จ</div>;
   }
   return (
     <div className="p-4 print:p-0">
-      <ReceiptLayout bill={bill as any} />
+      <ReceiptPrintLayout>
+        <ReceiptLayout bill={bill as any} />
+      </ReceiptPrintLayout>
     </div>
-  )
+  );
 }

--- a/components/receipt/ReceiptPrintLayout.tsx
+++ b/components/receipt/ReceiptPrintLayout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from "react";
+import { pageClass } from "@/lib/pdf/print-styles";
+
+export default function ReceiptPrintLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <div className={pageClass}>{children}</div>;
+}


### PR DESCRIPTION
## Summary
- add dynamic open graph image for receipts
- add print layout component for receipts and hide dev UI when printing
- add auto shipping sync route
- log shipping exports and allow undo via new API
- support undo shipping-export in undo handler

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687ee3af43a88325bd0b97713086d29c