### PR TITLE
Add follow-up success filter

### DIFF
--- a/app/dashboard/analytics/unpaid-followup/page.tsx
+++ b/app/dashboard/analytics/unpaid-followup/page.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart"
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/cards/card"
+import Link from "next/link"
 import { getBills } from "@/core/mock/store"
 
 export default function UnpaidFollowupAnalytics() {
@@ -74,14 +75,16 @@ export default function UnpaidFollowupAnalytics() {
           </CardHeader>
           <CardContent>{followupsToday}</CardContent>
         </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>ชำระหลังติดตาม</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {paidAfterFollowup} / {followupBills.length} ({conversionRate}%)
-          </CardContent>
-        </Card>
+        <Link href="/admin/bills?filter=followup-success" className="no-underline">
+          <Card className="cursor-pointer hover:bg-accent/50">
+            <CardHeader>
+              <CardTitle>ชำระหลังติดตาม</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {paidAfterFollowup} / {followupBills.length} ({conversionRate}%)
+            </CardContent>
+          </Card>
+        </Link>
       </div>
       {chartData.some(d => d.count > 0) ? (
         <ChartContainer className="h-60" config={{ follow: { color: "hsl(10,80%,50%)" } }}>

--- a/components/admin/bills/BillRow.tsx
+++ b/components/admin/bills/BillRow.tsx
@@ -14,12 +14,19 @@ interface BillRowProps {
   onSelect: () => void
   onStatusChange: (s: AdminBill['status']) => void
   onEdit: () => void
+  paidDate?: string | null
+  highlightPayment?: boolean
 }
 
-export default function BillRow({ bill, selected, onSelect, onStatusChange, onEdit }: BillRowProps) {
+export default function BillRow({ bill, selected, onSelect, onStatusChange, onEdit, paidDate, highlightPayment }: BillRowProps) {
   const total = bill.items.reduce((s, it) => s + it.price * it.quantity, 0) + bill.shipping
   const phone = (bill as any).phone ?? (bill as any).customer?.phone ?? '-'
   const lastFollow = bill.followup_log?.[bill.followup_log.length - 1]
+  const diffDays = lastFollow && paidDate
+    ? Math.round(
+        (new Date(paidDate).getTime() - new Date(lastFollow).getTime()) / 86400000,
+      )
+    : null
 
   return (
     <TableRow>
@@ -33,7 +40,14 @@ export default function BillRow({ bill, selected, onSelect, onStatusChange, onEd
       <TableCell>
         <BillStatusDropdown status={bill.status} onChange={onStatusChange} />
       </TableCell>
-      <TableCell>{lastFollow ? formatDateThai(lastFollow) : '-'}</TableCell>
+      <TableCell>
+        {lastFollow ? formatDateThai(lastFollow) : '-'}
+        {highlightPayment && paidDate && (
+          <span className="block text-xs text-green-600">
+            → {formatDateThai(paidDate)}{diffDays !== null ? ` (+${diffDays}d)` : ''}
+          </span>
+        )}
+      </TableCell>
       <TableCell>{formatDateThai(bill.createdAt)}</TableCell>
       <TableCell className="flex gap-2">
         <button


### PR DESCRIPTION
## Summary
- make follow-up conversions on analytics page clickable
- add query parameter based filtering for follow-up successes on bills page
- highlight paid date after follow-up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd986eed4832591e8085afe54582c