### PR TITLE
Add transfer confirmation flow

### DIFF
--- a/app/admin/bill/view/[billId]/page.tsx
+++ b/app/admin/bill/view/[billId]/page.tsx
@@ -1,9 +1,40 @@
-import BillDetail from '@/components/bill/BillDetail'
+"use client"
+import { useEffect, useState } from 'react'
 
 export default function ViewPage({ params }: { params: { billId: string } }) {
+  const [bill, setBill] = useState<any | null>(null)
+
+  useEffect(() => {
+    fetch('/mock/store/bills.json')
+      .then(r => r.json())
+      .then((list: any[]) => {
+        const found = list.find(b => b.id === params.billId)
+        setBill(found || null)
+      })
+      .catch(() => setBill(null))
+  }, [params.billId])
+
+  if (!bill) {
+    return <div className="p-4 text-center">ไม่พบบิลนี้</div>
+  }
+
   return (
-    <div className="p-4">
-      <BillDetail id={params.billId} />
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">บิล {bill.id}</h1>
+      <p>
+        สถานะ:{' '}
+        <span className={bill.status === 'แจ้งโอนแล้ว' ? 'text-red-600 font-bold' : ''}>
+          {bill.status}
+        </span>
+      </p>
+      {bill.transferConfirmation && (
+        <div className="border p-2 rounded">
+          <p>ธนาคาร: {bill.transferConfirmation.bank}</p>
+          <p>เวลา: {bill.transferConfirmation.time}</p>
+          <p>จำนวนเงิน: ฿{bill.transferConfirmation.amount}</p>
+          {bill.transferConfirmation.note && <p>หมายเหตุ: {bill.transferConfirmation.note}</p>}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/api/bill/confirm-transfer/route.ts
+++ b/app/api/bill/confirm-transfer/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { join } from 'path'
+import { readJson, writeJson } from '@/lib/jsonFile'
+
+export async function POST(req: Request) {
+  const { billId, bank, time, amount, note } = (await req.json().catch(() => ({}))) as {
+    billId?: string
+    bank?: string
+    time?: string
+    amount?: number
+    note?: string
+  }
+
+  if (!billId || !bank || !time || typeof amount !== 'number') {
+    return NextResponse.json({ error: 'missing fields' }, { status: 400 })
+  }
+
+  const file = join(process.cwd(), 'mock', 'store', 'bills.json')
+  const bills = await readJson<any[]>(file, [])
+  const bill = bills.find(b => b.id === billId)
+  if (!bill) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  bill.transferConfirmation = { bank, time, amount, note }
+  bill.status = 'แจ้งโอนแล้ว'
+
+  await writeJson(file, bills)
+
+  return NextResponse.json({ success: true })
+}

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -77,7 +77,7 @@ export default function BillViewPage({ params }: { params: { billId: string } })
       </ul>
       {bill.note && <p className="text-sm">หมายเหตุ: {bill.note}</p>}
       <BillQRSection total={total} />
-      <TransferConfirmForm billId={bill.id} />
+      <TransferConfirmForm billId={bill.id} existing={bill.transferConfirmation} />
       <button className="border px-3 py-1" onClick={handleShare}>คัดลอกลิงก์</button>
     </div>
   )

--- a/components/bill/TransferConfirmForm.tsx
+++ b/components/bill/TransferConfirmForm.tsx
@@ -1,28 +1,98 @@
 "use client"
 import { useState } from 'react'
-import { addPaymentConfirmation } from '@/core/mock/store/paymentConfirmations'
+import { useToast } from '@/hooks/use-toast'
 
-export default function TransferConfirmForm({ billId }: { billId: string }) {
-  const [amount, setAmount] = useState('')
-  const [datetime, setDatetime] = useState('')
+interface TransferInfo {
+  bank: string
+  time: string
+  amount: number
+  note?: string
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+interface Props {
+  billId: string
+  existing?: TransferInfo
+}
+
+export default function TransferConfirmForm({ billId, existing }: Props) {
+  const { toast } = useToast()
+  const [bank, setBank] = useState(existing?.bank || '')
+  const [time, setTime] = useState(existing?.time || '')
+  const [amount, setAmount] = useState(
+    existing?.amount ? existing.amount.toString() : ''
+  )
+  const [note, setNote] = useState(existing?.note || '')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(!!existing)
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const amt = parseFloat(amount) || 0
-    addPaymentConfirmation({
-      billId,
-      amount: amt,
-      method: 'transfer',
-      datetime: datetime || new Date().toISOString(),
-    })
-    alert('บันทึกข้อมูลแล้ว (mock)')
-    setAmount('')
-    setDatetime('')
+    setLoading(true)
+    try {
+      const res = await fetch('/api/bill/confirm-transfer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          billId,
+          bank,
+          time,
+          amount: parseFloat(amount) || 0,
+          note,
+        }),
+      })
+      if (res.ok) {
+        toast({ title: 'บันทึกข้อมูลแล้ว' })
+        setSubmitted(true)
+      } else {
+        toast({ title: 'บันทึกไม่สำเร็จ', variant: 'destructive' })
+      }
+    } catch {
+      toast({ title: 'บันทึกไม่สำเร็จ', variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="space-y-1 border p-4 rounded-md">
+        <h3 className="font-semibold text-red-600">แจ้งโอนแล้ว</h3>
+        <p>ธนาคาร: {bank}</p>
+        <p>เวลา: {time}</p>
+        <p>จำนวนเงิน: ฿{parseFloat(amount).toLocaleString()}</p>
+        {note && <p>หมายเหตุ: {note}</p>}
+      </div>
+    )
   }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded-md">
       <h3 className="font-semibold">แจ้งโอน</h3>
+      <div>
+        <label className="block text-sm mb-1">ธนาคารปลายทาง</label>
+        <select
+          className="border p-2 w-full"
+          value={bank}
+          onChange={e => setBank(e.target.value)}
+          required
+        >
+          <option value="">เลือกธนาคาร</option>
+          <option value="SCB">SCB</option>
+          <option value="KBank">KBank</option>
+          <option value="Krungthai">Krungthai</option>
+          <option value="BBL">BBL</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm mb-1">เวลาที่โอน</label>
+        <input
+          type="datetime-local"
+          className="border p-2 w-full"
+          value={time}
+          onChange={e => setTime(e.target.value)}
+          required
+        />
+      </div>
       <div>
         <label className="block text-sm mb-1">จำนวนเงิน</label>
         <input
@@ -31,18 +101,24 @@ export default function TransferConfirmForm({ billId }: { billId: string }) {
           className="border p-2 w-full"
           value={amount}
           onChange={e => setAmount(e.target.value)}
+          required
         />
       </div>
       <div>
-        <label className="block text-sm mb-1">วันที่โอน</label>
+        <label className="block text-sm mb-1">หมายเหตุเพิ่มเติม</label>
         <input
-          type="datetime-local"
           className="border p-2 w-full"
-          value={datetime}
-          onChange={e => setDatetime(e.target.value)}
+          value={note}
+          onChange={e => setNote(e.target.value)}
         />
       </div>
-      <button type="submit" className="border px-3 py-1">บันทึก</button>
+      <button
+        type="submit"
+        className="border px-3 py-1"
+        disabled={loading}
+      >
+        {loading ? 'กำลังบันทึก...' : 'บันทึก'}
+      </button>
     </form>
   )
 }

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -10,13 +10,19 @@
     "address": "123 ถนนสุขุมวิท แขวงคลองตัน เขตวัฒนา กรุงเทพฯ 10110",
     "note": "จัดส่งภายในสัปดาห์",
     "shipping": 50,
-    "status": "paid",
+    "status": "แจ้งโอนแล้ว",
     "phone": "0812345678",
     "paymentStatus": "paid",
     "createdAt": "2024-01-15T08:00:00Z",
     "followup_log": [],
     "sharedAt": "2024-01-20T00:00:00Z",
-    "sharedBy": "admin"
+    "sharedBy": "admin",
+    "transferConfirmation": {
+      "bank": "SCB",
+      "time": "2024-01-15T09:00:00Z",
+      "amount": 408,
+      "note": "เต็มจำนวน"
+    }
   },
   {
     "id": "BILL-002",


### PR DESCRIPTION
## Summary
- allow customers to submit transfer info via new API `/api/bill/confirm-transfer`
- extend transfer confirmation form with bank, time, amount and note fields
- store confirmation in `mock/store/bills.json` and mark status `แจ้งโอนแล้ว`
- show confirmation details on admin bill view page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68823ddeb19c8325bfb24f65f3842e10