### PR TITLE
Add customer payment confirmation flow

### DIFF
--- a/app/admin/bill/[billId]/page.tsx
+++ b/app/admin/bill/[billId]/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast'
 import { useBillStore } from '@/core/store'
 import { useBillById } from '@/hooks/useBillById'
 import { carriers } from '@/config/carriers'
+import PaymentConfirmationCard from '@/components/bill/PaymentConfirmationCard'
 
 export default function AdminBillDetailPage({ params }: { params: { billId: string } }) {
   const bill = useBillById(params.billId)
@@ -128,6 +129,36 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
           </Button>
         </CardContent>
       </Card>
+      {bill.confirmation && (
+        <Card>
+          <CardHeader>
+            <CardTitle>แจ้งโอนโดยลูกค้า</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <PaymentConfirmationCard confirmation={bill.confirmation} />
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="checkbox"
+                checked={!!bill.confirmation.verified}
+                onChange={e => {
+                  const verified = e.target.checked
+                  store.updateBill(bill.id, { confirmation: { ...bill.confirmation, verified } })
+                  toast({ title: 'บันทึกแล้ว' })
+                }}
+              />
+              <span>ตรวจสอบแล้ว</span>
+            </label>
+            <Button
+              onClick={() => {
+                store.updateStatus(bill.id, 'paid')
+                toast({ title: 'ยืนยันรับยอด' })
+              }}
+            >
+              ยืนยันรับยอด
+            </Button>
+          </CardContent>
+        </Card>
+      )}
       <Card>
         <CardHeader>
           <CardTitle>แนบใบเสร็จ</CardTitle>

--- a/app/api/bill/confirm-payment/route.ts
+++ b/app/api/bill/confirm-payment/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { join } from 'path'
+import { readJson, writeJson } from '@/lib/server/jsonFile'
+
+export async function POST(req: Request) {
+  const { billId, amountTransferred, transferDate, transferSlipUrl, customerNote } = (await req.json().catch(() => ({}))) as {
+    billId?: string
+    amountTransferred?: number
+    transferDate?: string
+    transferSlipUrl?: string
+    customerNote?: string
+  }
+  if (!billId || !transferDate || !transferSlipUrl || typeof amountTransferred !== 'number') {
+    return NextResponse.json({ error: 'missing fields' }, { status: 400 })
+  }
+  const file = join(process.cwd(), 'mock', 'store', 'bills.json')
+  const bills = await readJson<any[]>(file, [])
+  const bill = bills.find(b => b.id === billId)
+  if (!bill) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  bill.confirmation = { amountTransferred, transferDate, transferSlipUrl, customerNote }
+  if (Array.isArray(bill.productionTimeline)) {
+    bill.productionTimeline.push({
+      status: 'payment-confirmed-by-customer',
+      timestamp: new Date().toISOString(),
+      by: 'customer',
+    })
+  }
+  await writeJson(file, bills)
+  return NextResponse.json({ success: true })
+}

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -2,7 +2,8 @@
 import { useState, useEffect } from 'react'
 import bills from '@/mock/store/bills.json'
 import BillQRSection from '@/components/bill/BillQRSection'
-import TransferConfirmForm from '@/components/bill/TransferConfirmForm'
+import CustomerPaymentForm from '@/components/bill/CustomerPaymentForm'
+import PaymentConfirmationCard from '@/components/bill/PaymentConfirmationCard'
 import BillStatusTracker from '@/components/bill/BillStatusTracker'
 import BillTimeline from '@/components/bill/BillTimeline'
 import ShippingInfoCard from '@/components/bill/ShippingInfoCard'
@@ -136,7 +137,13 @@ export default function BillViewPage({ params }: { params: { billId: string } })
         </div>
       )}
       <ReceiptCard url={bill.receiptUrl} note={bill.receiptNote} />
