### PR TITLE
Final patch - collections picker + analytics prep

### DIFF
--- a/app/admin/analytics/cards/OrdersTodayCard.tsx
+++ b/app/admin/analytics/cards/OrdersTodayCard.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Card, CardContent } from "@/components/ui/cards/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEffect, useState } from "react"
+import { fetchAnalyticsSummary } from "@/lib/mock/analytics"
+
+export function OrdersTodayCard() {
+  const [count, setCount] = useState<number | null>(null)
+  useEffect(() => {
+    fetchAnalyticsSummary().then((d) => setCount(d.ordersToday))
+  }, [])
+  return (
+    <Card>
+      <CardContent className="p-4 text-center">
+        <p className="text-sm text-gray-600">ออเดอร์วันนี้</p>
+        {count === null ? (
+          <Skeleton className="h-6 w-10 mx-auto" />
+        ) : (
+          <p className="text-2xl font-bold">{count}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/admin/analytics/cards/ReadyToShipCard.tsx
+++ b/app/admin/analytics/cards/ReadyToShipCard.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Card, CardContent } from "@/components/ui/cards/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEffect, useState } from "react"
+import { fetchAnalyticsSummary } from "@/lib/mock/analytics"
+
+export function ReadyToShipCard() {
+  const [count, setCount] = useState<number | null>(null)
+  useEffect(() => {
+    fetchAnalyticsSummary().then((d) => setCount(d.readyToShip))
+  }, [])
+  return (
+    <Card>
+      <CardContent className="p-4 text-center">
+        <p className="text-sm text-gray-600">รอจัดส่ง</p>
+        {count === null ? (
+          <Skeleton className="h-6 w-8 mx-auto" />
+        ) : (
+          <p className="text-2xl font-bold">{count}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/admin/analytics/cards/RevenueSummaryCard.tsx
+++ b/app/admin/analytics/cards/RevenueSummaryCard.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Card, CardContent } from "@/components/ui/cards/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEffect, useState } from "react"
+import { fetchAnalyticsSummary } from "@/lib/mock/analytics"
+
+export function RevenueSummaryCard() {
+  const [total, setTotal] = useState<number | null>(null)
+  useEffect(() => {
+    fetchAnalyticsSummary().then((d) => setTotal(d.revenueToday))
+  }, [])
+  return (
+    <Card>
+      <CardContent className="p-4 text-center">
+        <p className="text-sm text-gray-600">รายได้วันนี้</p>
+        {total === null ? (
+          <Skeleton className="h-6 w-16 mx-auto" />
+        ) : (
+          <p className="text-2xl font-bold">฿{total.toLocaleString()}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/admin/analytics/cards/UnpaidOrdersCard.tsx
+++ b/app/admin/analytics/cards/UnpaidOrdersCard.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { Card, CardContent } from "@/components/ui/cards/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEffect, useState } from "react"
+import { fetchAnalyticsSummary } from "@/lib/mock/analytics"
+
+export function UnpaidOrdersCard() {
+  const [count, setCount] = useState<number | null>(null)
+  useEffect(() => {
+    fetchAnalyticsSummary().then((d) => setCount(d.unpaidOrders))
+  }, [])
+  return (
+    <Card>
+      <CardContent className="p-4 text-center">
+        <p className="text-sm text-gray-600">ยังไม่โอน</p>
+        {count === null ? (
+          <Skeleton className="h-6 w-8 mx-auto" />
+        ) : (
+          <p className="text-2xl font-bold">{count}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/admin/analytics/cards/index.ts
+++ b/app/admin/analytics/cards/index.ts
@@ -1,0 +1,4 @@
+export { OrdersTodayCard } from "./OrdersTodayCard"
+export { RevenueSummaryCard } from "./RevenueSummaryCard"
+export { UnpaidOrdersCard } from "./UnpaidOrdersCard"
+export { ReadyToShipCard } from "./ReadyToShipCard"

--- a/app/admin/analytics/content.tsx
+++ b/app/admin/analytics/content.tsx
@@ -1,56 +1,22 @@
 "use client"
-import { useState } from "react"
 import Link from "next/link"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/cards/card"
 import { Button } from "@/components/ui/buttons/button"
-import { mockOrders } from "@/lib/mock/orders"
-import type { Order } from "@/types/order"
+import {
+  OrdersTodayCard,
+  RevenueSummaryCard,
+  UnpaidOrdersCard,
+  ReadyToShipCard,
+} from "./cards"
 
 export default function AnalyticsContent() {
-  const [orders] = useState<Order[]>(mockOrders)
-  let todayCount = 0
-  let todayIncome = 0
-  let unpaid = 0
-  let ready = 0
-  if (Array.isArray(orders)) {
-    const today = new Date().toDateString()
-    for (const o of orders) {
-      if (new Date(o.createdAt).toDateString() === today) {
-        todayCount += 1
-        todayIncome += o.total
-      }
-      if (o.status === "pendingPayment") unpaid += 1
-      if (o.status === "paid" && o.shipping_status === "pending") ready += 1
-    }
-  }
   return (
     <div className="space-y-6 p-4">
       <h1 className="text-2xl font-bold">สถิติร้าน</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-        <Card>
-          <CardContent className="p-4 text-center">
-            <p className="text-sm text-gray-600">ออเดอร์วันนี้</p>
-            <p className="text-2xl font-bold">{todayCount}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <p className="text-sm text-gray-600">รายได้วันนี้</p>
-            <p className="text-2xl font-bold">฿{todayIncome.toLocaleString()}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <p className="text-sm text-gray-600">ยังไม่โอน</p>
-            <p className="text-2xl font-bold">{unpaid}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <p className="text-sm text-gray-600">รอจัดส่ง</p>
-            <p className="text-2xl font-bold">{ready}</p>
-          </CardContent>
-        </Card>
+        <OrdersTodayCard />
+        <RevenueSummaryCard />
+        <UnpaidOrdersCard />
+        <ReadyToShipCard />
       </div>
       <Link href="/admin/analytics/store-kpi">
         <Button variant="outline">ดู Store KPI</Button>

--- a/app/admin/bill/create/page.tsx
+++ b/app/admin/bill/create/page.tsx
@@ -48,7 +48,12 @@ export default function AdminBillCreatePage() {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('selectedFabric')
       if (stored) {
-        setFabricId(stored)
+        try {
+          const obj = JSON.parse(stored) as { id: string }
+          setFabricId(obj.id)
+        } catch {
+          setFabricId(stored)
+        }
         localStorage.removeItem('selectedFabric')
       }
     }

--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/buttons/button"
 import { useCompare } from "@/contexts/compare-context"
 import { mockCoViewLog } from "@/lib/mock-co-view-log"
+import { useToast } from "@/hooks/use-toast"
 
 interface Fabric {
   id: string
@@ -20,6 +21,7 @@ interface Fabric {
 export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]; selectable?: boolean }) {
   const { items, toggleCompare } = useCompare()
   const router = useRouter()
+  const { toast } = useToast()
 
   const handleCompare = () => {
     router.push(`/compare`)
@@ -60,24 +62,29 @@ export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]
                     />
                   </div>
                 </Link>
+              </div>
+              <div className="p-2 text-center space-y-2">
+                <Link href={`/fabrics/${slug}`} className="block">
+                  <p className="font-medium line-clamp-2">{fabric.name}</p>
+                </Link>
                 {selectable && (
                   <Button
                     size="sm"
-                    className="absolute bottom-2 right-2 z-10 text-xs"
+                    className="w-full text-xs"
                     onClick={() => {
-                      localStorage.setItem('selectedFabric', fabric.id)
-                      window.location.href = '/admin/bill/create'
+                      const obj = {
+                        id: fabric.id,
+                        code: fabric.sku || (fabric as any).code || '',
+                        name: fabric.name,
+                      }
+                      localStorage.setItem('selectedFabric', JSON.stringify(obj))
+                      toast({ title: 'เลือกลายผ้าแล้ว! กลับไปสร้างบิลต่อได้เลย' })
                     }}
                   >
                     เลือกผ้านี้
                   </Button>
                 )}
               </div>
-              <Link href={`/fabrics/${slug}`}> 
-                <div className="p-2 text-center">
-                  <p className="font-medium line-clamp-2">{fabric.name}</p>
-                </div>
-              </Link>
             </div>
           )
         })}

--- a/lib/mock/analytics.ts
+++ b/lib/mock/analytics.ts
@@ -1,0 +1,29 @@
+import type { Order } from "@/types/order"
+import { mockOrders } from "./orders"
+
+export interface AnalyticsSummary {
+  ordersToday: number
+  revenueToday: number
+  unpaidOrders: number
+  readyToShip: number
+}
+
+function calculate(orders: Order[]): AnalyticsSummary {
+  const today = new Date().toDateString()
+  return orders.reduce(
+    (acc, o) => {
+      if (new Date(o.createdAt).toDateString() === today) {
+        acc.ordersToday += 1
+        acc.revenueToday += o.total
+      }
+      if (o.status === "pendingPayment") acc.unpaidOrders += 1
+      if (o.status === "paid" && o.shipping_status === "pending") acc.readyToShip += 1
+      return acc
+    },
+    { ordersToday: 0, revenueToday: 0, unpaidOrders: 0, readyToShip: 0 },
+  )
+}
+
+export async function fetchAnalyticsSummary(): Promise<AnalyticsSummary> {
+  return Promise.resolve(calculate(mockOrders))
+}


### PR DESCRIPTION
## Summary
- add selectable fabric button with toast and save to localStorage
- parse selectedFabric JSON in bill creation
- build analytics cards and refactor analytics content
- add mock analytics service

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d5b4f94c832585153996c30a9217