### PR TITLE
Fix build issues: move metadata to head

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,0 +1,15 @@
+import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = headers().get('accept-language') || ''
+  const th = lang.includes('th')
+  const title = th ? 'โซฟาคัฟเวอร์ โปร ร้านผ้าคลุมโซฟา' : 'SofaCover Pro Premium Sofa Covers'
+  const description = th ? 'ซื้อผ้าคลุมโซฟาคุณภาพและบริการครบวงจร' : 'Premium sofa covers with great service.'
+  const image = '/og-home.png'
+  return {
+    title,
+    description,
+    openGraph: { title, description, images: [{ url: image }] },
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,25 +14,6 @@ import type { Collection } from "@/types/collection"
 import { RecentProductsSection } from "@/components/RecentProductsSection"
 import { promises as fs } from "fs"
 import { join } from "path"
-import { headers } from "next/headers"
-import type { Metadata } from "next"
-
-export async function generateMetadata(): Promise<Metadata> {
-  const lang = headers().get("accept-language") || ""
-  const th = lang.includes("th")
-  const title = th
-    ? "โซฟาคัฟเวอร์ โปร ร้านผ้าคลุมโซฟา"
-    : "SofaCover Pro Premium Sofa Covers"
-  const description = th
-    ? "ซื้อผ้าคลุมโซฟาคุณภาพและบริการครบวงจร"
-    : "Premium sofa covers with great service."
-  const image = "/og-home.png"
-  return {
-    title,
-    description,
-    openGraph: { title, description, images: [{ url: image }] },
-  }
-}
 
 export default async function HomePage() {
   const featuredProducts = mockProducts.slice(0, 4)


### PR DESCRIPTION
## Summary
- move HomePage `generateMetadata` into `app/head.tsx`
- remove metadata logic from `app/page.tsx`

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688110d98ba483259a06da5131c24e2e