### PR TITLE
Add bill production progress

### DIFF
--- a/app/admin/bill/view/[billId]/page.tsx
+++ b/app/admin/bill/view/[billId]/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 import { useEffect, useState } from 'react'
+import AdminStatusEditor from '@/components/AdminStatusEditor'
+import BillTimeline from '@/components/bill/BillTimeline'
+import { formatDateThai } from '@/lib/formatDateThai'
 
 export default function ViewPage({ params }: { params: { billId: string } }) {
   const [bill, setBill] = useState<any | null>(null)
@@ -27,6 +30,19 @@ export default function ViewPage({ params }: { params: { billId: string } }) {
           {bill.status}
         </span>
       </p>
+      <div className="space-y-2">
+        <h2 className="font-medium">สถานะงานผลิต</h2>
+        <AdminStatusEditor billId={bill.id} step={bill.productionStatus || 'waiting'} />
+        <BillTimeline status={bill.productionStatus || 'waiting'} />
+        {bill.productionTimeline?.length > 0 && (
+          <p className="text-xs text-gray-500">
+            อัปเดตล่าสุด:{' '}
+            {formatDateThai(
+              bill.productionTimeline[bill.productionTimeline.length - 1].timestamp
+            )}
+          </p>
+        )}
+      </div>
       {bill.transferConfirmation && (
         <div className="border p-2 rounded">
           <p>ธนาคาร: {bill.transferConfirmation.bank}</p>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -4,6 +4,8 @@ import bills from '@/mock/store/bills.json'
 import BillQRSection from '@/components/bill/BillQRSection'
 import TransferConfirmForm from '@/components/bill/TransferConfirmForm'
 import BillStatusTracker from '@/components/bill/BillStatusTracker'
+import BillTimeline from '@/components/bill/BillTimeline'
+import { formatDateThai } from '@/lib/formatDateThai'
 
 export default function BillViewPage({ params }: { params: { billId: string } }) {
   const bill = (bills as any[]).find(b => b.id === params.billId)
@@ -33,6 +35,15 @@ export default function BillViewPage({ params }: { params: { billId: string } })
     <div className="p-4 space-y-4 max-w-xl mx-auto">
       <h1 className="text-xl font-bold text-center">บิล {bill.id}</h1>
       <BillStatusTracker status={bill.status} />
+      <BillTimeline status={bill.productionStatus || 'waiting'} />
+      {bill.productionTimeline?.length > 0 && (
+        <p className="text-xs text-gray-500 text-center">
+          อัปเดตล่าสุด:{' '}
+          {formatDateThai(
+            bill.productionTimeline[bill.productionTimeline.length - 1].timestamp
+          )}
+        </p>
+      )}
       <div className="space-y-1">
         <p className="font-medium">{bill.customer}</p>
         {editAddr ? (

--- a/components/AdminStatusEditor.tsx
+++ b/components/AdminStatusEditor.tsx
@@ -1,0 +1,38 @@
+"use client"
+import { useState } from 'react'
+
+const options = [
+  { value: 'waiting', label: 'รอตัด' },
+  { value: 'cutting', label: 'กำลังตัด' },
+  { value: 'sewing', label: 'รอเย็บ' },
+  { value: 'done', label: 'เย็บเสร็จ' },
+  { value: 'packing', label: 'แพ็คแล้ว' },
+  { value: 'shipped', label: 'จัดส่งแล้ว' },
+] as const
+
+type Step = typeof options[number]['value']
+
+export default function AdminStatusEditor({ billId, step }: { billId: string; step: Step }) {
+  const [value, setValue] = useState<Step>(step)
+  const update = async (newStep: Step) => {
+    setValue(newStep)
+    await fetch('/api/bill/update-production-status', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ billId, newStatus: newStep }),
+    })
+  }
+  return (
+    <select
+      className="border px-2 py-1"
+      value={value}
+      onChange={e => update(e.target.value as Step)}
+    >
+      {options.map(o => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/components/BillStatusStepper.tsx
+++ b/components/BillStatusStepper.tsx
@@ -1,16 +1,17 @@
-import { Clock, Scissors, Package, Truck } from 'lucide-react'
-import type { BillStatus } from '@/core/mock/fakeBillDB'
+import { Clock, Scissors, Shirt, Package, Truck, CircleCheck } from 'lucide-react'
 
 const steps = [
-  { key: 'waiting', label: 'Waiting', icon: Clock },
-  { key: 'cutting', label: 'Cutting', icon: Scissors },
-  { key: 'packing', label: 'Packing', icon: Package },
-  { key: 'shipped', label: 'Shipped', icon: Truck },
+  { key: 'waiting', label: 'รอตัด', icon: Clock },
+  { key: 'cutting', label: 'กำลังตัด', icon: Scissors },
+  { key: 'sewing', label: 'รอเย็บ', icon: Shirt },
+  { key: 'done', label: 'เย็บเสร็จ', icon: CircleCheck },
+  { key: 'packing', label: 'แพ็คแล้ว', icon: Package },
+  { key: 'shipped', label: 'จัดส่งแล้ว', icon: Truck },
 ] as const
 
 type StepKey = typeof steps[number]['key']
 
-export default function BillStatusStepper({ status }: { status: BillStatus }) {
+export default function BillStatusStepper({ status }: { status: StepKey }) {
   const currentStepIndex = steps.findIndex(s => s.key === status)
 
   return (

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -4,8 +4,16 @@
     "shortCode": "B001",
     "customer": "สมชาย ใจดี",
     "items": [
-      { "name": "ผ้าคลุมโซฟา", "quantity": 1, "price": 299 },
-      { "name": "ปลอกหมอน", "quantity": 2, "price": 59 }
+      {
+        "name": "ผ้าคลุมโซฟา",
+        "quantity": 1,
+        "price": 299
+      },
+      {
+        "name": "ปลอกหมอน",
+        "quantity": 2,
+        "price": 59
+      }
     ],
     "address": "123 ถนนสุขุมวิท แขวงคลองตัน เขตวัฒนา กรุงเทพฯ 10110",
     "note": "จัดส่งภายในสัปดาห์",
@@ -22,14 +30,20 @@
       "time": "2024-01-15T09:00:00Z",
       "amount": 408,
       "note": "เต็มจำนวน"
-    }
+    },
+    "productionStatus": "waiting",
+    "productionTimeline": []
   },
   {
     "id": "BILL-002",
     "shortCode": "B002",
     "customer": "ทดสอบ ยกเลิก",
     "items": [
-      { "name": "ชุดโซฟา", "quantity": 1, "price": 500 }
+      {
+        "name": "ชุดโซฟา",
+        "quantity": 1,
+        "price": 500
+      }
     ],
     "address": "99/1 ซอยสุขุมวิท 10 กรุงเทพฯ 10110",
     "note": "ลูกค้าขอยกเลิก",
@@ -39,14 +53,20 @@
     "createdAt": "2024-01-16T08:00:00Z",
     "followup_log": [],
     "sharedAt": null,
-    "sharedBy": null
+    "sharedBy": null,
+    "productionStatus": "waiting",
+    "productionTimeline": []
   },
   {
     "id": "BILL-003",
     "shortCode": "B003",
     "customer": "Cancelled Order",
     "items": [
-      { "name": "ปลอกหมอน", "quantity": 4, "price": 59 }
+      {
+        "name": "ปลอกหมอน",
+        "quantity": 4,
+        "price": 59
+      }
     ],
     "address": "555/9 Test Road Bangkok",
     "note": "cancel due to duplicate",
@@ -56,6 +76,8 @@
     "createdAt": "2024-01-17T08:00:00Z",
     "followup_log": [],
     "sharedAt": null,
-    "sharedBy": null
+    "sharedBy": null,
+    "productionStatus": "waiting",
+    "productionTimeline": []
   }
 ]


### PR DESCRIPTION
## Summary
- allow editing production status on bill admin view via new `AdminStatusEditor`
- display production stepper on customer bill page with latest update time
- local stepper component now covers cutting->shipped workflow
- store production status in mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68825cd729cc8325a2b488a42da83827