### PR TITLE
Add print button to bill view

### DIFF
--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import BillClientInteraction from '@/components/BillClientInteraction'
 import EditAddressForm from '@/components/bill/EditAddressForm'
+import PrintButton from '@/components/ui/PrintButton'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
 import { getBillById } from '@/core/mock/fakeBillDB'
 
@@ -27,7 +28,10 @@ export default function BillViewPage({ params }: { params: { billId: string } })
   }
 
   return (
-    <div className="space-y-6 p-4">
+    <div className="space-y-6 p-4 print:p-6 print:w-[210mm] print:mx-auto">
+      <div className="print:hidden">
+        <PrintButton />
+      </div>
       <BillClientInteraction bill={bill} />
       <EditAddressForm
         billId={bill.id}

--- a/components/ui/PrintButton.tsx
+++ b/components/ui/PrintButton.tsx
@@ -1,0 +1,29 @@
+"use client"
+import { Printer } from 'lucide-react'
+import { Button, type ButtonProps } from '@/components/ui/buttons/button'
+import { triggerPrint } from '@/lib/pdf/print'
+
+export default function PrintButton({
+  className,
+  variant = 'outline',
+  size = 'sm',
+  label = 'Print Bill',
+  ...props
+}: Omit<ButtonProps, 'variant' | 'size' | 'children'> & {
+  label?: string
+  variant?: ButtonProps['variant']
+  size?: ButtonProps['size']
+}) {
+  return (
+    <Button
+      onClick={triggerPrint}
+      variant={variant}
+      size={size}
+      className={className}
+      {...props}
+    >
+      <Printer className="h-4 w-4 mr-2" />
+      {label}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add `PrintButton` shared UI component
- show print button on `/bill/view/[billId]`
- refine print layout with Tailwind print classes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68809029e61883259d03a5e758ba9210