### PR TITLE
UI polish and admin quick menu

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import EmptyState from '@/components/ui/EmptyState'
 import BillItemActions from '@/components/admin/BillItemActions'
 import type { AdminBill, BillItem } from '@/mock/bills'
 import { useBillStore } from '@/core/store'
@@ -22,10 +23,15 @@ export default function AdminBillsPage() {
   const [bills, setBills] = useState<AdminBill[]>(store.bills)
 
   useEffect(() => {
-    store.refresh()
-    setBills([...store.bills])
+    try {
+      store.refresh()
+      setBills([...store.bills])
+    } catch (e) {
+      setError(true)
+    }
   }, [])
   const [open, setOpen] = useState(false)
+  const [error, setError] = useState(false)
   const [customer, setCustomer] = useState('')
   const [items, setItems] = useState<BillItem[]>([])
   const [shipping, setShipping] = useState(50)
@@ -256,7 +262,9 @@ export default function AdminBillsPage() {
           </Tabs>
         </CardHeader>
         <CardContent className="overflow-x-auto">
-          {filteredBills.length ? (
+          {error ? (
+            <EmptyState icon="⚠️" title="โหลดข้อมูลไม่สำเร็จ" />
+          ) : filteredBills.length ? (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -339,9 +347,10 @@ export default function AdminBillsPage() {
               </TableBody>
             </Table>
           ) : (
-            <div className="text-center text-muted text-sm">
-              {bills.length === 0 ? 'ยังไม่มีบิลในระบบ' : 'ไม่พบบิลที่ค้นหา'}
-            </div>
+            <EmptyState
+              icon="🗒️"
+              title={bills.length === 0 ? 'ยังไม่มีบิลในระบบ' : 'ไม่พบบิลที่ค้นหา'}
+            />
           )}
         </CardContent>
       </Card>

--- a/app/admin/dev/quick/page.tsx
+++ b/app/admin/dev/quick/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { Button } from '@/components/ui/buttons/button'
+import { GripVertical, FileText, Upload, FolderDown, MessageSquare } from 'lucide-react'
+import { useState } from 'react'
+
+const actions = [
+  { id: 'create', label: 'Create Bill', icon: <FileText />, href: '/admin/bills' },
+  { id: 'labels', label: 'Print Labels', icon: <Upload />, href: '/admin/shipping/labels' },
+  { id: 'csv', label: 'Export CSV', icon: <FolderDown />, href: '/admin/bills' },
+  { id: 'feedback', label: 'Check Feedback', icon: <MessageSquare />, href: '/admin/reviews' },
+]
+
+export default function DevQuickPage() {
+  const [items, setItems] = useState(actions)
+  // mock-only drag reorder
+  const move = (from: number, to: number) => {
+    const updated = [...items]
+    const [it] = updated.splice(from, 1)
+    updated.splice(to, 0, it)
+    setItems(updated)
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Quick Access</h1>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {items.map((a, idx) => (
+          <Button
+            key={a.id}
+            asChild
+            className="flex flex-col items-center py-6"
+            draggable
+            onDragStart={(e) => {
+              e.dataTransfer.setData('text/plain', idx.toString())
+            }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              const from = Number(e.dataTransfer.getData('text/plain'))
+              move(from, idx)
+            }}
+          >
+            <a href={a.href} className="flex flex-col items-center space-y-2">
+              {a.icon}
+              <span>{a.label}</span>
+              <GripVertical className="opacity-50" />
+            </a>
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/reviews/content.tsx
+++ b/app/admin/reviews/content.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from 'lucide-react'
 import { Button } from '@/components/ui/buttons/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import EmptyState from '@/components/ui/EmptyState'
 
 interface Feedback {
   id: string
@@ -20,11 +21,13 @@ export default function AdminReviewsPage() {
   const [list, setList] = useState<Feedback[]>([])
   const [rating, setRating] = useState('all')
   const [sort, setSort] = useState<'date' | 'rating'>('date')
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     fetch('/api/feedback')
       .then((r) => r.json())
       .then((d) => setList(d.feedback || []))
+      .catch(() => setError(true))
   }, [])
 
   const items = list
@@ -73,6 +76,11 @@ export default function AdminReviewsPage() {
             <CardTitle>Feedback List ({items.length})</CardTitle>
           </CardHeader>
           <CardContent>
+            {error ? (
+              <EmptyState icon="⚠️" title="โหลดข้อมูลไม่สำเร็จ" />
+            ) : items.length === 0 ? (
+              <EmptyState icon="💬" title="No feedback" />
+            ) : (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -102,6 +110,7 @@ export default function AdminReviewsPage() {
                 ))}
               </TableBody>
             </Table>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/admin/shipping/dashboard.tsx
+++ b/app/admin/shipping/dashboard.tsx
@@ -7,14 +7,20 @@ import { mockBills, markReminderSent } from '@/lib/mock-bills'
 import { syncKerryStatuses } from '@/lib/kerryApi'
 import { mockNotificationService } from '@/lib/mock-notification-service'
 import { addNotification } from '@/lib/mock-notifications'
+import EmptyState from '@/components/ui/EmptyState'
 
 export default function ShippingDashboard() {
   const [bills, setBills] = useState(() => mockBills.map(b => ({ ...b })))
+  const [error, setError] = useState(false)
 
   const handleSync = async () => {
-    const res = await syncKerryStatuses(bills as any)
-    setBills(mockBills.map(b => ({ ...b })))
-    toast.success(`สำเร็จ ${res.success} ไม่พบเลข ${res.missing} ล้มเหลว ${res.failed}`)
+    try {
+      const res = await syncKerryStatuses(bills as any)
+      setBills(mockBills.map(b => ({ ...b })))
+      toast.success(`สำเร็จ ${res.success} ไม่พบเลข ${res.missing} ล้มเหลว ${res.failed}`)
+    } catch (e) {
+      setError(true)
+    }
   }
 
   const handleRemind = async (id: string) => {
@@ -43,6 +49,11 @@ export default function ShippingDashboard() {
         <h1 className="text-2xl font-bold">Shipping Dashboard</h1>
         <Button onClick={handleSync}>เช็คสถานะ Kerry Express</Button>
       </div>
+      {error ? (
+        <EmptyState icon="⚠️" title="โหลดข้อมูลไม่สำเร็จ" />
+      ) : bills.length === 0 ? (
+        <EmptyState icon="📦" title="ยังไม่มีข้อมูล" />
+      ) : (
       <Table>
         <TableHeader>
           <TableRow>
@@ -80,6 +91,7 @@ export default function ShippingDashboard() {
           ))}
         </TableBody>
       </Table>
+      )}
     </div>
   )
 }

--- a/app/receipt/[billId]/ReceiptPageClient.tsx
+++ b/app/receipt/[billId]/ReceiptPageClient.tsx
@@ -45,12 +45,14 @@ export default function ReceiptPageClient({ bill, meta }: { bill: BillData; meta
       </Head>
       <div className="min-h-screen p-4 flex flex-col items-center space-y-4">
         <h1 className="text-lg font-semibold">ใบเสร็จคำสั่งซื้อของคุณ</h1>
+        <p className="text-sm">
+          {bill.status === 'paid' ? '✔️ ชำระแล้ว' : '🧾 ยังไม่ชำระ'}
+        </p>
       <div className="flex gap-2 print:hidden">
         <Button variant="outline" size="sm" onClick={copyLink}>
           <Copy className="w-4 h-4 mr-2" /> คัดลอกลิงก์
         </Button>
-        <Button variant="outline" size="sm" onClick={shareLine}>LINE</Button>
-        <Button variant="outline" size="sm" onClick={shareFacebook}>Facebook</Button>
+        <Button variant="outline" size="sm" onClick={shareLine}>Share Receipt</Button>
         <Button size="sm" onClick={downloadPdf}>
           <Download className="w-4 h-4 mr-2" /> PDF
         </Button>

--- a/components/ui/buttons/button.tsx
+++ b/components/ui/buttons/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl shadow-sm text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -20,9 +20,9 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: "min-h-[44px] px-6 py-3",
+        sm: "min-h-[40px] rounded-xl px-4 py-2.5 text-sm",
+        lg: "min-h-[48px] rounded-xl px-8 py-3.5 text-base",
         icon: "h-10 w-10",
       },
     },

--- a/components/ui/inputs/input.tsx
+++ b/components/ui/inputs/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex min-h-[44px] w-full rounded-xl border border-input bg-background px-4 py-3 shadow-sm text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex min-h-[44px] w-full items-center justify-between rounded-xl border border-input bg-background px-4 py-3 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Sarabun', 'Prompt', 'Inter', sans-serif;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- tweak base components with rounded corners and soft shadows
- add new quick access page for admin tools
- improve receipt page with status icon and share button
- show friendly empty and error states in admin pages
- update global font stack to use Sarabun/Prompt/Inter

## Testing
- `pnpm eslint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687f68dad02883258f06e5dbf3b9bb14