### PR TITLE
Add unpaid bill tracking

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -317,6 +317,7 @@ export default function AdminBillsPage() {
                   <TableHead>ติดต่อ</TableHead>
                   <TableHead>แท็ก</TableHead>
                   <TableHead>สถานะ</TableHead>
+                  <TableHead>Last Follow-up</TableHead>
                   <TableHead>วันที่</TableHead>
                   <TableHead className="w-24" />
                 </TableRow>

--- a/app/admin/bills/unpaid/page.tsx
+++ b/app/admin/bills/unpaid/page.tsx
@@ -1,0 +1,75 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { useBillStore } from '@/core/store'
+import { formatCurrency, formatDateThai } from '@/lib/utils'
+import { toast } from 'sonner'
+
+export default function UnpaidBillsPage() {
+  const store = useBillStore()
+  const [bills, setBills] = useState(store.bills)
+
+  useEffect(() => {
+    store.refresh()
+    setBills([...store.bills])
+  }, [])
+
+  const sendFollowup = async (id: string) => {
+    await fetch('/api/notify/followup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ billId: id }),
+    })
+    store.refresh()
+    setBills([...store.bills])
+    toast.success('บันทึกการติดตามแล้ว')
+  }
+
+  const unpaid = bills.filter(b => b.status === 'unpaid')
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">บิลค้างจ่าย</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>รายการ ({unpaid.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ชื่อลูกค้า</TableHead>
+                <TableHead>วันที่</TableHead>
+                <TableHead className="text-right">ยอดรวม</TableHead>
+                <TableHead>Last Contact</TableHead>
+                <TableHead className="w-32" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {unpaid.map(b => {
+                const total = b.items.reduce((s, it) => s + it.price * it.quantity, 0) + b.shipping
+                const last = b.followup_log?.[b.followup_log.length - 1]
+                return (
+                  <TableRow key={b.id}>
+                    <TableCell>{b.customer}</TableCell>
+                    <TableCell>{formatDateThai(b.createdAt)}</TableCell>
+                    <TableCell className="text-right">{formatCurrency(total)}</TableCell>
+                    <TableCell>{last ? formatDateThai(last) : '-'}</TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" onClick={() => sendFollowup(b.id)}>
+                        ติดตาม ({b.followup_log?.length || 0})
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+          {unpaid.length === 0 && <p className="text-center py-4 text-sm">ไม่มีบิลค้างจ่าย</p>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/admin/bills/BillRow.tsx
+++ b/components/admin/bills/BillRow.tsx
@@ -19,6 +19,7 @@ interface BillRowProps {
 export default function BillRow({ bill, selected, onSelect, onStatusChange, onEdit }: BillRowProps) {
   const total = bill.items.reduce((s, it) => s + it.price * it.quantity, 0) + bill.shipping
   const phone = (bill as any).phone ?? (bill as any).customer?.phone ?? '-'
+  const lastFollow = bill.followup_log?.[bill.followup_log.length - 1]
 
   return (
     <TableRow>
@@ -32,6 +33,7 @@ export default function BillRow({ bill, selected, onSelect, onStatusChange, onEd
       <TableCell>
         <BillStatusDropdown status={bill.status} onChange={onStatusChange} />
       </TableCell>
+      <TableCell>{lastFollow ? formatDateThai(lastFollow) : '-'}</TableCell>
       <TableCell>{formatDateThai(bill.createdAt)}</TableCell>
       <TableCell className="flex gap-2">
         <button

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -25,6 +25,8 @@ export interface AdminBill {
   createdAt: string
   feedback?: BillFeedback
   archived?: boolean
+  /** timestamps for follow up contact */
+  followup_log?: string[]
 }
 
 export const mockBills: AdminBill[] = [
@@ -44,6 +46,7 @@ export const mockBills: AdminBill[] = [
     shippingMethod: 'Flash',
     shippingStatus: 'shipped',
     createdAt: new Date().toISOString(),
+    followup_log: [],
   },
 ]
 
@@ -55,6 +58,7 @@ export function addBill(
     status: 'unpaid',
     paymentStatus: 'unpaid',
     createdAt: new Date().toISOString(),
+    followup_log: [],
     ...data,
   }
   mockBills.unshift(bill)

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -9,6 +9,7 @@
     "shipping": 50,
     "status": "paid",
     "paymentStatus": "paid",
-    "createdAt": "2024-01-15T08:00:00Z"
+    "createdAt": "2024-01-15T08:00:00Z",
+    "followup_log": []
   }
 ]


### PR DESCRIPTION
## Summary
- log follow-up contact dates for bills
- show last follow-up in admin bill table
- add unpaid bills screen with follow-up action
- persist follow-up logs on notify

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687fcee447e48325a3dd946c1d78666b