### PR TITLE
Extend fast bill screen for sofa covers

### DIFF
--- a/lib/mock-fast-bills.ts
+++ b/lib/mock-fast-bills.ts
@@ -6,6 +6,12 @@ export interface FastBill {
   total: number
   deposit: number
   days: number
+  fabricName: string
+  fabricImage: string
+  sofaType: string
+  sofaSize: string
+  quantity: number
+  tags: string[]
   depositPaid: boolean
   createdAt: string
 }


### PR DESCRIPTION
## Summary
- support sofa cover details in `FastBill` model
- enhance fast bill form with sofa fields and tag checkboxes
- show sofa info and tags in `/admin/bills/fast` table
- add dropdown filters for fabric name and sofa type

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687faea9452083259c6f477da05cfd9e