### PR TITLE
Refactor bill calculation into shared module

### DIFF
--- a/app/admin/bill/[billId]/page.tsx
+++ b/app/admin/bill/[billId]/page.tsx
@@ -14,6 +14,7 @@ import { useBillStore } from '@/core/store'
 import { useBillById } from '@/hooks/useBillById'
 import { carriers } from '@/config/carriers'
 import PaymentConfirmationCard from '@/components/bill/PaymentConfirmationCard'
+import { calculateTotal, getBillStatus } from '@/core/modules/bill'
 
 export default function AdminBillDetailPage({ params }: { params: { billId: string } }) {
   const bill = useBillById(params.billId)
@@ -34,9 +35,12 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
     return <div className="p-4 text-center">ไม่พบบิล</div>
   }
 
-  const subtotal = bill.items.reduce((sum, it) => sum + it.price * it.quantity, 0)
   const discount = (bill as any).discount || 0
-  const total = subtotal - discount + bill.shipping
+  const { subtotal, total } = calculateTotal({
+    items: bill.items,
+    shipping: bill.shipping,
+    discount,
+  })
 
   return (
     <div className="space-y-6 p-4">
@@ -47,7 +51,7 @@ export default function AdminBillDetailPage({ params }: { params: { billId: stri
           </Button>
         </Link>
         <h1 className="text-2xl font-bold">บิล {bill.id}</h1>
-        <Badge className="ml-auto">{bill.status}</Badge>
+        <Badge className="ml-auto">{getBillStatus(bill.status)}</Badge>
       </div>
       <Card>
         <CardHeader>

--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -13,6 +13,7 @@ import { formatDateThai } from '@/lib/formatDateThai'
 import type { StoreProfile } from '@/lib/config'
 import { getStoreProfile } from '@/lib/config'
 import { useToast } from '@/hooks/use-toast'
+import { calculateTotal } from '@/core/modules/bill'
 
 export default function BillViewPage({ params }: { params: { billId: string } }) {
   const bill = (bills as any[]).find(b => b.id === params.billId)
@@ -33,11 +34,7 @@ export default function BillViewPage({ params }: { params: { billId: string } })
     )
   }
 
-  const sum = bill.items.reduce(
-    (s: number, it: any) => s + it.price * it.quantity,
-    0,
-  )
-  const total = sum + bill.shipping
+  const { total } = calculateTotal({ items: bill.items, shipping: bill.shipping })
 
   const handleShare = () => {
     if (typeof window !== 'undefined') {

--- a/app/thankyou/[billId]/page.tsx
+++ b/app/thankyou/[billId]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useEffect, useState } from 'react'
 import BillQRSection from '@/components/bill/BillQRSection'
+import { calculateTotal } from '@/core/modules/bill'
 
 export default function ThankYouPage({ params }: { params: { billId: string } }) {
   const { billId } = params
@@ -15,8 +16,10 @@ export default function ThankYouPage({ params }: { params: { billId: string } })
 
   if (!bill) return <div className="p-4 text-center">ไม่พบบิลนี้</div>
 
-  const sum = bill.items?.reduce((s: number, it: any) => s + it.price * it.quantity, 0) || 0
-  const total = sum + (bill.shipping || 0)
+  const { total } = calculateTotal({
+    items: bill.items || [],
+    shipping: bill.shipping || 0,
+  })
 
   return (
     <div className="p-4 max-w-xl mx-auto space-y-4">

--- a/core/modules/bill.ts
+++ b/core/modules/bill.ts
@@ -1,0 +1,71 @@
+export interface BillItem {
+  name: string
+  quantity: number
+  price: number
+}
+
+export interface Bill {
+  id: string
+  shortCode: string
+  customerId: string
+  customer?: string
+  items: BillItem[]
+  shipping: number
+  discount?: number
+  status:
+    | 'draft'
+    | 'pending'
+    | 'unpaid'
+    | 'paid'
+    | 'packed'
+    | 'shipped'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled'
+  productionStatus?:
+    | 'waiting'
+    | 'cutting'
+    | 'sewing'
+    | 'packing'
+    | 'shipped'
+    | 'done'
+}
+
+import type { Customer as BaseCustomer } from '@/types/customer'
+export type Customer = BaseCustomer
+
+export function generateBillId() {
+  return `BILL-${Date.now().toString(36)}`
+}
+
+export function calculateTotal(bill: Pick<Bill, 'items' | 'shipping'> & { discount?: number }) {
+  const subtotal = bill.items.reduce((sum, it) => sum + it.price * it.quantity, 0)
+  const total = subtotal - (bill.discount || 0) + bill.shipping
+  return { subtotal, total }
+}
+
+const statusLabels: Record<Bill['status'], string> = {
+  draft: 'ร่าง',
+  pending: 'รอตรวจสอบ',
+  unpaid: 'ค้างชำระ',
+  paid: 'ชำระแล้ว',
+  packed: 'แพ็คแล้ว',
+  shipped: 'จัดส่งแล้ว',
+  delivered: 'ส่งสำเร็จ',
+  failed: 'ล้มเหลว',
+  cancelled: 'ยกเลิก',
+}
+
+export function getBillStatus(status: Bill['status']): string {
+  return statusLabels[status] || status
+}
+
+export function formatBillDisplay(bill: Bill) {
+  const { subtotal, total } = calculateTotal(bill)
+  return {
+    ...bill,
+    subtotal,
+    total,
+    statusLabel: getBillStatus(bill.status),
+  }
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,6 +9,9 @@ export interface StoreProfile {
   accountNumber: string
 }
 
+export const dataMode: 'mock' | 'real' =
+  (process.env.NEXT_PUBLIC_DATA_MODE as 'mock' | 'real') || 'mock'
+
 export async function getStoreProfile(): Promise<StoreProfile> {
   const res = await fetch('/api/config/store-profile')
   return res.json()

--- a/lib/mock-customers.ts
+++ b/lib/mock-customers.ts
@@ -1,4 +1,5 @@
-import type { Customer, PointLog } from '@/types/customer'
+import type { Customer } from '@/core/modules/bill'
+import type { PointLog } from '@/types/customer'
 export type { Customer }
 
 import { mockOrders } from "./mock-orders"

--- a/lib/utils/billFormatter.ts
+++ b/lib/utils/billFormatter.ts
@@ -1,0 +1,13 @@
+import type { Bill } from '@/core/modules/bill'
+import { calculateTotal, getBillStatus } from '@/core/modules/bill'
+import { formatCurrencyTHB } from '@/lib/format/currency'
+
+export function formatBillDisplay(bill: Bill) {
+  const { subtotal, total } = calculateTotal(bill)
+  return {
+    ...bill,
+    subtotalText: formatCurrencyTHB(subtotal),
+    totalText: formatCurrencyTHB(total),
+    statusLabel: getBillStatus(bill.status),
+  }
+}

--- a/mock/bills.ts
+++ b/mock/bills.ts
@@ -1,4 +1,5 @@
-import type { BillFeedback, BillItem } from '@/types/bill'
+import type { BillFeedback } from '@/types/bill'
+import type { BillItem } from '@/core/modules/bill'
 
 export interface AdminBill {
   id: string


### PR DESCRIPTION
## Summary
- add core bill module with shared calculation helpers
- format bill display values in a util
- refactor admin and customer bill pages to use shared helpers
- update mock DB types to use new module
- expose dataMode toggle in `lib/config.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882f89e02cc83258101ad4ede9f7590