### PR TITLE
Add admin search page

### DIFF
--- a/app/admin/search/page.tsx
+++ b/app/admin/search/page.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Input } from "@/components/ui/inputs/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/buttons/button"
+import PageWrapper from "@/components/admin/PageWrapper"
+
+interface Bill {
+  id: string
+  shortCode?: string
+  customer: string
+  paymentStatus?: string
+  status?: string
+  sharedAt?: string | null
+}
+
+interface Customer {
+  id: string
+  name: string
+  totalSpent: number
+  lastOrder: string
+  tags?: string[]
+}
+
+interface PendingItem {
+  billId: string
+  billNo: string
+  customer: string
+  updatedAt: string
+  status: string
+  category: string
+}
+
+export default function AdminSearchPage() {
+  const [query, setQuery] = useState("")
+  const [bills, setBills] = useState<Bill[]>([])
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [pending, setPending] = useState<PendingItem[]>([])
+
+  useEffect(() => {
+    async function load() {
+      const [billRes, custRes, pendRes] = await Promise.all([
+        fetch("/mock/store/bills.json").then(r => r.json()),
+        fetch("/mock/store/customers.json").then(r => r.json()),
+        fetch("/mock/store/pending-orders.json").then(r => r.json()),
+      ])
+      setBills(billRes)
+      setCustomers(custRes)
+      setPending(pendRes)
+    }
+    load()
+  }, [])
+
+  const billFiltered = bills.filter(b =>
+    b.customer.toLowerCase().includes(query.toLowerCase()) ||
+    b.id.toLowerCase().includes(query.toLowerCase()) ||
+    (b.shortCode ?? "").toLowerCase().includes(query.toLowerCase())
+  )
+
+  const customerFiltered = customers
+    .filter(c => c.name.toLowerCase().includes(query.toLowerCase()))
+    .sort((a, b) => b.totalSpent - a.totalSpent)
+
+  const pendingFiltered = pending.filter(p =>
+    p.billNo.toLowerCase().includes(query.toLowerCase()) ||
+    p.customer.toLowerCase().includes(query.toLowerCase())
+  )
+
+  return (
+    <PageWrapper title="Global Search" breadcrumb={[{ title: "Search" }]}>
+      <div className="mb-4 flex">
+        <Input
+          placeholder="Search..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          className="max-w-xs"
+        />
+      </div>
+      <Tabs defaultValue="bills" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="bills">Bills</TabsTrigger>
+          <TabsTrigger value="customers">Customers</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+        </TabsList>
+        <TabsContent value="bills">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Customer</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {billFiltered.map(b => (
+                <TableRow key={b.id}>
+                  <TableCell>{b.shortCode || b.id}</TableCell>
+                  <TableCell>{b.customer}</TableCell>
+                  <TableCell>
+                    {b.paymentStatus === "paid" ? (
+                      <Badge className="bg-green-500 text-white">paid</Badge>
+                    ) : (
+                      <Badge className="bg-red-500 text-white">unpaid</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Link href={`/admin/bill/view/${b.id}`}>
+                      <Button size="sm" variant="outline">View</Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {billFiltered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-sm">No results</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TabsContent>
+        <TabsContent value="customers">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Total Spent</TableHead>
+                <TableHead>Last Order</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {customerFiltered.map(c => (
+                <TableRow key={c.id}>
+                  <TableCell>{c.name}</TableCell>
+                  <TableCell>฿{c.totalSpent.toLocaleString()}</TableCell>
+                  <TableCell>{new Date(c.lastOrder).toLocaleDateString("th-TH")}</TableCell>
+                  <TableCell className="text-right">
+                    <Link href={`/admin/customers/${c.id}`}>
+                      <Button size="sm" variant="outline">View</Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {customerFiltered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-sm">No results</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TabsContent>
+        <TabsContent value="pending">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Bill</TableHead>
+                <TableHead>Customer</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pendingFiltered.map(p => (
+                <TableRow key={p.billId}>
+                  <TableCell>{p.billNo}</TableCell>
+                  <TableCell>{p.customer}</TableCell>
+                  <TableCell>{p.category}</TableCell>
+                  <TableCell className="text-right">
+                    <Link href={`/admin/bill/view/${p.billId}`}>
+                      <Button size="sm" variant="outline">View</Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {pendingFiltered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-sm">No results</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TabsContent>
+      </Tabs>
+    </PageWrapper>
+  )
+}
+

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   MailQuestion,
   Megaphone,
   MessageCircle,
+  Search as SearchIcon,
   UserPlus,
   Percent,
   Database,
@@ -52,6 +53,12 @@ const groups = [
     items: [
       { href: "/admin/customers", label: "ลูกค้า", icon: Users, feature: "customers" },
       { href: "/admin/customers/create", label: "เพิ่มลูกค้าใหม่", icon: UserPlus, feature: "customers" },
+    ],
+  },
+  {
+    label: "Search",
+    items: [
+      { href: "/admin/search", label: "ค้นหา", icon: SearchIcon, feature: "dashboard" },
     ],
   },
   {

--- a/mock/store/customers.json
+++ b/mock/store/customers.json
@@ -1,7 +1,7 @@
 [
-  {"id":"2","name":"John Doe","tags":["ลูกค้าประจำ"]},
-  {"id":"3","name":"Jane Smith","tags":["COD"]},
-  {"id":"4","name":"Mike Johnson","tags":[]},
-  {"id":"5","name":"Sarah Wilson","tags":[]},
-  {"id":"6","name":"David Brown","tags":[]}
+  {"id": "c001", "name": "สมชาย ใจดี", "totalSpent": 12000, "lastOrder": "2024-07-10T00:00:00Z", "tags": ["VIP"]},
+  {"id": "c002", "name": "วิไลวรรณ มั่นคง", "totalSpent": 8500, "lastOrder": "2024-07-08T00:00:00Z", "tags": ["COD"]},
+  {"id": "c003", "name": "Michael Johnson", "totalSpent": 3000, "lastOrder": "2024-06-15T00:00:00Z", "tags": []},
+  {"id": "c004", "name": "Sarah Wilson", "totalSpent": 4500, "lastOrder": "2024-06-20T00:00:00Z", "tags": []},
+  {"id": "c005", "name": "David Brown", "totalSpent": 2200, "lastOrder": "2024-05-30T00:00:00Z", "tags": []}
 ]


### PR DESCRIPTION
## Summary
- add a global admin search page for bills, customers and pending orders
- expose search link in the sidebar
- provide richer mock customer data

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882218e45748325ad592a89787c5cbf