### PR TITLE
Add bill status timeline to bill page

### DIFF
--- a/components/BillClientInteraction.tsx
+++ b/components/BillClientInteraction.tsx
@@ -2,11 +2,10 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
-import BillProgress from '@/components/BillProgress'
+import BillStatusStepper from '@/components/BillStatusStepper'
 import QRCodePlaceholder from '@/components/bills/QRCodePlaceholder'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
 
-const steps = ['กำลังตัดผ้า', 'รอเย็บ', 'กำลังแพ็ค', 'จัดส่งแล้ว']
 
 export default function BillClientInteraction({ bill }: { bill: FakeBill }) {
   const [address, setAddress] = useState(bill.customerAddress)
@@ -88,7 +87,7 @@ export default function BillClientInteraction({ bill }: { bill: FakeBill }) {
       </section>
       <section className="space-y-2">
         <h2 className="font-semibold">สถานะการผลิต</h2>
-        <BillProgress steps={steps} current={bill.statusStep} updatedAt={bill.lastUpdated} />
+        <BillStatusStepper status={bill.status} />
       </section>
       <section className="space-y-2">
         <h2 className="font-semibold">สอบถามเพิ่มเติม</h2>

--- a/components/BillStatusStepper.tsx
+++ b/components/BillStatusStepper.tsx
@@ -1,0 +1,59 @@
+import { Clock, Scissors, Package, Truck } from 'lucide-react'
+import type { BillStatus } from '@/core/mock/fakeBillDB'
+
+const steps = [
+  { key: 'waiting', label: 'Waiting', icon: Clock },
+  { key: 'cutting', label: 'Cutting', icon: Scissors },
+  { key: 'packing', label: 'Packing', icon: Package },
+  { key: 'shipped', label: 'Shipped', icon: Truck },
+] as const
+
+type StepKey = typeof steps[number]['key']
+
+export default function BillStatusStepper({ status }: { status: BillStatus }) {
+  const currentStepIndex = steps.findIndex(s => s.key === status)
+
+  return (
+    <div className="flex items-center justify-between relative">
+      {steps.map((step, index) => {
+        const StepIcon = step.icon
+        const isCompleted = index <= currentStepIndex
+        const isCurrent = index === currentStepIndex
+        return (
+          <div key={step.key} className="flex flex-col items-center flex-1">
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center mb-1 ${
+                isCompleted
+                  ? 'bg-green-500 text-white'
+                  : isCurrent
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 text-gray-400'
+              }`}
+            >
+              <StepIcon className="h-4 w-4" />
+            </div>
+            <span
+              className={`text-xs text-center ${
+                isCompleted || isCurrent ? 'text-gray-900 font-medium' : 'text-gray-400'
+              }`}
+            >
+              {step.label}
+            </span>
+            {index < steps.length - 1 && (
+              <div
+                className={`absolute h-0.5 w-full mt-4 ${
+                  index < currentStepIndex ? 'bg-green-500' : 'bg-gray-200'
+                }`}
+                style={{
+                  left: `${(100 / steps.length) * (index + 0.5)}%`,
+                  width: `${100 / steps.length}%`,
+                  zIndex: -1,
+                }}
+              />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/core/mock/fakeBillDB.ts
+++ b/core/mock/fakeBillDB.ts
@@ -1,3 +1,5 @@
+export type BillStatus = 'waiting' | 'cutting' | 'packing' | 'shipped'
+
 export interface FakeBillItem {
   fabricName: string
   sofaType: string
@@ -12,6 +14,7 @@ export interface FakeBill {
   customerAddress: string
   customerPhone: string
   items: FakeBillItem[]
+  status: BillStatus
   statusStep: number
   lastUpdated: string
   note?: string
@@ -25,6 +28,7 @@ interface RawBill {
   phone: string
   address: string
   delivered?: boolean
+  status: BillStatus
 }
 
 let bills: FakeBill[] | null = null
@@ -32,14 +36,21 @@ let bills: FakeBill[] | null = null
 async function loadBills(): Promise<FakeBill[]> {
   if (!bills) {
     const data = (await import('../../mock/bills.json')).default as RawBill[]
+    const stepMap: Record<BillStatus, number> = {
+      waiting: 0,
+      cutting: 1,
+      packing: 2,
+      shipped: 3,
+    }
     bills = data.map((b) => ({
       id: b.id,
       customerName: b.name,
       customerPhone: b.phone,
       customerAddress: b.address,
       delivered: b.delivered,
+      status: b.status,
       items: [],
-      statusStep: 1,
+      statusStep: stepMap[b.status] ?? 0,
       lastUpdated: '',
       estimatedTotal: 0,
     }))

--- a/mock/bills.json
+++ b/mock/bills.json
@@ -4,13 +4,15 @@
     "name": "สมชาย ใจดี",
     "phone": "0812345678",
     "address": "123 ถนนสุขุมวิท กรุงเทพฯ",
-    "delivered": false
+    "delivered": false,
+    "status": "waiting"
   },
   {
     "id": "b_delivered",
     "name": "นาย ส่งของแล้ว",
     "phone": "0899999999",
     "address": "99/1 ถนนพัฒนา กรุงเทพฯ",
-    "delivered": true
+    "delivered": true,
+    "status": "shipped"
   }
 ]


### PR DESCRIPTION
## Summary
- mock bills now include a `status` field
- support bill status in fakeBillDB and map it to step index
- create `BillStatusStepper` component for visual progress
- show bill production status on bill view page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68808a482e188325b0acce7b4a5cc6ad