### PR TITLE
Add bill address update API and client fetch

### DIFF
--- a/app/api/bill/[id]/update-address/route.ts
+++ b/app/api/bill/[id]/update-address/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { updateBillAddress } from '@/core/mock/fakeBillDB'
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { address } = (await req.json().catch(() => ({}))) as {
+    address?: string
+  }
+  if (!address) {
+    return NextResponse.json({ error: 'address required' }, { status: 400 })
+  }
+  try {
+    await updateBillAddress(params.id, address)
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 })
+  }
+}

--- a/components/BillClientInteraction.tsx
+++ b/components/BillClientInteraction.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Image from 'next/image'
 import BillProgress from '@/components/BillProgress'
 import QRCodePlaceholder from '@/components/bills/QRCodePlaceholder'
-import { updateBillAddress, type FakeBill } from '@/core/mock/fakeBillDB'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
 
 const steps = ['กำลังตัดผ้า', 'รอเย็บ', 'กำลังแพ็ค', 'จัดส่งแล้ว']
 
@@ -13,7 +13,11 @@ export default function BillClientInteraction({ bill }: { bill: FakeBill }) {
   const [question, setQuestion] = useState('')
 
   const handleSave = async () => {
-    await updateBillAddress(bill.id, address)
+    await fetch(`/api/bill/${bill.id}/update-address`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address }),
+    })
     alert('บันทึกที่อยู่แล้ว')
   }
 


### PR DESCRIPTION
## Summary
- expose PUT `/api/bill/[id]/update-address` route calling `updateBillAddress`
- update `BillClientInteraction` to use the API instead of directly importing DB function

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68803e91f4308325889f59f30fe4f39c