### PR TITLE
Add realtime bill sync

### DIFF
--- a/app/api/bill/view/[billId]/route.ts
+++ b/app/api/bill/view/[billId]/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import { getBillById } from '@/core/mock/fakeBillDB'
+
+export async function GET(req: Request, { params }: { params: { billId: string } }) {
+  const bill = await getBillById(params.billId)
+  if (!bill) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+  return NextResponse.json(bill)
+}

--- a/components/bill/BillTimeline.tsx
+++ b/components/bill/BillTimeline.tsx
@@ -13,7 +13,7 @@ const steps = [
 export default function BillTimeline({ status }: { status: BillStatus }) {
   const current = steps.findIndex(s => s.key === status)
   return (
-    <div className="flex items-center justify-between relative">
+    <div id="bill-timeline" className="flex items-center justify-between relative transition-all">
       {steps.map((step, index) => {
         const StepIcon = step.icon
         const isDone = index <= current
@@ -21,7 +21,7 @@ export default function BillTimeline({ status }: { status: BillStatus }) {
         return (
           <div key={step.key} className="flex flex-col items-center flex-1">
             <div
-              className={`w-8 h-8 rounded-full flex items-center justify-center mb-1 ${
+              className={`w-8 h-8 rounded-full flex items-center justify-center mb-1 transition-colors ${
                 isDone
                   ? 'bg-green-500 text-white'
                   : isCurrent

--- a/hooks/useBillSync.ts
+++ b/hooks/useBillSync.ts
@@ -1,0 +1,12 @@
+"use client"
+import useSWR from 'swr'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function useBillSync(id: string) {
+  const { data, error, mutate } = useSWR<FakeBill>(`/api/bill/view/${id}`, fetcher, {
+    refreshInterval: 5000,
+  })
+  return { bill: data, isLoading: !data && !error, error, mutate }
+}


### PR DESCRIPTION
## Summary
- create API endpoint for fetching fake bill
- add polling hook
- highlight BillTimeline with transitions and ID for scrolling
- rework bill view page to poll and show update indicator

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6881004cd80c8325a4cebe6159d3281e