### PR TITLE
Handle bill DB IO errors

### DIFF
--- a/app/api/bill/[id]/route.ts
+++ b/app/api/bill/[id]/route.ts
@@ -1,13 +1,22 @@
 import { NextResponse } from 'next/server'
-import { readFileSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { join } from 'path'
 
 const billPath = join(process.cwd(), 'db', 'bill.json')
 
+function ensureFile() {
+  if (!existsSync(billPath)) writeFileSync(billPath, '[]')
+}
+
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const id = params.id
-  const all = JSON.parse(readFileSync(billPath, 'utf8'))
-  const found = all.find((b: any) => b.id === id)
-  if (!found) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  return NextResponse.json(found)
+  try {
+    ensureFile()
+    const all = JSON.parse(readFileSync(billPath, 'utf8'))
+    const found = all.find((b: any) => b.id === id)
+    if (!found) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    return NextResponse.json(found)
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary
- add file existence checks to bill routes
- wrap bill file IO in try/catch and return 500 on errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fbd7ae3c08325869d48906579ab96