### PR TITLE
Add store profile settings and integration

### DIFF
--- a/app/admin/settings/store/page.tsx
+++ b/app/admin/settings/store/page.tsx
@@ -1,0 +1,10 @@
+import StoreProfileForm from '@/components/StoreProfileForm'
+
+export default function StoreSettingsPage() {
+  return (
+    <div className="container mx-auto space-y-4 py-8">
+      <h1 className="text-2xl font-bold">Store Profile</h1>
+      <StoreProfileForm />
+    </div>
+  )
+}

--- a/app/api/config/store-profile/route.ts
+++ b/app/api/config/store-profile/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { getStoreProfile, setStoreProfile } from '@/core/mock/store'
+import type { StoreProfile } from '@/core/mock/store/store-profile'
+
+export async function GET() {
+  return NextResponse.json(getStoreProfile())
+}
+
+export async function POST(req: Request) {
+  try {
+    const data: StoreProfile = await req.json()
+    setStoreProfile(data)
+    return NextResponse.json({ success: true })
+  } catch (e) {
+    console.error('Save store profile error', e)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -1,16 +1,23 @@
 "use client"
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import bills from '@/mock/store/bills.json'
 import BillQRSection from '@/components/bill/BillQRSection'
 import TransferConfirmForm from '@/components/bill/TransferConfirmForm'
 import BillStatusTracker from '@/components/bill/BillStatusTracker'
 import BillTimeline from '@/components/bill/BillTimeline'
 import { formatDateThai } from '@/lib/formatDateThai'
+import type { StoreProfile } from '@/lib/config'
+import { getStoreProfile } from '@/lib/config'
 
 export default function BillViewPage({ params }: { params: { billId: string } }) {
   const bill = (bills as any[]).find(b => b.id === params.billId)
   const [editAddr, setEditAddr] = useState(false)
   const [address, setAddress] = useState(bill?.address || '')
+  const [store, setStore] = useState<StoreProfile | null>(null)
+
+  useEffect(() => {
+    getStoreProfile().then(setStore)
+  }, [])
 
   if (!bill) {
     return (
@@ -88,6 +95,12 @@ export default function BillViewPage({ params }: { params: { billId: string } })
       </ul>
       {bill.note && <p className="text-sm">หมายเหตุ: {bill.note}</p>}
       <BillQRSection total={total} />
+      {store && (
+        <div className="text-sm text-center space-y-1">
+          <p className="font-semibold">{store.storeName}</p>
+          <p>{store.phoneNumber}</p>
+        </div>
+      )}
       <TransferConfirmForm billId={bill.id} existing={bill.transferConfirmation} />
       <button className="border px-3 py-1" onClick={handleShare}>คัดลอกลิงก์</button>
     </div>

--- a/components/StoreProfileForm.tsx
+++ b/components/StoreProfileForm.tsx
@@ -1,0 +1,90 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/inputs/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/buttons/button'
+import { Label } from '@/components/ui/label'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/cards/card'
+import type { StoreProfile } from '@/lib/config'
+import { getStoreProfile, saveStoreProfile } from '@/lib/config'
+
+const empty: StoreProfile = {
+  storeName: '',
+  phoneNumber: '',
+  address: '',
+  logoUrl: '',
+  promptPayId: '',
+  bankName: '',
+  accountName: '',
+  accountNumber: '',
+}
+
+export default function StoreProfileForm() {
+  const [profile, setProfile] = useState<StoreProfile>(empty)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    getStoreProfile().then((p) => {
+      setProfile(p)
+      setLoaded(true)
+    })
+  }, [])
+
+  const handleChange = (field: keyof StoreProfile) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setProfile({ ...profile, [field]: e.target.value })
+    }
+
+  const save = async () => {
+    await saveStoreProfile(profile)
+    alert('saved')
+  }
+
+  if (!loaded) return <p>Loading...</p>
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Store Profile</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {profile.logoUrl && (
+          <img src={profile.logoUrl} alt="logo" className="w-24 h-24 object-contain" />
+        )}
+        <div className="space-y-2">
+          <Label htmlFor="name">ชื่อร้าน</Label>
+          <Input id="name" value={profile.storeName} onChange={handleChange('storeName')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="phone">เบอร์โทร</Label>
+          <Input id="phone" value={profile.phoneNumber} onChange={handleChange('phoneNumber')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="addr">ที่อยู่</Label>
+          <Textarea id="addr" value={profile.address} onChange={handleChange('address')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="logo">โลโก้ร้าน URL</Label>
+          <Input id="logo" value={profile.logoUrl} onChange={handleChange('logoUrl')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="pp">PromptPay ID</Label>
+          <Input id="pp" value={profile.promptPayId} onChange={handleChange('promptPayId')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="bank">Bank Name</Label>
+          <Input id="bank" value={profile.bankName} onChange={handleChange('bankName')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="accname">Account Name</Label>
+          <Input id="accname" value={profile.accountName} onChange={handleChange('accountName')} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="accnum">Account Number</Label>
+          <Input id="accnum" value={profile.accountNumber} onChange={handleChange('accountNumber')} />
+        </div>
+        <Button onClick={save}>Save</Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/bill/BillHeader.tsx
+++ b/components/bill/BillHeader.tsx
@@ -1,17 +1,17 @@
-import { company } from '@/lib/config/company.config'
-import { formatAddress } from '@/lib/format/address'
+import { getStoreProfile } from '@/core/mock/store'
 
 export default function BillHeader() {
+  const company = getStoreProfile()
   return (
     <div className="flex items-start mb-6 space-x-4">
-      {company.logo && (
-        <img src={company.logo} alt={company.name} className="w-12 h-12" />
+      {company.logoUrl && (
+        <img src={company.logoUrl} alt={company.storeName} className="w-12 h-12" />
       )}
       <div className="text-sm">
         <h1 className="text-2xl font-bold mb-1">ใบเสร็จรับเงิน</h1>
-        <h2 className="text-xl font-semibold leading-none">{company.name}</h2>
-        <p className="whitespace-pre-line">{formatAddress(company.address)}</p>
-        <p>โทร: {company.phone}</p>
+        <h2 className="text-xl font-semibold leading-none">{company.storeName}</h2>
+        <p className="whitespace-pre-line">{company.address}</p>
+        <p>โทร: {company.phoneNumber}</p>
       </div>
     </div>
   )

--- a/components/bill/BillPaymentQR.tsx
+++ b/components/bill/BillPaymentQR.tsx
@@ -1,6 +1,18 @@
 import { generateQRUrl } from '@/lib/qr/generate'
+import { getStoreProfile } from '@/core/mock/store'
 
 export default function BillPaymentQR({ value }: { value: string }) {
   const src = generateQRUrl(value)
-  return <img src={src} alt="QR" className="w-32 h-32 mx-auto" />
+  const store = getStoreProfile()
+  return (
+    <div className="text-center space-y-1">
+      <img src={src} alt="QR" className="w-32 h-32 mx-auto" />
+      {store.promptPayId && <p>PromptPay: {store.promptPayId}</p>}
+      {store.bankName && (
+        <p>
+          {store.bankName} {store.accountName} {store.accountNumber}
+        </p>
+      )}
+    </div>
+  )
 }

--- a/components/bill/BillQRSection.tsx
+++ b/components/bill/BillQRSection.tsx
@@ -1,14 +1,32 @@
 "use client"
+import { useEffect, useState } from 'react'
 import { generateQRUrl } from '@/lib/qr/generate'
+import type { StoreProfile } from '@/lib/config'
+import { getStoreProfile } from '@/lib/config'
 
 export default function BillQRSection({ total }: { total: number }) {
+  const [profile, setProfile] = useState<StoreProfile | null>(null)
   const src = generateQRUrl(`PAY:${total}`)
+
+  useEffect(() => {
+    getStoreProfile().then(setProfile)
+  }, [])
+
   return (
     <div className="text-center space-y-2">
       <p className="font-semibold">ยอดโอนทั้งหมด</p>
       <p className="text-xl font-bold">฿{total.toLocaleString()}</p>
       <img src={src} alt="QR" className="w-40 h-40 mx-auto" />
-      <p className="text-sm text-gray-600">สแกนเพื่อโอน (mock)</p>
+      {profile && (
+        <div className="text-sm space-y-1">
+          {profile.promptPayId && <p>PromptPay: {profile.promptPayId}</p>}
+          {profile.bankName && (
+            <p>
+              {profile.bankName} {profile.accountName} {profile.accountNumber}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/core/mock/store/index.ts
+++ b/core/mock/store/index.ts
@@ -12,6 +12,7 @@ export * from './paymentConfirmations'
 export * from './roles'
 export * from './team-access'
 export * from './notes'
+export * from './store-profile'
 
 import { resetOrders, regenerateOrders } from './orders'
 import { resetSimpleOrders, regenerateSimpleOrders } from './simple-orders'

--- a/core/mock/store/store-profile.ts
+++ b/core/mock/store/store-profile.ts
@@ -1,0 +1,29 @@
+import data from '@/mock/store/config/store-profile.json'
+import { loadFromStorage, saveToStorage } from './persist'
+
+export interface StoreProfile {
+  storeName: string
+  phoneNumber: string
+  address: string
+  logoUrl: string
+  promptPayId: string
+  bankName: string
+  accountName: string
+  accountNumber: string
+}
+
+const KEY = 'mockStore_profile'
+let profile: StoreProfile = loadFromStorage<StoreProfile>(KEY, data as StoreProfile)
+
+function persist() {
+  saveToStorage(KEY, profile)
+}
+
+export function getStoreProfile() {
+  return profile
+}
+
+export function setStoreProfile(newProfile: StoreProfile) {
+  profile = { ...profile, ...newProfile }
+  persist()
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,23 @@
+export interface StoreProfile {
+  storeName: string
+  phoneNumber: string
+  address: string
+  logoUrl: string
+  promptPayId: string
+  bankName: string
+  accountName: string
+  accountNumber: string
+}
+
+export async function getStoreProfile(): Promise<StoreProfile> {
+  const res = await fetch('/api/config/store-profile')
+  return res.json()
+}
+
+export async function saveStoreProfile(profile: StoreProfile) {
+  await fetch('/api/config/store-profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(profile),
+  })
+}

--- a/lib/pdf/receipt.tsx
+++ b/lib/pdf/receipt.tsx
@@ -1,6 +1,6 @@
 import { Document, Page, Text, View, StyleSheet, Image } from '@react-pdf/renderer'
 import type { BillData } from '@/lib/hooks/useBillData'
-import { company } from '@/lib/config/company.config'
+import { getStoreProfile } from '@/core/mock/store'
 
 const styles = StyleSheet.create({
   page: { padding: 24, fontSize: 12, fontFamily: 'Helvetica' },
@@ -16,19 +16,17 @@ const styles = StyleSheet.create({
 export async function generateReceiptPDF(bill: BillData, options?: { mock?: boolean; qr?: string }) {
   const subtotal = bill.items.reduce((s, it) => s + it.price * it.quantity, 0)
   const total = subtotal - (bill.discount || 0) + (bill.shipping || 0)
+  const company = getStoreProfile()
   const doc = (
     <Document>
       <Page size="A4" style={styles.page}>
         {options?.mock && <Text style={styles.watermark}>ตัวอย่าง</Text>}
         <View style={styles.header}>
-          {company.logo && <Image src={company.logo} style={styles.logo} />}
+          {company.logoUrl && <Image src={company.logoUrl} style={styles.logo} />}
           <View>
-            <Text>{company.name}</Text>
-            <Text>{company.address.line1}</Text>
-            {company.address.line2 && <Text>{company.address.line2}</Text>}
-            <Text>
-              {company.address.city} {company.address.postalCode}
-            </Text>
+            <Text>{company.storeName}</Text>
+            <Text>{company.address}</Text>
+            <Text>{company.phoneNumber}</Text>
           </View>
         </View>
         <Text>บิลเลขที่ {bill.id}</Text>

--- a/mock/store/config/store-profile.json
+++ b/mock/store/config/store-profile.json
@@ -1,0 +1,10 @@
+{
+  "storeName": "My Store",
+  "phoneNumber": "0123456789",
+  "address": "123 Test Street, Bangkok",
+  "logoUrl": "/placeholder-logo.png",
+  "promptPayId": "0812345678",
+  "bankName": "KBank",
+  "accountName": "John Doe",
+  "accountNumber": "012-3-45678-9"
+}


### PR DESCRIPTION
## Summary
- add store profile configuration JSON
- expose `getStoreProfile` helpers and API
- build admin Store Profile settings page
- show store info on bills and receipts
- update receipt PDF generator

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688287f06370832585608b58a9231498