### PR TITLE
Implement fabric selection on collections page

### DIFF
--- a/components/FabricsList.tsx
+++ b/components/FabricsList.tsx
@@ -1,43 +1,65 @@
-"use client"
+"use client";
 
-import Image from "next/image"
-import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Button } from "@/components/ui/buttons/button"
-import { useCompare } from "@/contexts/compare-context"
-import { mockCoViewLog } from "@/lib/mock-co-view-log"
-import { useToast } from "@/hooks/use-toast"
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/buttons/button";
+import { useCompare } from "@/contexts/compare-context";
+import { mockCoViewLog } from "@/lib/mock-co-view-log";
+import { useToast } from "@/hooks/use-toast";
+import { CheckCircle } from "lucide-react";
 
 interface Fabric {
-  id: string
-  slug: string | null
-  name: string
-  sku?: string | null
-  image_url?: string | null
-  image_urls?: string[] | null
+  id: string;
+  slug: string | null;
+  name: string;
+  sku?: string | null;
+  image_url?: string | null;
+  image_urls?: string[] | null;
 }
 
-export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]; selectable?: boolean }) {
-  const { items, toggleCompare } = useCompare()
-  const router = useRouter()
-  const { toast } = useToast()
+export function FabricsList({
+  fabrics,
+  selectable = false,
+}: {
+  fabrics: Fabric[];
+  selectable?: boolean;
+}) {
+  const { items, toggleCompare } = useCompare();
+  const router = useRouter();
+  const { toast } = useToast();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("selectedFabric");
+    if (stored) {
+      try {
+        const obj = JSON.parse(stored) as { id: string };
+        setSelectedId(obj.id);
+      } catch {
+        setSelectedId(stored);
+      }
+    }
+  }, []);
 
   const handleCompare = () => {
-    router.push(`/compare`)
-  }
+    router.push(`/compare`);
+  };
 
   return (
     <>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
         {fabrics.map((fabric) => {
-          const slug = fabric.slug || fabric.id
-          const checked = items.includes(slug)
-          const coViewed = mockCoViewLog[slug]?.length
+          const slug = fabric.slug || fabric.id;
+          const checked = items.includes(slug);
+          const coViewed = mockCoViewLog[slug]?.length;
           return (
             <div
               key={slug}
-              className="border rounded-lg overflow-hidden bg-white hover:shadow transition relative"
+              className={`border rounded-lg overflow-hidden bg-white hover:shadow transition relative ${selectedId === fabric.id ? "ring-2 ring-primary" : ""}`}
             >
               {coViewed && (
                 <span className="absolute top-2 right-2 bg-primary text-white text-xs px-2 py-1 rounded">
@@ -50,11 +72,16 @@ export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]
                 className="absolute top-2 left-2 z-10 bg-white/80"
               />
               <div className="relative">
-                <Link href={`/fabrics/${slug}`}> 
+                {selectedId === fabric.id && (
+                  <CheckCircle className="absolute bottom-2 right-2 z-10 text-green-500 h-5 w-5" />
+                )}
+                <Link href={`/fabrics/${slug}`}>
                   <div className="relative aspect-square">
                     <Image
                       src={
-                        fabric.image_urls?.[0] || fabric.image_url || "/placeholder.svg"
+                        fabric.image_urls?.[0] ||
+                        fabric.image_url ||
+                        "/placeholder.svg"
                       }
                       alt={fabric.name}
                       fill
@@ -74,11 +101,21 @@ export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]
                     onClick={() => {
                       const obj = {
                         id: fabric.id,
-                        code: fabric.sku || (fabric as any).code || '',
+                        code: fabric.sku || (fabric as any).code || "",
                         name: fabric.name,
-                      }
-                      localStorage.setItem('selectedFabric', JSON.stringify(obj))
-                      toast({ title: 'เลือกลายผ้าแล้ว! กลับไปสร้างบิลต่อได้เลย' })
+                        image:
+                          fabric.image_urls?.[0] ||
+                          fabric.image_url ||
+                          "/placeholder.svg",
+                      };
+                      localStorage.setItem(
+                        "selectedFabric",
+                        JSON.stringify(obj),
+                      );
+                      setSelectedId(fabric.id);
+                      toast({
+                        title: "เลือกลายผ้าแล้ว! กลับไปสร้างบิลต่อได้เลย",
+                      });
                     }}
                   >
                     เลือกผ้านี้
@@ -86,7 +123,7 @@ export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]
                 )}
               </div>
             </div>
-          )
+          );
         })}
       </div>
       {items.length > 1 && (
@@ -95,5 +132,5 @@ export function FabricsList({ fabrics, selectable = false }: { fabrics: Fabric[]
         </div>
       )}
     </>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- enhance `FabricsList` with local storage fabric selection
- highlight currently selected fabric and store image data
- show toast confirmation when choosing a fabric

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6881dbd1327c83259663a65165bc43b8