### PR TITLE
Add bill shipping label print pages

### DIFF
--- a/app/admin/bills/print-labels/page.tsx
+++ b/app/admin/bills/print-labels/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { useEffect, useState } from 'react'
+import BillLabel from '@/components/shipping/BillLabel'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+import { getBillById } from '@/core/mock/fakeBillDB'
+
+export default function PrintBillLabelsPage({ searchParams }: { searchParams: { ids?: string } }) {
+  const [bills, setBills] = useState<FakeBill[]>([])
+
+  useEffect(() => {
+    if (searchParams.ids) {
+      const idList = searchParams.ids.split(',')
+      Promise.all(idList.map(id => getBillById(id))).then(res => setBills(res.filter(Boolean) as FakeBill[]))
+    }
+  }, [searchParams.ids])
+
+  useEffect(() => {
+    if (bills.length > 0 && typeof window !== 'undefined') {
+      setTimeout(() => window.print(), 500)
+    }
+  }, [bills])
+
+  if (bills.length === 0) {
+    return <div className="p-8">ไม่พบข้อมูล</div>
+  }
+
+  return (
+    <div className="p-4 space-y-4 print:p-0">
+      {bills.map(bill => (
+        <BillLabel key={bill.id} bill={bill} />
+      ))}
+      <style jsx>{`
+        @media print { body { margin: 0; } }
+      `}</style>
+    </div>
+  )
+}

--- a/app/bill/label/[billId]/page.tsx
+++ b/app/bill/label/[billId]/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useEffect, useState } from 'react'
+import BillLabel from '@/components/shipping/BillLabel'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+import { getBillById } from '@/core/mock/fakeBillDB'
+
+export default function BillLabelPage({ params }: { params: { billId: string } }) {
+  const { billId } = params
+  const [bill, setBill] = useState<FakeBill | undefined>()
+
+  useEffect(() => {
+    getBillById(billId).then(setBill)
+  }, [billId])
+
+  useEffect(() => {
+    if (bill && typeof window !== 'undefined') {
+      setTimeout(() => window.print(), 500)
+    }
+  }, [bill])
+
+  if (!bill) {
+    return <div className="p-8">ไม่พบบิล</div>
+  }
+
+  return (
+    <div className="p-4 print:p-0">
+      <div className="print:hidden mb-4">
+        <button type="button" className="border px-3 py-1" onClick={() => window.print()}>
+          พิมพ์
+        </button>
+      </div>
+      <div className="flex justify-center">
+        <BillLabel bill={bill} />
+      </div>
+      <style jsx>{`
+        @media print {
+          body { margin: 0; }
+          button { display: none; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/components/admin/BillItemActions.tsx
+++ b/components/admin/BillItemActions.tsx
@@ -34,6 +34,16 @@ export default function BillItemActions({ bill, onEdit }: BillItemActionsProps) 
           <Printer className="h-4 w-4" />
         </Button>
       </Link>
+      <Link
+        href={`/bill/label/${bill.id}`}
+        className="no-underline"
+        target="_blank"
+        title="พิมพ์ใบปะหน้า"
+      >
+        <Button variant="outline" size="sm">
+          <Printer className="h-4 w-4" /> ใบปะหน้า
+        </Button>
+      </Link>
       <Link href={`/admin/bill/create?from=${bill.id}`} className="no-underline" title="ทำซ้ำบิล">
         <Button variant="outline" size="sm">
           <Copy className="h-4 w-4" />

--- a/components/shipping/BillLabel.tsx
+++ b/components/shipping/BillLabel.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+
+interface BillLabelProps {
+  bill: FakeBill
+  className?: string
+}
+
+export default function BillLabel({ bill, className }: BillLabelProps) {
+  const summary = bill.items.map(it => `${it.fabricName ?? it.name ?? ''}×${it.quantity}`).join(', ')
+  return (
+    <div
+      className={cn(
+        'border p-4 w-80 print:w-[100mm] print:h-[150mm] flex flex-col justify-between',
+        className,
+      )}
+    >
+      <div className="space-y-1 text-sm">
+        <p className="font-bold text-lg">{bill.customerName}</p>
+        <p className="whitespace-pre-line">{bill.customerAddress}</p>
+        <p>โทร {bill.customerPhone}</p>
+      </div>
+      <div className="text-sm space-y-1">
+        {summary && <p>สินค้า: {summary}</p>}
+        {bill.carrier && (
+          <p>
+            ขนส่ง: {bill.carrier}{' '}
+            {bill.trackingNo && <span>#{bill.trackingNo}</span>}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow printing a shipping label for a bill via `/bill/label/[billId]`
- support batch printing at `/admin/bills/print-labels`
- display bill details with new `BillLabel` component
- link from admin bill actions to print the label

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68813a3e29d8832585403253fdecc66d