### PR TITLE
Fix OG image import for Next.js 15

### DIFF
--- a/app/api/og/receipt/[billId]/route.tsx
+++ b/app/api/og/receipt/[billId]/route.tsx
@@ -1,4 +1,5 @@
-import { ImageResponse, NextResponse } from "next/server";
+import { ImageResponse } from "next/og";
+import { NextResponse } from "next/server";
 import { getBills } from "@/core/mock/store";
 
 export const runtime = "edge";


### PR DESCRIPTION
## Summary
- switch OG image import from `next/server` to `next/og`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687f517fe4f88325a61b129c39dd2e27