### PR TITLE
Add status tags and show note in admin bills

### DIFF
--- a/components/admin/bills/BillRow.tsx
+++ b/components/admin/bills/BillRow.tsx
@@ -3,7 +3,8 @@ import { TableRow, TableCell } from '@/components/ui/table'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Copy } from 'lucide-react'
 import BillItemActions from '@/components/admin/BillItemActions'
-import BillStatusControl from '../BillStatusControl'
+import BillStatusTag from './BillStatusTag'
+import { Badge } from '@/components/ui/badge'
 import { formatCurrency } from '@/lib/utils'
 import { formatDateThai } from '@/lib/formatDateThai'
 import { copyToClipboard } from '@/helpers/clipboard'
@@ -52,8 +53,15 @@ export default function BillRow({ bill, selected, onSelect, onEdit, paidDate, hi
       <TableCell className="text-right">{formatCurrency(total)}</TableCell>
       <TableCell>{contact}</TableCell>
       <TableCell className="max-w-[8rem] truncate">{bill.note}</TableCell>
+      <TableCell className="space-x-1 whitespace-nowrap">
+        {bill.tags.map((t) => (
+          <Badge key={t} variant="secondary">
+            {t}
+          </Badge>
+        ))}
+      </TableCell>
       <TableCell>
-        <BillStatusControl billId={bill.id} status={bill.status} />
+        <BillStatusTag status={bill.status} />
       </TableCell>
       <TableCell>
         {lastFollow ? formatDateThai(lastFollow) : '-'}

--- a/components/admin/bills/BillStatusDropdown.tsx
+++ b/components/admin/bills/BillStatusDropdown.tsx
@@ -2,38 +2,24 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import type { AdminBill } from "@/mock/bills"
+import {
+  getBillStatusBadgeClass,
+  getBillStatusLabel,
+} from "@/lib/bill-status"
 
 interface BillStatusDropdownProps {
   status: AdminBill['status']
   onChange: (status: AdminBill['status']) => void
 }
 
-function getBadgeClass(status: AdminBill['status']) {
-  if (status === 'paid') return 'bg-green-500 text-white'
-  if (status === 'shipped') return 'bg-purple-500 text-white'
-  if (status === 'delivered') return 'bg-blue-500 text-white'
-  if (status === 'packing') return 'bg-yellow-500 text-white'
-  if (status === 'cutting' || status === 'sewing' || status === 'waiting')
-    return 'bg-gray-500 text-white'
-  return 'bg-gray-500 text-white'
-}
-
-function getLabel(status: AdminBill['status']) {
-  if (status === 'paid') return 'ชำระแล้ว'
-  if (status === 'shipped') return 'จัดส่งแล้ว'
-  if (status === 'delivered') return 'ส่งมอบแล้ว'
-  if (status === 'packing') return 'แพ็กของ'
-  if (status === 'cutting') return 'ตัดผ้า'
-  if (status === 'sewing') return 'เย็บ'
-  if (status === 'waiting') return 'รอคิว'
-  return status
-}
 
 export default function BillStatusDropdown({ status, onChange }: BillStatusDropdownProps) {
   return (
     <Select value={status} onValueChange={v => onChange(v as AdminBill['status'])}>
       <SelectTrigger className="w-32">
-        <Badge className={getBadgeClass(status)}>{getLabel(status)}</Badge>
+        <Badge className={getBillStatusBadgeClass(status)}>
+          {getBillStatusLabel(status)}
+        </Badge>
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="waiting">รอคิว</SelectItem>

--- a/components/admin/bills/BillStatusTag.tsx
+++ b/components/admin/bills/BillStatusTag.tsx
@@ -1,0 +1,12 @@
+"use client"
+import { Badge } from '@/components/ui/badge'
+import type { AdminBill } from '@/mock/bills'
+import { getBillStatusBadgeClass, getBillStatusLabel } from '@/lib/bill-status'
+
+export default function BillStatusTag({ status }: { status: AdminBill['status'] }) {
+  return (
+    <Badge className={getBillStatusBadgeClass(status)}>
+      {getBillStatusLabel(status)}
+    </Badge>
+  )
+}

--- a/lib/bill-status.ts
+++ b/lib/bill-status.ts
@@ -1,0 +1,55 @@
+import type { AdminBill } from '@/mock/bills'
+
+export function getBillStatusLabel(status: AdminBill['status']): string {
+  switch (status) {
+    case 'waiting':
+      return 'รอคิว'
+    case 'cutting':
+      return 'ตัดผ้า'
+    case 'sewing':
+      return 'เย็บ'
+    case 'packing':
+    case 'packed':
+      return 'แพ็กของ'
+    case 'shipped':
+      return 'จัดส่งแล้ว'
+    case 'delivered':
+      return 'ส่งมอบแล้ว'
+    case 'paid':
+      return 'ชำระแล้ว'
+    case 'unpaid':
+      return 'รอชำระ'
+    case 'pending':
+      return 'รอตรวจสอบ'
+    case 'cancelled':
+      return 'ยกเลิก'
+    case 'failed':
+      return 'ไม่สำเร็จ'
+    default:
+      return status
+  }
+}
+
+export function getBillStatusBadgeClass(status: AdminBill['status']): string {
+  switch (status) {
+    case 'paid':
+      return 'bg-green-500 text-white'
+    case 'shipped':
+      return 'bg-purple-500 text-white'
+    case 'delivered':
+      return 'bg-blue-500 text-white'
+    case 'packing':
+    case 'packed':
+      return 'bg-yellow-500 text-white'
+    case 'cancelled':
+    case 'failed':
+      return 'bg-red-500 text-white'
+    case 'waiting':
+    case 'cutting':
+    case 'sewing':
+    case 'unpaid':
+    case 'pending':
+    default:
+      return 'bg-gray-500 text-white'
+  }
+}


### PR DESCRIPTION
## Summary
- show note and status badges in admin bill list
- provide color helpers for bill status

## Testing
- `pnpm test`
- `pnpm eslint`


------
https://chatgpt.com/codex/tasks/task_e_6880e8e690108325b0f791018d251509