-      <TransferConfirmForm billId={bill.id} existing={bill.transferConfirmation} />
+      {bill.confirmation ? (
+        <PaymentConfirmationCard confirmation={bill.confirmation} />
+      ) : (
+        bill.paymentStatus === 'unpaid' && (
+          <CustomerPaymentForm billId={bill.id} autofillAmount={total} />
+        )
+      )}
       <button className="border px-3 py-1" onClick={handleShare}>คัดลอกลิงก์</button>
     </div>
   )

--- a/components/bill/CustomerPaymentForm.tsx
+++ b/components/bill/CustomerPaymentForm.tsx
@@ -1,0 +1,122 @@
+"use client"
+import { useState } from 'react'
+import { useToast } from '@/hooks/use-toast'
+import { uploadSlip } from '@/lib/upload/slipUploader'
+import { useBillStore } from '@/core/store'
+import type { PaymentConfirmation } from '@/types/payment-confirmation'
+import PaymentConfirmationCard from './PaymentConfirmationCard'
+
+interface Props {
+  billId: string
+  existing?: PaymentConfirmation | null
+  autofillAmount?: number
+}
+
+export default function CustomerPaymentForm({ billId, existing, autofillAmount }: Props) {
+  const { toast } = useToast()
+  const store = useBillStore()
+  const [amount, setAmount] = useState(existing?.amountTransferred?.toString() || (autofillAmount?.toString() || ''))
+  const [date, setDate] = useState(existing?.transferDate || new Date().toISOString().slice(0,10))
+  const [slip, setSlip] = useState<File | null>(null)
+  const [slipPreview, setSlipPreview] = useState(existing?.transferSlipUrl || '')
+  const [note, setNote] = useState(existing?.customerNote || '')
+  const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(!!existing)
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0]
+    if (f) {
+      setSlip(f)
+      const reader = new FileReader()
+      reader.onload = () => setSlipPreview(reader.result as string)
+      reader.readAsDataURL(f)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!slip && !slipPreview) {
+      toast({ title: 'กรุณาแนบสลิป' })
+      return
+    }
+    setLoading(true)
+    try {
+      const slipUrl = slip ? await uploadSlip(slip) : slipPreview
+      const payload: PaymentConfirmation = {
+        amountTransferred: parseFloat(amount) || 0,
+        transferDate: date,
+        transferSlipUrl: slipUrl,
+        customerNote: note,
+      }
+      const res = await fetch('/api/bill/confirm-payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ billId, ...payload }),
+      })
+      if (res.ok) {
+        store.updateBill(billId, { confirmation: payload })
+        store.updateProductionStatus(billId, 'payment-confirmed-by-customer')
+        toast({ title: 'แจ้งโอนสำเร็จ! รอแอดมินตรวจสอบ' })
+        setSubmitted(true)
+      } else {
+        toast({ title: 'บันทึกไม่สำเร็จ', variant: 'destructive' })
+      }
+    } catch {
+      toast({ title: 'บันทึกไม่สำเร็จ', variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (submitted) {
+    return <PaymentConfirmationCard confirmation={{
+      amountTransferred: parseFloat(amount) || 0,
+      transferDate: date,
+      transferSlipUrl: slipPreview,
+      customerNote: note,
+    }} />
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded-md">
+      <h3 className="font-semibold">แจ้งโอนเงิน</h3>
+      <div>
+        <label className="block text-sm mb-1">จำนวนเงิน</label>
+        <input
+          type="number"
+          step="0.01"
+          className="border p-2 w-full"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">วันที่โอน</label>
+        <input
+          type="date"
+          className="border p-2 w-full"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">สลิปการโอน</label>
+        <input type="file" accept="image/*" onChange={handleFile} />
+        {slipPreview && <img src={slipPreview} alt="slip" className="mt-2 w-40" />}
+      </div>
+      <div>
+        <label className="block text-sm mb-1">หมายเหตุเพิ่มเติม</label>
+        <textarea
+          className="border p-2 w-full"
+          value={note}
+          onChange={e => setNote(e.target.value)}
+        />
+      </div>
+      <button type="submit" className="border px-3 py-1" disabled={loading}>
+        {loading ? 'กำลังบันทึก...' : 'ยืนยันการชำระเงิน'}
+      </button>
+    </form>
+  )
+}

--- a/components/bill/PaymentConfirmationCard.tsx
+++ b/components/bill/PaymentConfirmationCard.tsx
@@ -1,0 +1,19 @@
+"use client"
+import type { PaymentConfirmation } from '@/types/payment-confirmation'
+
+export default function PaymentConfirmationCard({ confirmation }: { confirmation: PaymentConfirmation }) {
+  return (
+    <div className="space-y-1 border p-4 rounded-md">
+      <h3 className="font-semibold text-red-600">แจ้งโอนแล้ว</h3>
+      <p>จำนวนเงิน: ฿{confirmation.amountTransferred.toLocaleString()}</p>
+      <p>วันที่โอน: {confirmation.transferDate}</p>
+      {confirmation.customerNote && <p>หมายเหตุ: {confirmation.customerNote}</p>}
+      {confirmation.transferSlipUrl && (
+        <img src={confirmation.transferSlipUrl} alt="slip" className="w-40" />
+      )}
+      <p className="text-sm text-gray-500">
+        {confirmation.verified ? 'ตรวจสอบแล้ว' : 'รอตรวจสอบ'}
+      </p>
+    </div>
+  )
+}

--- a/lib/upload/slipUploader.ts
+++ b/lib/upload/slipUploader.ts
@@ -1,0 +1,8 @@
+export async function uploadSlip(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('read error'))
+    reader.readAsDataURL(file)
+  })
+}

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -52,6 +52,13 @@ export interface AdminBill {
   sharedBy?: string | null
   customerNotes?: { message: string; createdAt: string; from: string }[]
   packedBy?: string
+  confirmation?: {
+    amountTransferred: number
+    transferDate: string
+    transferSlipUrl: string
+    customerNote?: string
+    verified?: boolean
+  }
 }
 
 export const mockBills: AdminBill[] = [

--- a/mock/store/bills.json
+++ b/mock/store/bills.json
@@ -46,11 +46,22 @@
         "status": "cutting",
         "by": "Bob",
         "note": "เริ่มตัดผ้า"
+      },
+      {
+        "timestamp": "2024-01-15T10:00:00Z",
+        "status": "payment-confirmed-by-customer",
+        "by": "customer"
       }
     ],
     "trackingNumber": "EX123456789TH",
     "carrier": "Flash",
