### PR TITLE
Add bill notes field for admins

### DIFF
--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -348,6 +348,7 @@ export default function AdminBillsPage() {
                   <TableHead>ชื่อลูกค้า</TableHead>
                   <TableHead className="text-right">ยอดรวม</TableHead>
                   <TableHead>ติดต่อ</TableHead>
+                  <TableHead>หมายเหตุ</TableHead>
                   <TableHead>แท็ก</TableHead>
                   <TableHead>สถานะ</TableHead>
                   <TableHead>Last Follow-up</TableHead>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -46,6 +46,7 @@ export default function BillViewPage({ params }: { params: { billId: string } })
       />
       <BillTimeline status={bill.status} />
       <MarkAsPaidButton billId={bill.id} status={bill.status} onPaid={() => setBill({ ...bill, status: 'paid' })} />
+      {bill.note && <p className="text-sm">Note: {bill.note}</p>}
       {(bill.trackingNo || bill.deliveryDate) && (
         <div className="text-sm space-y-1">
           {bill.trackingNo && <p>Tracking: {bill.trackingNo}</p>}

--- a/components/admin/bills/BillRow.tsx
+++ b/components/admin/bills/BillRow.tsx
@@ -51,6 +51,7 @@ export default function BillRow({ bill, selected, onSelect, onEdit, paidDate, hi
       <TableCell>{bill.customer}</TableCell>
       <TableCell className="text-right">{formatCurrency(total)}</TableCell>
       <TableCell>{contact}</TableCell>
+      <TableCell className="max-w-[8rem] truncate">{bill.note}</TableCell>
       <TableCell>
         <BillStatusControl billId={bill.id} status={bill.status} />
       </TableCell>

--- a/core/mock/fakeBillDB.ts
+++ b/core/mock/fakeBillDB.ts
@@ -39,6 +39,7 @@ interface RawBill {
   status: BillStatus
   deliveryDate?: string
   trackingNo?: string
+  notes?: string
 }
 
 let bills: FakeBill[] | null = null
@@ -63,6 +64,7 @@ async function loadBills(): Promise<FakeBill[]> {
       status: b.status,
       deliveryDate: b.deliveryDate,
       trackingNo: b.trackingNo,
+      note: b.notes,
       items: [],
       statusStep: stepMap[b.status] ?? 0,
       lastUpdated: '',

--- a/mock/bills.json
+++ b/mock/bills.json
@@ -7,7 +7,8 @@
     "delivered": false,
     "status": "waiting",
     "deliveryDate": "2024-05-20",
-    "trackingNo": "TH1234567890"
+    "trackingNo": "TH1234567890",
+    "notes": ""
   },
   {
     "id": "b_delivered",
@@ -17,6 +18,7 @@
     "delivered": true,
     "status": "shipped",
     "deliveryDate": "2024-05-18",
-    "trackingNo": "TH0987654321"
+    "trackingNo": "TH0987654321",
+    "notes": ""
   }
 ]


### PR DESCRIPTION
## Summary
- add `notes` column to mock bills dataset
- expose notes from fake bill DB
- show notes column in admin bills table
- display bill note on bill view page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6880e443788083259527c9beef7722ad