### PR TITLE
Add bill status update API

### DIFF
--- a/app/api/bill/update-status/route.ts
+++ b/app/api/bill/update-status/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { join } from 'path'
+import { readJson, writeJson } from '@/lib/jsonFile'
+
+export async function POST(req: Request) {
+  const { billId, newStatus } = (await req.json().catch(() => ({}))) as {
+    billId?: string
+    newStatus?: string
+  }
+
+  if (!billId || !newStatus) {
+    return NextResponse.json({ error: 'missing fields' }, { status: 400 })
+  }
+
+  const file = join(process.cwd(), 'mock', 'bills.json')
+  const bills = await readJson<any[]>(file, [])
+  const bill = bills.find(b => b.id === billId)
+  if (!bill) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  bill.status = newStatus
+  await writeJson(file, bills)
+  return NextResponse.json(bill)
+}


### PR DESCRIPTION
## Summary
- add new `POST /api/bill/update-status` endpoint
- allow clients to update a bill status in `mock/bills.json`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68809d0e60408325a2c58208a4b104b7