### PR TITLE
Add pending order alerts page

### DIFF
--- a/app/admin/analytics/content.tsx
+++ b/app/admin/analytics/content.tsx
@@ -26,6 +26,9 @@ export default function AnalyticsContent() {
           <Link href="/admin/analytics/store-kpi">
             <Button variant="outline" className="w-full">ดู Store KPI</Button>
           </Link>
+          <Link href="/admin/alerts/pending-orders">
+            <Button variant="outline" className="w-full">Alerts</Button>
+          </Link>
         </div>
         <div className="space-y-2">
           <div className="border rounded p-4 bg-white text-center">

--- a/mock/store/pending-orders.json
+++ b/mock/store/pending-orders.json
@@ -1,0 +1,26 @@
+[
+  {
+    "billId": "BILL-101",
+    "billNo": "B101",
+    "customer": "สมชาย ใจดี",
+    "updatedAt": "2024-07-01T09:00:00Z",
+    "status": "unpaid",
+    "category": "unpaid"
+  },
+  {
+    "billId": "BILL-102",
+    "billNo": "B102",
+    "customer": "วิไลวรรณ มั่นคง",
+    "updatedAt": "2024-07-02T11:30:00Z",
+    "status": "awaiting_print",
+    "category": "notPrinted"
+  },
+  {
+    "billId": "BILL-103",
+    "billNo": "B103",
+    "customer": "นรินทร์ สุขสวัสดิ์",
+    "updatedAt": "2024-07-02T14:45:00Z",
+    "status": "packed",
+    "category": "readyToShip"
+  }
+]


### PR DESCRIPTION
## Summary
- show pending orders by category at `/admin/alerts/pending-orders`
- provide mock data for pending orders
- link the alert page from analytics dashboard

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68821ec2e2a48325971427ece86c6f51