-    "shippedAt": "2024-01-30T10:00:00Z"
+    "shippedAt": "2024-01-30T10:00:00Z",
+    "confirmation": {
+      "amountTransferred": 408,
+      "transferDate": "2024-01-15",
+      "transferSlipUrl": "https://example.com/slip1.jpg",
+      "customerNote": "เต็มจำนวน"
+    }
   },
   {
     "id": "BILL-002",
@@ -85,7 +96,8 @@
     ],
     "trackingNumber": "EX123456789TH",
     "carrier": "Flash",
-    "shippedAt": "2024-01-30T10:00:00Z"
+    "shippedAt": "2024-01-30T10:00:00Z",
+    "confirmation": null
   },
   {
     "id": "BILL-003",
@@ -145,6 +157,7 @@
     ],
     "trackingNumber": "EX123456789TH",
     "carrier": "Flash",
-    "shippedAt": "2024-01-30T10:00:00Z"
+    "shippedAt": "2024-01-30T10:00:00Z",
+    "confirmation": null
   }
 ]

--- a/types/payment-confirmation.ts
+++ b/types/payment-confirmation.ts
@@ -1,0 +1,7 @@
+export interface PaymentConfirmation {
+  amountTransferred: number
+  transferDate: string
+  transferSlipUrl: string
+  customerNote?: string
+  verified?: boolean
+}


### PR DESCRIPTION
## Summary
- let customers confirm payment with slip image and note
- display confirmation summary card on bill view
- show confirmation details in admin bill page
- update mock data schema with `confirmation`
- mock uploader utility for payment slips

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e516a2dc8325ad9b3c7f3954c5e6