### PR TITLE
Add global bill store

### DIFF
--- a/__tests__/bill-store.test.ts
+++ b/__tests__/bill-store.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useBillStore } from '../app/store/useBillStore'
+
+describe('bill store', () => {
+  beforeEach(() => {
+    useBillStore.setState({ bill: { id: 'B1', status: 'unpaid' } as any })
+  })
+
+  it('updates status', () => {
+    useBillStore.getState().updateStatus('paid')
+    expect(useBillStore.getState().bill?.status).toBe('paid')
+  })
+})

--- a/app/admin/bill/[billId]/view.tsx
+++ b/app/admin/bill/[billId]/view.tsx
@@ -1,25 +1,25 @@
 "use client"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Button } from "@/components/ui/buttons/button"
 import { Badge } from "@/components/ui/badge"
-import type { AdminBill } from "@/mock/bills"
-import { useBillStore } from "@/core/store"
+import { useBillStore as useBillListStore } from "@/core/store"
+import { useBillStore } from "@/app/store/useBillStore"
 import { generateReceiptPDF } from "@/lib/pdf/receipt"
 import { exportPDF } from "@/lib/pdf/export"
 import { Star } from "lucide-react"
 
 export default function AdminBillViewPage({ params }: { params: { billId: string } }) {
-  const store = useBillStore()
-  const [bill, setBill] = useState<AdminBill | undefined>(() =>
-    store.bills.find((b) => b.id === params.billId),
-  )
+  const listStore = useBillListStore()
+  const { bill, fetch } = useBillStore()
 
   useEffect(() => {
-    store.refresh()
-    setBill(store.bills.find((b) => b.id === params.billId))
-  }, [params.billId, store])
+    if (!bill) {
+      fetch(params.billId)
+    }
+    listStore.refresh()
+  }, [params.billId, bill, fetch, listStore])
 
   if (!bill) {
     return <div className="p-4">ไม่พบข้อมูลบิล</div>

--- a/app/store/useBillStore.ts
+++ b/app/store/useBillStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { FakeBill } from '@/core/mock/fakeBillDB'
+import type { AdminBill } from '@/mock/bills'
+import { getBillById, updateProductionStatus } from '@/core/mock/fakeBillDB'
+
+type Bill = FakeBill | AdminBill
+
+interface BillState {
+  bill: Bill | null
+  setBill: (bill: Bill) => void
+  updateStatus: (status: string) => void
+  updateProduction: (step: string) => void
+  fetch: (id: string) => Promise<void>
+}
+
+export const useBillStore = create<BillState>((set, get) => ({
+  bill: null,
+  setBill: (bill) => set({ bill }),
+  updateStatus: (status) =>
+    set(state => (state.bill ? { bill: { ...state.bill, status } } : state)),
+  updateProduction: (step) => {
+    const { bill } = get()
+    if (!bill) return
+    updateProductionStatus(bill.id, step)
+    set({ bill: { ...bill, productionStatus: step } })
+  },
+  async fetch(id) {
+    const bill = await getBillById(id)
+    if (bill) set({ bill })
+  },
+}))


### PR DESCRIPTION
## Summary
- add Zustand store for bill data
- refactor bill view page to use store
- refactor admin bill view to use new store
- test bill store functionality

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68813d5b71888325918ffcebde12c4e7