### PR TITLE
Add product collection pages

### DIFF
--- a/app/collection/[slug]/error.tsx
+++ b/app/collection/[slug]/error.tsx
@@ -1,0 +1,4 @@
+'use client'
+export default function Error() {
+  return <div className="p-4 text-red-500">เกิดข้อผิดพลาดในการโหลดข้อมูล</div>
+}

--- a/app/collection/[slug]/loading.tsx
+++ b/app/collection/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="p-4 animate-pulse text-gray-400">กำลังโหลด...</div>
+}

--- a/app/collection/[slug]/page.tsx
+++ b/app/collection/[slug]/page.tsx
@@ -1,0 +1,31 @@
+import collections from '@/mock/store/collections.json'
+import products from '@/mock/store/products.json'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import { ProductCard } from '@/components/ProductCard'
+import { notFound } from 'next/navigation'
+
+export default function CollectionPage({ params }: { params: { slug: string } }) {
+  const collection = (collections as any[]).find(c => c.slug === params.slug)
+  if (!collection) notFound()
+  const items = (products as any[]).filter(p => (p.collections || []).includes(collection.id))
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1 space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">{collection.title}</h1>
+          {collection.description && (
+            <p className="text-gray-600">{collection.description}</p>
+          )}
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {items.map((p) => (
+            <ProductCard key={p.id} product={p as any} />
+          ))}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/app/product/[id]/error.tsx
+++ b/app/product/[id]/error.tsx
@@ -1,0 +1,4 @@
+'use client'
+export default function Error() {
+  return <div className="p-4 text-red-500">เกิดข้อผิดพลาดในการโหลดสินค้า</div>
+}

--- a/app/product/[id]/loading.tsx
+++ b/app/product/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="p-4 animate-pulse text-gray-400">กำลังโหลดสินค้า...</div>
+}

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,0 +1,37 @@
+import products from '@/mock/store/products.json'
+import { Navbar } from '@/components/navbar'
+import { Footer } from '@/components/footer'
+import Image from 'next/image'
+import { Button } from '@/components/ui/buttons/button'
+import { notFound } from 'next/navigation'
+
+export default function ProductDetail({ params }: { params: { id: string } }) {
+  const product = (products as any[]).find(p => p.id === params.id)
+  if (!product) notFound()
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="container mx-auto px-4 py-8 flex-1 space-y-6">
+        <h1 className="text-3xl font-bold">{product.name}</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            {product.images.map((img: string, idx: number) => (
+              <div key={idx} className="relative aspect-square">
+                <Image src={img} alt={product.name} fill className="object-cover rounded" />
+              </div>
+            ))}
+          </div>
+          <div className="space-y-2">
+            {product.sizes && <p>ขนาด: {product.sizes.join(', ')}</p>}
+            {product.material && <p>ผิวสัมผัส: {product.material}</p>}
+            {product.type && <p>เหมาะกับ: {product.type}</p>}
+            <a href="https://m.me/elfsofacover" target="_blank" rel="noopener noreferrer">
+              <Button className="mt-4">สอบถามเข้าร้าน</Button>
+            </a>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,0 +1,31 @@
+"use client"
+import Image from 'next/image'
+import Link from 'next/link'
+import { Button } from '@/components/ui/buttons/button'
+import type { Product } from '@/types/product'
+
+export function ProductCard({ product }: { product: Product }) {
+  return (
+    <div className="border rounded-lg overflow-hidden bg-white flex flex-col">
+      <div className="relative aspect-square">
+        <Image
+          src={product.images?.[0] || '/placeholder.svg'}
+          alt={product.name}
+          fill
+          className="object-cover"
+        />
+      </div>
+      <div className="p-3 flex-1 flex flex-col space-y-2 text-center">
+        <h3 className="font-medium line-clamp-2">{product.name}</h3>
+        {product.sizes && (
+          <p className="text-sm text-gray-600">ขนาด {product.sizes.join(', ')}</p>
+        )}
+        <Link href={`/product/${product.id}`} className="mt-auto">
+          <Button className="w-full" size="sm">
+            ดูรายละเอียด
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/mock/store/collections.json
+++ b/mock/store/collections.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "col-1",
+    "title": "ผ้าลายมัดหมี่",
+    "description": "ชุดผ้าลายมัดหมี่พื้นเมือง",
+    "slug": "mudmee",
+    "products": ["1"]
+  },
+  {
+    "id": "col-2",
+    "title": "Minimal สีเรียบ",
+    "description": "โทนสีเรียบ เหมาะกับทุกห้อง",
+    "slug": "minimal",
+    "products": ["2", "3"]
+  }
+]

--- a/mock/store/products.json
+++ b/mock/store/products.json
@@ -6,7 +6,8 @@
     "colors": ["Navy Blue", "Charcoal Gray"],
     "material": "Velvet",
     "image": "/placeholder.svg?height=400&width=400",
-    "description": "ผ้ากำมะหยี่คุณภาพสูง นุ่มสบาย กันน้ำ"
+    "description": "ผ้ากำมะหยี่คุณภาพสูง นุ่มสบาย กันน้ำ",
+    "collections": ["col-1"]
   },
   {
     "id": "2",
@@ -15,7 +16,8 @@
     "colors": ["Cream", "Beige"],
     "material": "Cotton",
     "image": "/placeholder.svg?height=400&width=400",
-    "description": "ระบายอากาศได้ดี เหมาะกับอากาศร้อน"
+    "description": "ระบายอากาศได้ดี เหมาะกับอากาศร้อน",
+    "collections": ["col-2"]
   },
   {
     "id": "3",
@@ -24,6 +26,7 @@
     "colors": ["Black", "Brown"],
     "material": "Polyester",
     "image": "/placeholder.svg?height=400&width=400",
-    "description": "กันน้ำ 100% เหมาะสำหรับบ้านที่มีสัตว์เลี้ยง"
+    "description": "กันน้ำ 100% เหมาะสำหรับบ้านที่มีสัตว์เลี้ยง",
+    "collections": ["col-2"]
   }
 ]


### PR DESCRIPTION
## Summary
- mock data: collections.json with product relationships
- link products to collections in products.json
- add a reusable ProductCard component
- show collection details and products at `/collection/[slug]`
- provide simplified product detail view at `/product/[id]`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6880f63aebd883259c1e5b60f9f5a405