### PR TITLE
Add BillStatus typing for update-status API

### DIFF
--- a/app/api/bill/update-status/route.ts
+++ b/app/api/bill/update-status/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server'
 import { join } from 'path'
 import { readJson, writeJson } from '@/lib/jsonFile'
+import type { BillStatus } from '@/core/mock/fakeBillDB'
 
 export async function PATCH(req: Request) {
   const { billId, newStatus } = (await req.json().catch(() => ({}))) as {
     billId?: string
-    newStatus?: string
+    newStatus?: BillStatus
   }
   if (!billId || !newStatus) {
     return NextResponse.json({ error: 'missing fields' }, { status: 400 })


### PR DESCRIPTION
## Summary
- tighten typing for `/api/bill/update-status`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b72144d48325be1a35f78506321a