### PR TITLE
Improve clipboard error handling

### DIFF
--- a/helpers/clipboard.ts
+++ b/helpers/clipboard.ts
@@ -1,8 +1,12 @@
 import { toast } from 'sonner'
 
-export function copyToClipboard(text: string) {
+export async function copyToClipboard(text: string) {
   if (typeof navigator !== 'undefined' && navigator.clipboard) {
-    navigator.clipboard.writeText(text)
-    toast.success('คัดลอกลิงก์แล้ว')
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success('คัดลอกลิงก์แล้ว')
+    } catch (err) {
+      toast.error('ไม่สามารถคัดลอกลิงก์ได้')
+    }
   }
 }

--- a/hooks/__tests__/clipboard.test.ts
+++ b/hooks/__tests__/clipboard.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { copyToClipboard } from '@/helpers/clipboard'
+import { toast } from 'sonner'
+
+describe('copyToClipboard', () => {
+  it('shows error toast on failure', async () => {
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('fail')),
+      },
+    } as any)
+
+    await copyToClipboard('text')
+
+    expect(toast.error).toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- handle clipboard write failures with error toast
- add regression test for failed copy

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688022c6aad883259f28543e4eaea5ee