### PR TITLE
Implement message-to-bill workflow

### DIFF
--- a/app/admin/bill/create/page.tsx
+++ b/app/admin/bill/create/page.tsx
@@ -18,6 +18,7 @@ import { getFabrics, getBills } from '@/core/mock/store'
 import customersData from '@/mock/customers.json'
 import type { Customer } from '@/types/customer'
 import { copyToClipboard } from '@/helpers/clipboard'
+import { parseMessage } from '@/lib/messageToBill'
 
 export default function AdminBillCreatePage() {
   const router = useRouter()
@@ -44,7 +45,31 @@ export default function AdminBillCreatePage() {
 
   useEffect(() => {
     const from = params.get('from')
-    if (from) {
+    if (from === 'cart') {
+      if (typeof window !== 'undefined') {
+        const stored = localStorage.getItem('cart')
+        if (stored) {
+          try {
+            const cart = JSON.parse(stored) as Array<{id:string;qty:number}>
+            if (cart[0]) {
+              setFabricId(cart[0].id)
+              setQuantity(cart[0].qty)
+            }
+          } catch {}
+        }
+      }
+    } else if (from === 'message') {
+      const text = params.get('text') || ''
+      if (text) {
+        const { items, customerName: name, customerPhone: phone } = parseMessage(text)
+        if (items[0]) {
+          setFabricId(items[0].productId)
+          setQuantity(items[0].quantity)
+        }
+        if (name) setCustomerName(name)
+        if (phone) setCustomerPhone(phone)
+      }
+    } else if (from) {
       const b = getBills().find(x => x.id === from)
       if (b) {
         setCustomerName(b.customer)

--- a/app/admin/bills/page.tsx
+++ b/app/admin/bills/page.tsx
@@ -25,6 +25,7 @@ import type { AdminBill, BillItem } from '@/mock/bills'
 import { useBillStore } from '@/core/store'
 import { getBillActivity } from '@/core/mock/store'
 import { toast } from 'sonner'
+import CreateBillFromMessageDialog from '@/components/admin/bills/CreateBillFromMessageDialog'
 
 export default function AdminBillsPage() {
   const store = useBillStore()
@@ -281,6 +282,7 @@ export default function AdminBillsPage() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+        <CreateBillFromMessageDialog onCreated={(id)=>toast.success(`สร้างบิล ${id}`)} />
       </div>
       <Card>
         <CardHeader>

--- a/components/admin/bills/CreateBillFromMessageDialog.tsx
+++ b/components/admin/bills/CreateBillFromMessageDialog.tsx
@@ -1,0 +1,70 @@
+"use client"
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from '@/components/ui/modals/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/buttons/button'
+import { Input } from '@/components/ui/inputs/input'
+import { parseMessage } from '@/lib/messageToBill'
+import { useBillStore } from '@/core/store'
+
+export default function CreateBillFromMessageDialog({ onCreated }: { onCreated: (id: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [message, setMessage] = useState('')
+  const [items, setItems] = useState<{productId:string,quantity:number}[]>([])
+  const [customerName, setCustomerName] = useState('')
+  const [customerPhone, setCustomerPhone] = useState('')
+  const addBill = useBillStore(s => s.addBill)
+
+  useEffect(() => {
+    const parsed = parseMessage(message)
+    setItems(parsed.items)
+    if (parsed.customerName) setCustomerName(parsed.customerName)
+    if (parsed.customerPhone) setCustomerPhone(parsed.customerPhone)
+  }, [message])
+
+  const create = () => {
+    if (items.length === 0) return
+    const bill = addBill({
+      customer: customerName || 'ลูกค้า',
+      items: items.map(it => ({ name: it.productId, quantity: it.quantity, price: 0 })),
+      shipping: 0,
+      note: '',
+      tags: [],
+      paymentStatus: 'unpaid',
+    } as any)
+    setOpen(false)
+    setMessage('')
+    setItems([])
+    onCreated((bill as any).id)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">สร้างบิลจากแชท</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>สร้างบิลจากข้อความ</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Textarea placeholder="วางข้อความแชท" value={message} onChange={e=>setMessage(e.target.value)} />
+          <Input placeholder="ชื่อลูกค้า" value={customerName} onChange={e=>setCustomerName(e.target.value)} />
+          <Input placeholder="เบอร์โทร" value={customerPhone} onChange={e=>setCustomerPhone(e.target.value)} />
+          <div className="space-y-1 text-sm">
+            {items.map((it,idx)=>(
+              <div key={idx} className="flex justify-between">
+                <span>{it.productId}</span>
+                <span>x{it.quantity}</span>
+              </div>
+            ))}
+            {items.length===0 && <p className="text-center text-gray-500">ไม่พบสินค้า</p>}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={create} disabled={items.length===0}>สร้างบิล</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/messageToBill.ts
+++ b/lib/messageToBill.ts
@@ -1,0 +1,54 @@
+import customersData from '@/mock/customers.json'
+
+export interface ParsedItem {
+  productId: string
+  quantity: number
+}
+
+export interface ParsedMessage {
+  customerId?: string
+  customerName?: string
+  customerPhone?: string
+  items: ParsedItem[]
+}
+
+const templateMap: Record<string, string> = {
+  'ปลอกหมอน': 'pillow-case',
+  'สีครีม 3 เมตร': 'cream-3m',
+}
+
+export function parseMessage(text: string): ParsedMessage {
+  const lower = text.toLowerCase()
+  const items: ParsedItem[] = []
+  for (const [phrase, productId] of Object.entries(templateMap)) {
+    const idx = lower.indexOf(phrase.toLowerCase())
+    if (idx !== -1) {
+      const after = text.slice(idx + phrase.length)
+      const qtyMatch = after.match(/(\d+)/)
+      const qty = qtyMatch ? parseInt(qtyMatch[1]) : 1
+      items.push({ productId, quantity: qty })
+    }
+  }
+
+  let customerPhone: string | undefined
+  const phoneMatch = text.match(/0\d{8,9}/)
+  if (phoneMatch) customerPhone = phoneMatch[0]
+
+  let customerName: string | undefined
+  const nameMatch = text.match(/คุณ\s*([^\s\d]+)/)
+  if (nameMatch) customerName = nameMatch[1]
+
+  let customerId: string | undefined
+  if (customerPhone) {
+    const customers = customersData as Array<{ id: string; name: string; phone?: string }>
+    const c = customers.find(cu => cu.phone && cu.phone.includes(customerPhone!))
+    if (c) {
+      customerId = c.id
+      customerName = c.name
+    }
+  }
+
+  return { customerId, customerName, customerPhone, items }
+}
+
+export const templateMapping = templateMap


### PR DESCRIPTION
## Summary
- add parser for converting chat text to bill data
- provide a dialog to create bills directly from chat messages
- support `from=cart` and `from=message` on bill create page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6880faf15a0483258b98c08a3f7a62e2