### PR TITLE
Fix bill view page client component

### DIFF
--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -1,10 +1,21 @@
+"use client"
+
+import { useEffect, useState } from 'react'
 import BillClientInteraction from '@/components/BillClientInteraction'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
 import { getBillById } from '@/core/mock/fakeBillDB'
 
-export default async function BillViewPage({ params }: { params: { billId: string } }) {
-  const bill = await getBillById(params.billId)
+export default function BillViewPage({ params }: { params: { billId: string } }) {
+  const { billId } = params
+  const [bill, setBill] = useState<FakeBill | undefined>()
+
+  useEffect(() => {
+    getBillById(billId).then(setBill)
+  }, [billId])
+
   if (!bill) {
     return <div className="p-8">ไม่พบบิลนี้</div>
   }
+
   return <BillClientInteraction bill={bill} />
 }


### PR DESCRIPTION
## Summary
- make `/bill/view/[billId]` a Client Component
- fetch mock bill data on mount using `getBillById`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688069faa020832583cd90104b726c87