### PR TITLE
Add shipping info fields and display

### DIFF
--- a/app/admin/bill/[billId]/page.tsx
+++ b/app/admin/bill/[billId]/page.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useToast } from '@/hooks/use-toast'
 import { useBillStore } from '@/core/store'
 import { useBillById } from '@/hooks/useBillById'
+import { carriers } from '@/config/carriers'
 
 export default function AdminBillDetailPage({ params }: { params: { billId: string } }) {
   const bill = useBillById(params.billId)
@@ -17,6 +18,8 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
   const { toast } = useToast()
   const [status, setStatus] = useState<'waiting' | 'cutting' | 'sewing' | 'packing' | 'shipped' | 'done'>(bill.productionStatus ?? 'waiting')
   const [note, setNote] = useState('')
+  const [tracking, setTracking] = useState(bill.trackingNumber || '')
+  const [carrier, setCarrier] = useState<string>(bill.carrier || carriers[0])
 
   if (bill === undefined) {
     return <div className="p-4 text-center">Loading...</div>
@@ -83,6 +86,44 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
             <span>รวมทั้งหมด</span>
             <span className="text-primary">฿{total.toLocaleString()}</span>
           </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>ข้อมูลขนส่ง</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <input
+            className="border p-2 w-full"
+            placeholder="เลขพัสดุ"
+            value={tracking}
+            onChange={e => setTracking(e.target.value)}
+          />
+          <Select value={carrier} onValueChange={setCarrier}>
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {carriers.map(c => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            onClick={() => {
+              store.updateBill(bill.id, {
+                trackingNumber: tracking,
+                carrier,
+                shippedAt: new Date().toISOString(),
+              })
+              store.updateProductionStatus(bill.id, 'shipped', 'บันทึกหมายเลขพัสดุ')
+              toast({ title: 'อัปเดตหมายเลขพัสดุแล้ว' })
+            }}
+          >
+            บันทึกหมายเลขพัสดุ
+          </Button>
         </CardContent>
       </Card>
       <Card>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -5,6 +5,7 @@ import BillQRSection from '@/components/bill/BillQRSection'
 import TransferConfirmForm from '@/components/bill/TransferConfirmForm'
 import BillStatusTracker from '@/components/bill/BillStatusTracker'
 import BillTimeline from '@/components/bill/BillTimeline'
+import ShippingInfoCard from '@/components/bill/ShippingInfoCard'
 import { formatDateThai } from '@/lib/formatDateThai'
 import type { StoreProfile } from '@/lib/config'
 import { getStoreProfile } from '@/lib/config'
@@ -55,6 +56,11 @@ export default function BillViewPage({ params }: { params: { billId: string } })
           )}
         </p>
       )}
+      <ShippingInfoCard
+        trackingNumber={bill.trackingNumber}
+        carrier={bill.carrier}
+        shippedAt={bill.shippedAt}
+      />
       <div className="space-y-1">
         <p className="font-medium">{bill.customer}</p>
         {editAddr ? (

--- a/components/bill/ShippingInfoCard.tsx
+++ b/components/bill/ShippingInfoCard.tsx
@@ -1,0 +1,34 @@
+"use client"
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/cards/card'
+import { Button } from '@/components/ui/buttons/button'
+import { copyToClipboard } from '@/helpers/clipboard'
+import { formatDateThai } from '@/lib/utils/formatDateThai'
+
+interface Props {
+  trackingNumber?: string
+  carrier?: string
+  shippedAt?: string
+}
+
+export default function ShippingInfoCard({ trackingNumber, carrier, shippedAt }: Props) {
+  if (!trackingNumber && !carrier && !shippedAt) return null
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ข้อมูลการจัดส่ง</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 text-sm">
+        {carrier && <p>ขนส่ง: {carrier}</p>}
+        {trackingNumber && (
+          <p>
+            เลขพัสดุ: {trackingNumber}{' '}
+            <Button variant="outline" size="sm" onClick={() => copyToClipboard(trackingNumber!)}>
+              คัดลอก
+            </Button>
+          </p>
+        )}
+        {shippedAt && <p>ส่งเมื่อ: {formatDateThai(shippedAt)}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/config/carriers.ts
+++ b/config/carriers.ts
@@ -1,2 +1,2 @@
-export const carriers = ['Kerry', 'Flash', 'JT', 'EMS'] as const
+export const carriers = ['Flash', 'Kerry', 'ไปรษณีย์ไทย', 'J&T'] as const
 export type Carrier = (typeof carriers)[number]

--- a/lib/utils/formatDateThai.ts
+++ b/lib/utils/formatDateThai.ts
@@ -1,0 +1,1 @@
+export { formatDateThai } from '../formatDateThai'

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -20,9 +20,9 @@
     "shipping": 50,
     "status": "แจ้งโอนแล้ว",
     "phone": "0812345678",
-  "paymentStatus": "paid",
-  "createdBy": "Alice",
-  "createdAt": "2024-01-15T08:00:00Z",
+    "paymentStatus": "paid",
+    "createdBy": "Alice",
+    "createdAt": "2024-01-15T08:00:00Z",
     "followup_log": [],
     "sharedAt": "2024-01-20T00:00:00Z",
     "sharedBy": "admin",
@@ -45,7 +45,10 @@
         "by": "Bob",
         "note": "เริ่มตัดผ้า"
       }
-    ]
+    ],
+    "trackingNumber": "EX123456789TH",
+    "carrier": "Flash",
+    "shippedAt": "2024-01-30T10:00:00Z"
   },
   {
     "id": "BILL-002",
@@ -62,9 +65,9 @@
     "note": "ลูกค้าขอยกเลิก",
     "shipping": 50,
     "status": "cancelled",
-  "paymentStatus": "unpaid",
-  "createdBy": "Bob",
-  "createdAt": "2024-01-16T08:00:00Z",
+    "paymentStatus": "unpaid",
+    "createdBy": "Bob",
+    "createdAt": "2024-01-16T08:00:00Z",
     "followup_log": [],
     "sharedAt": null,
     "sharedBy": null,
@@ -75,7 +78,10 @@
         "status": "waiting",
         "by": "Bob"
       }
-    ]
+    ],
+    "trackingNumber": "EX123456789TH",
+    "carrier": "Flash",
+    "shippedAt": "2024-01-30T10:00:00Z"
   },
   {
     "id": "BILL-003",
@@ -92,9 +98,9 @@
     "note": "cancel due to duplicate",
     "shipping": 30,
     "status": "cancelled",
-  "paymentStatus": "unpaid",
-  "createdBy": "Alice",
-  "createdAt": "2024-01-17T08:00:00Z",
+    "paymentStatus": "unpaid",
+    "createdBy": "Alice",
+    "createdAt": "2024-01-17T08:00:00Z",
     "followup_log": [],
     "sharedAt": null,
     "sharedBy": null,
@@ -130,6 +136,9 @@
         "status": "done",
         "by": "Team"
       }
-    ]
+    ],
+    "trackingNumber": "EX123456789TH",
+    "carrier": "Flash",
+    "shippedAt": "2024-01-30T10:00:00Z"
   }
 ]


### PR DESCRIPTION
## Summary
- add tracking fields to mock bills
- support shipping info entry in admin bill page
- show shipping info on bill view
- include card component for shipping details
- re-export formatDateThai in utils
- update carrier list

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c1bdd32c8325b61a8d39a7a80da5