### PR TITLE
Add shareable bill link with QR and tracking

### DIFF
--- a/app/admin/bills/[id]/page.tsx
+++ b/app/admin/bills/[id]/page.tsx
@@ -2,6 +2,9 @@
 import { useEffect, useState } from 'react'
 import { getBills, addBillActivity } from '@/core/mock/store'
 import { useBillStore } from '@/core/store'
+import { copyToClipboard } from '@/helpers/clipboard'
+import { generateQRUrl } from '@/lib/qr/generate'
+import { useBillStore } from '@/core/store'
 import { Button } from '@/components/ui/buttons/button'
 import Link from 'next/link'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -66,6 +69,20 @@ export default function AdminBillDetail({ params }: { params: { id: string } }) 
       <div className="flex items-center space-x-2">
         <h1 className="text-xl font-bold">บิล {bill.id}</h1>
         <Link href={`/admin/bills/${bill.id}/timeline`} className="text-sm underline text-blue-600">timeline</Link>
+      </div>
+      <div className="flex items-center space-x-4">
+        <img
+          src={generateQRUrl(`${window.location.origin}/bill/view/${bill.id}`)}
+          alt="QR"
+          className="w-24 h-24 border"
+        />
+        <Button
+          variant="outline"
+          onClick={() => {
+            copyToClipboard(`${window.location.origin}/bill/view/${bill.id}`)
+            store.recordShare(bill.id, 'admin')
+          }}
+        >คัดลอกลิงก์</Button>
       </div>
       <div className="flex items-center space-x-2">
         <span className="text-sm">สถานะ:</span>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -10,8 +10,23 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/buttons/button'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
 import { getBillById } from '@/core/mock/fakeBillDB'
+import type { Metadata } from 'next'
 import { getCustomerById } from '@/core/mock/fakeCustomerDB'
 import type { Customer } from '@/types/customer'
