### PR TITLE
Enable bill status edits in admin

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -369,10 +369,19 @@ export default function AdminBillsPage() {
                       paidDate={paidAt}
                       highlightPayment={followupSuccess}
                       onSelect={() => toggle(b.id)}
-                      onStatusChange={(v) => {
-                        store.updateStatus(b.id, v)
-                        setBills([...store.bills])
-                        toast.success('สถานะบิลอัปเดตแล้ว ✅')
+                      onStatusChange={async (v) => {
+                        const res = await fetch('/api/bill/update-status', {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ billId: b.id, newStatus: v }),
+                        })
+                        if (res.ok) {
+                          store.updateStatus(b.id, v)
+                          setBills([...store.bills])
+                          toast.success('สถานะบิลอัปเดตแล้ว ✅')
+                        } else {
+                          toast.error('อัปเดตสถานะไม่สำเร็จ')
+                        }
                       }}
                       onEdit={() => {
                         setEdit(b.id)

--- a/app/api/bill/update-status/route.ts
+++ b/app/api/bill/update-status/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { join } from 'path'
+import { readJson, writeJson } from '@/lib/jsonFile'
+
+export async function PATCH(req: Request) {
+  const { billId, newStatus } = (await req.json().catch(() => ({}))) as {
+    billId?: string
+    newStatus?: string
+  }
+  if (!billId || !newStatus) {
+    return NextResponse.json({ error: 'missing fields' }, { status: 400 })
+  }
+  const file = join(process.cwd(), 'mock', 'bills.json')
+  const bills = await readJson<any[]>(file, [])
+  const bill = bills.find(b => b.id === billId)
+  if (!bill) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+  bill.status = newStatus
+  await writeJson(file, bills)
+  return NextResponse.json({ success: true })
+}

--- a/components/admin/bills/BillStatusDropdown.tsx
+++ b/components/admin/bills/BillStatusDropdown.tsx
@@ -10,19 +10,22 @@ interface BillStatusDropdownProps {
 
 function getBadgeClass(status: AdminBill['status']) {
   if (status === 'paid') return 'bg-green-500 text-white'
-  if (status === 'cancelled') return 'bg-gray-500 text-white'
-  if (status === 'unpaid') return 'bg-red-500 text-white'
   if (status === 'shipped') return 'bg-purple-500 text-white'
-  if (status === 'pending') return 'bg-blue-500 text-white'
-  return 'bg-yellow-500 text-white'
+  if (status === 'delivered') return 'bg-blue-500 text-white'
+  if (status === 'packing') return 'bg-yellow-500 text-white'
+  if (status === 'cutting' || status === 'sewing' || status === 'waiting')
+    return 'bg-gray-500 text-white'
+  return 'bg-gray-500 text-white'
 }
 
 function getLabel(status: AdminBill['status']) {
-  if (status === 'paid') return '🟢 ชำระแล้ว'
-  if (status === 'cancelled') return '⚫️ ยกเลิก'
-  if (status === 'unpaid') return '🔴 รอชำระ'
+  if (status === 'paid') return 'ชำระแล้ว'
   if (status === 'shipped') return 'จัดส่งแล้ว'
-  if (status === 'pending') return 'รอตรวจสอบ'
+  if (status === 'delivered') return 'ส่งมอบแล้ว'
+  if (status === 'packing') return 'แพ็กของ'
+  if (status === 'cutting') return 'ตัดผ้า'
+  if (status === 'sewing') return 'เย็บ'
+  if (status === 'waiting') return 'รอคิว'
   return status
 }
 
@@ -33,10 +36,13 @@ export default function BillStatusDropdown({ status, onChange }: BillStatusDropd
         <Badge className={getBadgeClass(status)}>{getLabel(status)}</Badge>
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="unpaid">รอชำระ</SelectItem>
-        <SelectItem value="paid">ชำระแล้ว</SelectItem>
+        <SelectItem value="waiting">รอคิว</SelectItem>
+        <SelectItem value="cutting">ตัดผ้า</SelectItem>
+        <SelectItem value="sewing">เย็บ</SelectItem>
+        <SelectItem value="packing">แพ็กของ</SelectItem>
         <SelectItem value="shipped">จัดส่งแล้ว</SelectItem>
-        <SelectItem value="cancelled">ยกเลิก</SelectItem>
+        <SelectItem value="delivered">ส่งมอบแล้ว</SelectItem>
+        <SelectItem value="paid">ชำระแล้ว</SelectItem>
       </SelectContent>
     </Select>
   )

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -16,6 +16,10 @@ export interface AdminBill {
     | 'delivered'
     | 'failed'
     | 'cancelled'
+    | 'waiting'
+    | 'cutting'
+    | 'sewing'
+    | 'packing'
   paymentStatus: 'unpaid' | 'paid' | 'partial'
   paymentMethod?: 'cod' | 'bank_transfer' | 'promptpay' | 'credit_card'
   tags: string[]


### PR DESCRIPTION
## Summary
- add endpoint `api/bill/update-status`
- allow status dropdown to show new statuses
- patch bill status via API from admin page
- extend `AdminBill` status type to include new states

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68809b7737108325aa990608996e9930