### PR TITLE
Add bill create API and update admin page

### DIFF
--- a/app/admin/bills/fast/page.tsx
+++ b/app/admin/bills/fast/page.tsx
@@ -42,7 +42,7 @@ export default function AdminFastBillPage() {
   }, [])
 
   const create = async () => {
-    const res = await fetch("/api/bills/fast/create", {
+    const res = await fetch("/api/bills/create", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/app/api/bills/create/route.ts
+++ b/app/api/bills/create/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { createFastBill } from '@/core/mock/fakeBillDB'
+
+const required = ['customerName', 'fabricName', 'sofaType', 'quantity', 'tags'] as const
+
+export async function POST(req: Request) {
+  let data: any
+  try {
+    data = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+
+  for (const field of required) {
+    if (data[field] === undefined || data[field] === null || (Array.isArray(data[field]) && data[field].length === 0) || data[field] === '') {
+      return NextResponse.json({ error: `missing field: ${field}` }, { status: 400 })
+    }
+  }
+
+  const bill = await createFastBill(data)
+  return NextResponse.json(bill)
+}


### PR DESCRIPTION
## Summary
- add `/api/bills/create` endpoint for creating fast bills
- validate required fields and store bill via mock DB
- update admin fast bill page to call the new endpoint

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb83eebfc8325932a398ea0c2aa89