+
+export async function generateMetadata({ params }: { params: { billId: string } }): Promise<Metadata> {
+  const bill = await getBillById(params.billId)
+  const title = '🧾 บิลของคุณ'
+  const description = bill ? `ชำระได้ที่นี่ → ${params.billId}` : 'บิลของคุณ'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+  }
+}
 
 export default function BillViewPage({ params }: { params: { billId: string } }) {
   const { billId } = params

--- a/app/s/[billId]/page.tsx
+++ b/app/s/[billId]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function ShortBill({ params }: { params: { billId: string } }) {
+  redirect(`/bill/view/${params.billId}`)
+}

--- a/components/admin/bills/BillRow.tsx
+++ b/components/admin/bills/BillRow.tsx
@@ -9,6 +9,7 @@ import { formatCurrency } from '@/lib/utils'
 import { formatDateThai } from '@/lib/formatDateThai'
 import { copyToClipboard } from '@/helpers/clipboard'
 import type { AdminBill } from '@/mock/bills'
+import { useBillStore } from '@/core/store'
 
 interface BillRowProps {
   bill: AdminBill
@@ -20,6 +21,7 @@ interface BillRowProps {
 }
 
 export default function BillRow({ bill, selected, onSelect, onEdit, paidDate, highlightPayment }: BillRowProps) {
+  const store = useBillStore()
   const total = bill.items.reduce((s, it) => s + it.price * it.quantity, 0) + bill.shipping
   const contact =
     (bill as any).customerPhone ??
@@ -43,7 +45,10 @@ export default function BillRow({ bill, selected, onSelect, onEdit, paidDate, hi
         {bill.id}
         <button
           type="button"
-          onClick={() => copyToClipboard(`${window.location.origin}/bill/${bill.id}`)}
+          onClick={() => {
+            copyToClipboard(`${window.location.origin}/bill/view/${bill.id}`)
+            store.recordShare(bill.id, 'admin')
+          }}
           title="คัดลอกลิงก์"
         >
           🔗
@@ -76,7 +81,10 @@ export default function BillRow({ bill, selected, onSelect, onEdit, paidDate, hi
         <button
           type="button"
           className="text-sm text-blue-600 flex items-center"
-          onClick={() => copyToClipboard(`${window.location.origin}/bill/${bill.id}`)}
+          onClick={() => {
+            copyToClipboard(`${window.location.origin}/bill/view/${bill.id}`)
+            store.recordShare(bill.id, 'admin')
+          }}
         >
           <Copy className="h-4 w-4 mr-1" />คัดลอกลิงก์
         </button>

--- a/core/mock/store/bills.ts
+++ b/core/mock/store/bills.ts
@@ -110,3 +110,11 @@ export function setBillFeedback(id: string, feedback: AdminBill['feedback']) {
     persist()
   }
 }
+
+export function recordShare(id: string, user: string) {
+  const idx = bills.findIndex(b => b.id === id)
+  if (idx !== -1) {
+    bills[idx] = { ...bills[idx], sharedAt: new Date().toISOString(), sharedBy: user }
+    persist()
+  }
+}

--- a/core/store/bills.ts
+++ b/core/store/bills.ts
@@ -13,6 +13,7 @@ import {
   deleteBill,
   autoArchiveBills,
 } from '@/core/mock/store'
+import { recordShare as recordShareInternal } from '@/core/mock/store'
 
 interface BillStore {
   bills: AdminBill[]
@@ -28,6 +29,7 @@ interface BillStore {
   restore: (id: string) => void
   remove: (id: string) => void
   setFeedback: (id: string, fb: AdminBill['feedback']) => void
+  recordShare: (id: string, user: string) => void
 }
 
 export const useBillStore = create<BillStore>((set) => ({
@@ -67,6 +69,10 @@ export const useBillStore = create<BillStore>((set) => ({
   },
   setFeedback: (id, fb) => {
     setFb(id, fb)
+    set({ bills: getBills() })
+  },
+  recordShare: (id, user) => {
+    recordShareInternal(id, user)
     set({ bills: getBills() })
   },
 }))

--- a/mock/bills.json
+++ b/mock/bills.json
@@ -7,7 +7,9 @@
     "deliveryDate": "2024-05-20",
     "trackingNo": "TH1234567890",
     "carrier": "Kerry",
-    "notes": ""
+    "notes": "",
+    "sharedAt": null,
+    "sharedBy": null
   },
   {
     "id": "b_delivered",
@@ -17,6 +19,8 @@
     "deliveryDate": "2024-05-18",
     "trackingNo": "TH0987654321",
     "carrier": "Flash",
-    "notes": ""
+    "notes": "",
+    "sharedAt": null,
+    "sharedBy": null
   }
 ]

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -36,6 +36,8 @@ export interface AdminBill {
   archived?: boolean
   /** timestamps for follow up contact */
   followup_log?: string[]
+  sharedAt?: string | null
+  sharedBy?: string | null
 }
 
 export const mockBills: AdminBill[] = [
@@ -55,11 +57,13 @@ export const mockBills: AdminBill[] = [
   trackingNo: 'TH1234567890',
   deliveryDate: new Date().toISOString(),
   carrier: 'Kerry',
-  shippingMethod: 'Flash',
+    shippingMethod: 'Flash',
     shippingStatus: 'shipped',
     phone: '0812345678',
     createdAt: new Date().toISOString(),
     followup_log: [],
+    sharedAt: null,
+    sharedBy: null,
   },
   {
     id: 'BILL-002',
@@ -76,6 +80,8 @@ export const mockBills: AdminBill[] = [
   carrier: 'Flash',
   createdAt: new Date().toISOString(),
     followup_log: [],
+    sharedAt: null,
+    sharedBy: null,
   },
   {
     id: 'BILL-003',
@@ -92,6 +98,8 @@ export const mockBills: AdminBill[] = [
   carrier: 'JT',
   createdAt: new Date().toISOString(),
     followup_log: [],
+    sharedAt: null,
+    sharedBy: null,
   },
 ]
 

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -11,7 +11,9 @@
     "phone": "0812345678",
     "paymentStatus": "paid",
     "createdAt": "2024-01-15T08:00:00Z",
-    "followup_log": []
+    "followup_log": [],
+    "sharedAt": "2024-01-20T00:00:00Z",
+    "sharedBy": "admin"
   },
   {
     "id": "BILL-002",
@@ -23,7 +25,9 @@
     "status": "cancelled",
     "paymentStatus": "unpaid",
     "createdAt": "2024-01-16T08:00:00Z",
-    "followup_log": []
+    "followup_log": [],
+    "sharedAt": null,
+    "sharedBy": null
   },
   {
     "id": "BILL-003",
@@ -35,6 +39,8 @@
     "status": "cancelled",
     "paymentStatus": "unpaid",
     "createdAt": "2024-01-17T08:00:00Z",
-    "followup_log": []
+    "followup_log": [],
+    "sharedAt": null,
+    "sharedBy": null
   }
 ]


### PR DESCRIPTION
## Summary
- allow admins to copy bill links that point to `/bill/view/[id]`
- record share time and user in bills store
- show QR code and copy button in admin bill detail
- short redirect route `/s/[billId]`
- expose Open Graph metadata for bill view links
- update mock bill data with `sharedAt` and `sharedBy` fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880fd44c40c8325ae8457c1e4fc2bf7