### PR TITLE
Add loading state to bill view page

### DIFF
--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -8,10 +8,18 @@ import { getBillById } from '@/core/mock/fakeBillDB'
 export default function BillViewPage({ params }: { params: { billId: string } }) {
   const { billId } = params
   const [bill, setBill] = useState<FakeBill | undefined>()
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    getBillById(billId).then(setBill)
+    getBillById(billId).then(b => {
+      setBill(b)
+      setLoading(false)
+    })
   }, [billId])
+
+  if (loading) {
+    return <div className="p-8">Loading…</div>
+  }
 
   if (!bill) {
     return <div className="p-8">ไม่พบบิลนี้</div>


### PR DESCRIPTION
## Summary
- add `loading` state to bill view page
- show a loading UI until the bill is fetched
- fall back to "ไม่พบบิลนี้" only after loading completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880750050b48325be56ddb7a6b3934f