### PR TITLE
Add public bill view page

### DIFF
--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -1,0 +1,100 @@
+import QRCodePlaceholder from '@/components/bills/QRCodePlaceholder'
+import { getBillById, type FakeBill } from '@/core/mock/fakeBillDB'
+import { useState } from 'react'
+
+const steps = ['กำลังตัดผ้า', 'รอเย็บ', 'กำลังแพ็ค', 'จัดส่งแล้ว']
+
+export default async function BillViewPage({ params }: { params: { billId: string } }) {
+  const bill = await getBillById(params.billId)
+  if (!bill) {
+    return <div className="p-8">ไม่พบบิลนี้</div>
+  }
+  return <BillClient bill={bill} />
+}
+
+function BillClient({ bill }: { bill: FakeBill }) {
+  'use client'
+  const [address, setAddress] = useState(bill.customerAddress)
+  const [question, setQuestion] = useState('')
+  const handleSave = () => {
+    alert('บันทึกที่อยู่แล้ว (mock)')
+  }
+  const handleQuestion = () => {
+    alert('ส่งคำถาม: ' + question)
+    setQuestion('')
+  }
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      <section className="space-y-2">
+        <h1 className="text-xl font-bold">บิล {bill.id}</h1>
+        <p className="font-medium">{bill.customerName}</p>
+        <input
+          className="border p-2 w-full"
+          value={address}
+          onChange={e => setAddress(e.target.value)}
+        />
+        <button className="border px-3 py-1 text-sm mt-1" onClick={handleSave}>
+          บันทึกที่อยู่
+        </button>
+        <p>
+          <a href={`tel:${bill.customerPhone}`} className="text-primary underline">
+            {bill.customerPhone}
+          </a>
+        </p>
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">รายการสินค้า</h2>
+        <ul className="space-y-1">
+          {bill.items.map((it, i) => (
+            <li key={i} className="flex justify-between text-sm">
+              <span>
+                {it.fabricName} {it.sofaType} × {it.quantity}
+              </span>
+              <span>฿{(it.unitPrice * it.quantity).toLocaleString()}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">สถานะการผลิต</h2>
+        <ol className="flex justify-between text-sm">
+          {steps.map((s, i) => (
+            <li
+              key={s}
+              className={i === bill.statusStep ? 'font-bold text-primary' : 'text-gray-500'}
+            >
+              {s}
+            </li>
+          ))}
+        </ol>
+        <p className="text-xs text-gray-500">อัปเดตล่าสุด: {bill.lastUpdated}</p>
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">สอบถามเพิ่มเติม</h2>
+        <a
+          href="https://line.me/ti/p/~sofacover"
+          className="px-4 py-2 bg-green-500 text-white rounded"
+        >
+          คุยทาง LINE
+        </a>
+        <div className="flex space-x-2">
+          <input
+            className="flex-1 border p-2 text-sm"
+            value={question}
+            onChange={e => setQuestion(e.target.value)}
+            placeholder="คำถามของคุณ"
+          />
+          <button className="border px-3 py-1" onClick={handleQuestion}>
+            ส่งคำถาม
+          </button>
+        </div>
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">ชำระเงิน</h2>
+        <p>ยอดประมาณการ: ฿{bill.estimatedTotal.toLocaleString()}</p>
+        <QRCodePlaceholder />
+        {bill.note && <p className="text-sm text-gray-600">{bill.note}</p>}
+      </section>
+    </div>
+  )
+}

--- a/core/mock/fakeBillDB.ts
+++ b/core/mock/fakeBillDB.ts
@@ -35,3 +35,50 @@ export async function getTodayTotal(): Promise<number> {
     .filter(b => b.createdAt.slice(0, 10) === today)
     .reduce((sum, b) => sum + b.total, 0)
 }
+
+
+export interface FakeBillItem {
+  fabricName: string
+  sofaType: string
+  quantity: number
+  unitPrice: number
+  image?: string
+}
+
+export interface FakeBill {
+  id: string
+  customerName: string
+  customerAddress: string
+  customerPhone: string
+  items: FakeBillItem[]
+  statusStep: number
+  lastUpdated: string
+  note?: string
+  estimatedTotal: number
+}
+
+const fakeBills: FakeBill[] = [
+  {
+    id: 'B001',
+    customerName: 'สมชาย ใจดี',
+    customerAddress: '123 ถนนสายม็อค กรุงเทพฯ',
+    customerPhone: '0812345678',
+    items: [
+      {
+        fabricName: 'Cotton',
+        sofaType: 'L-Shape',
+        quantity: 1,
+        unitPrice: 2500,
+        image: '/placeholder.svg',
+      },
+    ],
+    statusStep: 1,
+    lastUpdated: '2024-06-01',
+    note: 'รอชำระหลังตรวจสอบขนาด',
+    estimatedTotal: 2500,
+  },
+]
+
+export async function getBillById(id: string): Promise<FakeBill | undefined> {
+  return fakeBills.find(b => b.id === id)
+}


### PR DESCRIPTION
## Summary
- extend `fakeBillDB` with simple mock bill data and helper `getBillById`
- create `/bill/view/[billId]` route to display and interact with a bill

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687feb331d3883259519b628074d7a18