### PR TITLE
Add BillClient view test

### DIFF
--- a/__tests__/bill-view.test.tsx
+++ b/__tests__/bill-view.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BillClient } from '@/app/bill/view/[billId]/page'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+import * as db from '@/core/mock/fakeBillDB'
+
+const sampleBill: FakeBill = {
+  id: 'TEST-1',
+  customerName: 'John Doe',
+  customerAddress: '123 Main St',
+  customerPhone: '0800000000',
+  items: [
+    { fabricName: 'Cotton', sofaType: 'Sofa', quantity: 1, unitPrice: 1000 },
+  ],
+  statusStep: 2,
+  lastUpdated: '2024-06-01',
+  estimatedTotal: 1000,
+  note: 'note',
+}
+
+describe('BillClient', () => {
+  beforeEach(() => {
+    (globalThis as any).React = React
+    vi.stubGlobal('alert', vi.fn())
+  })
+
+  it('saves new address and highlights current step', async () => {
+    const updateSpy = vi.spyOn(db, 'updateBillAddress').mockResolvedValue(undefined)
+    const { getByDisplayValue, getByText } = render(<BillClient bill={sampleBill} />)
+
+    const input = getByDisplayValue('123 Main St') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '456 New Ave' } })
+    fireEvent.click(getByText('บันทึกที่อยู่'))
+    expect(updateSpy).toHaveBeenCalledWith('TEST-1', '456 New Ave')
+
+    const step = getByText('กำลังแพ็ค')
+    expect(step.className).toContain('font-bold')
+    expect(step.className).toContain('text-primary')
+  })
+})

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -14,7 +14,7 @@ export default async function BillViewPage({ params }: { params: { billId: strin
   return <BillClient bill={bill} />
 }
 
-function BillClient({ bill }: { bill: FakeBill }) {
+export function BillClient({ bill }: { bill: FakeBill }) {
   'use client'
   const [address, setAddress] = useState(bill.customerAddress)
   const [question, setQuestion] = useState('')


### PR DESCRIPTION
## Summary
- export `BillClient` for testing
- add `bill-view.test.tsx` covering editing address and progress step

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffdbeb6908325b717c7bbe3c22470