### PR TITLE
Add top products report

### DIFF
--- a/app/admin/reports/top-products/page.tsx
+++ b/app/admin/reports/top-products/page.tsx
@@ -1,0 +1,97 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/buttons/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { formatCurrency } from '@/lib/utils'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts'
+
+interface TopProduct {
+  name: string
+  quantity: number
+  count: number
+  subtotal: number
+  billIds: string[]
+}
+
+export default function TopProductsPage() {
+  const [range, setRange] = useState<'day' | 'month' | 'all'>('all')
+  const [data, setData] = useState<TopProduct[]>([])
+
+  useEffect(() => {
+    fetch(`/api/admin/top-products?range=${range}`)
+      .then(r => r.json())
+      .then(setData)
+  }, [range])
+
+  const chartData = data.slice(0, 5).map(p => ({ name: p.name, total: p.subtotal }))
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 space-y-6">
+        <div className="flex items-center space-x-4">
+          <Link href="/admin/reports">
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <h1 className="text-3xl font-bold">สินค้าขายดี</h1>
+          <Select value={range} onValueChange={v => setRange(v as 'day' | 'month' | 'all')}>
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="day">รายวัน</SelectItem>
+              <SelectItem value="month">รายเดือน</SelectItem>
+              <SelectItem value="all">ทั้งหมด</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {chartData.length > 0 && (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={chartData}>
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="total" fill="#0ea5e9" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+        <Card>
+          <CardHeader>
+            <CardTitle>รายการสินค้า</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>สินค้า</TableHead>
+                  <TableHead className="text-right">จำนวนครั้ง</TableHead>
+                  <TableHead className="text-right">ยอดรวม</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.map(p => (
+                  <TableRow key={p.name}>
+                    <TableCell>{p.name}</TableCell>
+                    <TableCell className="text-right">{p.count}</TableCell>
+                    <TableCell className="text-right">{formatCurrency(p.subtotal)}</TableCell>
+                    <TableCell>
+                      <Link href={`/admin/bills?product=${encodeURIComponent(p.name)}`}>
+                        <Button variant="outline" size="sm">ดูบิล</Button>
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/api/admin/top-products/route.ts
+++ b/app/api/admin/top-products/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getTopProducts } from '@/lib/get-top-products'
+
+export async function GET(req: NextRequest) {
+  const range = (req.nextUrl.searchParams.get('range') as 'day' | 'month' | 'all') || 'all'
+  const data = await getTopProducts(range)
+  return NextResponse.json(data)
+}

--- a/lib/get-top-products.ts
+++ b/lib/get-top-products.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+export interface TopProduct {
+  name: string
+  quantity: number
+  count: number
+  subtotal: number
+  billIds: string[]
+}
+
+function startOfToday() {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function startOfMonth() {
+  const d = new Date()
+  d.setDate(1)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+export async function getTopProducts(range: 'day' | 'month' | 'all' = 'all'): Promise<TopProduct[]> {
+  const file = join(process.cwd(), 'mock', 'store', 'bills.json')
+  const txt = await fs.readFile(file, 'utf8')
+  const bills = JSON.parse(txt) as any[]
+
+  const start = range === 'day' ? startOfToday() : range === 'month' ? startOfMonth() : new Date(0)
+  const now = new Date()
+
+  const map = new Map<string, TopProduct>()
+
+  for (const b of bills) {
+    const created = new Date(b.createdAt)
+    if (created < start || created > now) continue
+
+    for (const item of b.items || []) {
+      const curr = map.get(item.name) || { name: item.name, quantity: 0, count: 0, subtotal: 0, billIds: [] }
+      curr.quantity += item.quantity
+      curr.subtotal += item.quantity * item.price
+      if (!curr.billIds.includes(b.id)) {
+        curr.count += 1
+        curr.billIds.push(b.id)
+      }
+      map.set(item.name, curr)
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.subtotal - a.subtotal)
+}


### PR DESCRIPTION
## Summary
- aggregate bill data with `getTopProducts`
- expose `/api/admin/top-products` for fetching report data
- add `/admin/reports/top-products` page with filter and chart

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6881228a745083258bf02db5a761d17c