### PR TITLE
Add receipt attachment feature

### DIFF
--- a/app/admin/bill/[billId]/page.tsx
+++ b/app/admin/bill/[billId]/page.tsx
@@ -20,6 +20,8 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
   const [note, setNote] = useState('')
   const [tracking, setTracking] = useState(bill.trackingNumber || '')
   const [carrier, setCarrier] = useState<string>(bill.carrier || carriers[0])
+  const [receiptUrl, setReceiptUrl] = useState(bill.receiptUrl || '')
+  const [receiptNote, setReceiptNote] = useState(bill.receiptNote || '')
 
   if (bill === undefined) {
     return <div className="p-4 text-center">Loading...</div>
@@ -123,6 +125,45 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
             }}
           >
             บันทึกหมายเลขพัสดุ
+          </Button>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>แนบใบเสร็จ</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <input
+            type="file"
+            accept="application/pdf,image/*"
+            onChange={e => {
+              const f = e.target.files?.[0]
+              if (f) {
+                const reader = new FileReader()
+                reader.onload = () => setReceiptUrl(reader.result as string)
+                reader.readAsDataURL(f)
+              }
+            }}
+          />
+          <input
+            className="border p-2 w-full"
+            placeholder="หรือใส่ลิงก์ใบเสร็จ"
+            value={receiptUrl}
+            onChange={e => setReceiptUrl(e.target.value)}
+          />
+          <input
+            className="border p-2 w-full"
+            placeholder="หมายเหตุ"
+            value={receiptNote}
+            onChange={e => setReceiptNote(e.target.value)}
+          />
+          <Button
+            onClick={() => {
+              store.updateBill(bill.id, { receiptUrl, receiptNote })
+              toast({ title: 'แนบใบเสร็จสำเร็จ' })
+            }}
+          >
+            บันทึกใบเสร็จ
           </Button>
         </CardContent>
       </Card>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -6,6 +6,7 @@ import TransferConfirmForm from '@/components/bill/TransferConfirmForm'
 import BillStatusTracker from '@/components/bill/BillStatusTracker'
 import BillTimeline from '@/components/bill/BillTimeline'
 import ShippingInfoCard from '@/components/bill/ShippingInfoCard'
+import ReceiptCard from '@/components/bill/ReceiptCard'
 import { formatDateThai } from '@/lib/formatDateThai'
 import type { StoreProfile } from '@/lib/config'
 import { getStoreProfile } from '@/lib/config'
@@ -134,6 +135,7 @@ export default function BillViewPage({ params }: { params: { billId: string } })
           <p>{store.phoneNumber}</p>
         </div>
       )}
+      <ReceiptCard url={bill.receiptUrl} note={bill.receiptNote} />
       <TransferConfirmForm billId={bill.id} existing={bill.transferConfirmation} />
       <button className="border px-3 py-1" onClick={handleShare}>คัดลอกลิงก์</button>
     </div>

--- a/components/bill/ReceiptCard.tsx
+++ b/components/bill/ReceiptCard.tsx
@@ -1,0 +1,25 @@
+"use client"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/cards/card'
+import { Button } from '@/components/ui/buttons/button'
+
+interface Props {
+  url: string
+  note?: string
+}
+
+export default function ReceiptCard({ url, note }: Props) {
+  if (!url) return null
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ใบเสร็จ</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          <Button variant="outline">📄 ดูใบเสร็จ</Button>
+        </a>
+        {note && <p className="text-sm">{note}</p>}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/mock/orders.ts
+++ b/lib/mock/orders.ts
@@ -21,4 +21,12 @@ export function addOrderTimelineEntry(
   if (order) order.timeline.push(entry)
 }
 
+export function attachReceipt(id: string, url: string, note?: string) {
+  const order = mockOrders.find(o => o.id === id)
+  if (order) {
+    ;(order as any).receiptUrl = url
+    ;(order as any).receiptNote = note
+  }
+}
+
 export { getOrdersInRange, getDailySales, getTopSellingItems }

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -40,6 +40,8 @@ export interface AdminBill {
   shippingMethod?: string
   shippingStatus?: 'shipped' | 'delivered' | 'returned' | 'cancelled'
   phone?: string
+  receiptUrl?: string
+  receiptNote?: string
   contactChannel?: string
   createdAt: string
   feedback?: BillFeedback

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -26,6 +26,8 @@
     "followup_log": [],
     "sharedAt": "2024-01-20T00:00:00Z",
     "sharedBy": "admin",
+    "receiptUrl": "https://cdn.example.com/receipts/BILL-001.pdf",
+    "receiptNote": "ออกโดยแอดมินวันที่ 1 ส.ค.",
     "transferConfirmation": {
       "bank": "SCB",
       "time": "2024-01-15T09:00:00Z",
@@ -71,6 +73,8 @@
     "followup_log": [],
     "sharedAt": null,
     "sharedBy": null,
+    "receiptUrl": "",
+    "receiptNote": "",
     "productionStatus": "waiting",
     "productionTimeline": [
       {
@@ -104,6 +108,8 @@
     "followup_log": [],
     "sharedAt": null,
     "sharedBy": null,
+    "receiptUrl": "",
+    "receiptNote": "",
     "productionStatus": "done",
     "productionTimeline": [
       {


### PR DESCRIPTION
## Summary
- allow admin to upload or link a bill receipt
- show receipt button on customer bill page
- expose `attachReceipt` for orders
- support receipt fields in AdminBill mock data

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c63547088325bc81efecb9f382bf