### PR TITLE
Implement print-ready label pages

### DIFF
--- a/app/admin/bills/print-labels/page.tsx
+++ b/app/admin/bills/print-labels/page.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from 'react'
 import BillLabel from '@/components/shipping/BillLabel'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
 import { getBillById } from '@/core/mock/fakeBillDB'
+import { Noto_Sans_Thai } from 'next/font/google'
+
+const thaiFont = Noto_Sans_Thai({ subsets: ['thai'], weight: ['400', '700'] })
 
 export default function PrintBillLabelsPage({ searchParams }: { searchParams: { ids?: string } }) {
   const [bills, setBills] = useState<FakeBill[]>([])
@@ -25,12 +28,12 @@ export default function PrintBillLabelsPage({ searchParams }: { searchParams: { 
   }
 
   return (
-    <div className="p-4 space-y-4 print:p-0">
+    <div className={`p-4 space-y-4 print:space-y-0 print:p-0 bg-white ${thaiFont.className}`}>
       {bills.map(bill => (
         <BillLabel key={bill.id} bill={bill} />
       ))}
       <style jsx>{`
-        @media print { body { margin: 0; } }
+        @media print { body { margin: 0; background: white; } }
       `}</style>
     </div>
   )

--- a/app/admin/bills/unshipped/page.tsx
+++ b/app/admin/bills/unshipped/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useBillStore } from '@/core/store'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import Link from 'next/link'
 import { Button } from '@/components/ui/buttons/button'
 import BillStatusTag from '@/components/admin/bills/BillStatusTag'
 import { formatDateThai } from '@/lib/formatDateThai'
@@ -50,7 +51,14 @@ export default function UnshippedBillsPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">ยังไม่จัดส่ง</h1>
         {unshipped.length > 0 && (
-          <Button onClick={exportList}>Export รายการจัดส่ง</Button>
+          <div className="flex gap-2">
+            <Button onClick={exportList}>Export รายการจัดส่ง</Button>
+            <Link
+              href={`/admin/bills/print-labels?ids=${unshipped.map(b => b.id).join(',')}`}
+            >
+              <Button variant="outline">พิมพ์ใบปะหน้าทั้งหมด</Button>
+            </Link>
+          </div>
         )}
       </div>
       <Table>

--- a/app/bill/label/[billId]/page.tsx
+++ b/app/bill/label/[billId]/page.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from 'react'
 import BillLabel from '@/components/shipping/BillLabel'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
 import { getBillById } from '@/core/mock/fakeBillDB'
+import { Noto_Sans_Thai } from 'next/font/google'
+
+const thaiFont = Noto_Sans_Thai({ subsets: ['thai'], weight: ['400', '700'] })
 
 export default function BillLabelPage({ params }: { params: { billId: string } }) {
   const { billId } = params
@@ -23,7 +26,7 @@ export default function BillLabelPage({ params }: { params: { billId: string } }
   }
 
   return (
-    <div className="p-4 print:p-0">
+    <div className={`p-4 print:p-0 bg-white ${thaiFont.className}`}>
       <div className="print:hidden mb-4">
         <button type="button" className="border px-3 py-1" onClick={() => window.print()}>
           พิมพ์
@@ -34,7 +37,7 @@ export default function BillLabelPage({ params }: { params: { billId: string } }
       </div>
       <style jsx>{`
         @media print {
-          body { margin: 0; }
+          body { margin: 0; background: white; }
           button { display: none; }
         }
       `}</style>

--- a/components/shipping/BillLabel.tsx
+++ b/components/shipping/BillLabel.tsx
@@ -1,5 +1,9 @@
 import { cn } from '@/lib/utils'
 import type { FakeBill } from '@/core/mock/fakeBillDB'
+import { Noto_Sans_Thai } from 'next/font/google'
+import QRCode from 'react-qr-code'
+
+const thaiFont = Noto_Sans_Thai({ subsets: ['thai'], weight: ['400', '700'] })
 
 interface BillLabelProps {
   bill: FakeBill
@@ -11,16 +15,17 @@ export default function BillLabel({ bill, className }: BillLabelProps) {
   return (
     <div
       className={cn(
-        'border p-4 w-80 print:w-[100mm] print:h-[150mm] flex flex-col justify-between',
+        thaiFont.className,
+        'border border-black bg-white p-[3mm] w-80 print:w-[100mm] print:h-[150mm] flex flex-col justify-between print:break-after-page',
         className,
       )}
     >
-      <div className="space-y-1 text-sm">
-        <p className="font-bold text-lg">{bill.customerName}</p>
+      <div className="space-y-1 text-[14px]">
+        <p className="font-bold text-[16px]">{bill.customerName}</p>
         <p className="whitespace-pre-line">{bill.customerAddress}</p>
         <p>โทร {bill.customerPhone}</p>
       </div>
-      <div className="text-sm space-y-1">
+      <div className="text-[12px] space-y-1">
         {summary && <p>สินค้า: {summary}</p>}
         {bill.carrier && (
           <p>
@@ -28,7 +33,13 @@ export default function BillLabel({ bill, className }: BillLabelProps) {
             {bill.trackingNo && <span>#{bill.trackingNo}</span>}
           </p>
         )}
+        {bill.trackingNo && (
+          <div className="pt-2">
+            <QRCode value={bill.trackingNo} size={64} />
+          </div>
+        )}
       </div>
+      <div className="border border-dashed h-16 mt-2" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- polish bill label layout with QR and font
- improve standalone label page
- support batch label printing
- allow printing all labels from unshipped bills

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688143edbfd48325a879b8cb704cf221