### PR TITLE
Add supabase toggle and data layer

### DIFF
--- a/app/bill/view/[billId]/page.tsx
+++ b/app/bill/view/[billId]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState, useEffect } from 'react'
-import bills from '@/mock/store/bills.json'
+import { getBillById } from '@/lib/data/bills'
 import BillQRSection from '@/components/bill/BillQRSection'
 import CustomerPaymentForm from '@/components/bill/CustomerPaymentForm'
 import PaymentConfirmationCard from '@/components/bill/PaymentConfirmationCard'
@@ -16,17 +16,26 @@ import { useToast } from '@/hooks/use-toast'
 import { calculateTotal } from '@/core/modules/bill'
 
 export default function BillViewPage({ params }: { params: { billId: string } }) {
-  const bill = (bills as any[]).find(b => b.id === params.billId)
+  const [bill, setBill] = useState<any | undefined>(undefined)
   const [editAddr, setEditAddr] = useState(false)
-  const [address, setAddress] = useState(bill?.address || '')
+  const [address, setAddress] = useState('')
   const [editPhone, setEditPhone] = useState(false)
-  const [phone, setPhone] = useState(bill?.phone || '')
+  const [phone, setPhone] = useState('')
   const [store, setStore] = useState<StoreProfile | null>(null)
   const { toast } = useToast()
-  
+
   useEffect(() => {
+    getBillById(params.billId).then(b => {
+      setBill(b)
+      setAddress(b?.address || '')
+      setPhone(b?.phone || '')
+    })
     getStoreProfile().then(setStore)
-  }, [])
+  }, [params.billId])
+
+  if (bill === undefined) {
+    return <div className="p-4 text-center">Loading...</div>
+  }
 
   if (!bill) {
     return (

--- a/app/thankyou/[billId]/page.tsx
+++ b/app/thankyou/[billId]/page.tsx
@@ -2,16 +2,14 @@
 import { useEffect, useState } from 'react'
 import BillQRSection from '@/components/bill/BillQRSection'
 import { calculateTotal } from '@/core/modules/bill'
+import { getBillById } from '@/lib/data/bills'
 
 export default function ThankYouPage({ params }: { params: { billId: string } }) {
   const { billId } = params
   const [bill, setBill] = useState<any | null>(null)
 
   useEffect(() => {
-    fetch(`/api/bill/${billId}`)
-      .then(r => r.json())
-      .then(setBill)
-      .catch(() => setBill(null))
+    getBillById(billId).then(setBill).catch(() => setBill(null))
   }, [billId])
 
   if (!bill) return <div className="p-4 text-center">ไม่พบบิลนี้</div>

--- a/hooks/useBillById.ts
+++ b/hooks/useBillById.ts
@@ -1,17 +1,19 @@
 "use client"
 import { useEffect, useState } from 'react'
 import type { AdminBill } from '@/mock/bills'
-import { getBill } from '@/core/mock/store'
+import { getBillById } from '@/lib/data/bills'
 
 export function useBillById(id: string) {
-  const [bill, setBill] = useState<AdminBill | undefined>(() => getBill(id))
+  const [bill, setBill] = useState<AdminBill | undefined>(undefined)
 
   useEffect(() => {
-    setBill(getBill(id))
+    getBillById(id).then(setBill)
   }, [id])
 
   useEffect(() => {
-    const handler = () => setBill(getBill(id))
+    const handler = () => {
+      getBillById(id).then(setBill)
+    }
     window.addEventListener('storage', handler)
     return () => window.removeEventListener('storage', handler)
   }, [id])

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,6 +9,8 @@ export interface StoreProfile {
   accountNumber: string
 }
 
+export const USE_SUPABASE = false
+
 export const dataMode: 'mock' | 'real' =
   (process.env.NEXT_PUBLIC_DATA_MODE as 'mock' | 'real') || 'mock'
 

--- a/lib/data/bills.ts
+++ b/lib/data/bills.ts
@@ -1,0 +1,18 @@
+import { USE_SUPABASE } from '../config'
+import type { AdminBill } from '@/mock/bills'
+import { getBill, getBills } from '@/mockDB/bills'
+import { getBillFromSupabase, getBillsFromSupabase } from '../supabase/billService'
+
+export async function getBillById(id: string): Promise<AdminBill | null> {
+  if (USE_SUPABASE) {
+    return getBillFromSupabase(id)
+  }
+  return Promise.resolve(getBill(id) || null)
+}
+
+export async function getAllBills(): Promise<AdminBill[]> {
+  if (USE_SUPABASE) {
+    return getBillsFromSupabase()
+  }
+  return Promise.resolve([...getBills()])
+}

--- a/lib/data/customers.ts
+++ b/lib/data/customers.ts
@@ -1,0 +1,18 @@
+import { USE_SUPABASE } from '../config'
+import type { Customer } from '@/types/customer'
+import { getCustomer, getCustomers } from '@/mockDB/customers'
+
+export async function getAllCustomers(): Promise<Customer[]> {
+  if (USE_SUPABASE) {
+    // TODO connect to Supabase later
+    return Promise.resolve([])
+  }
+  return Promise.resolve([...getCustomers()])
+}
+
+export async function getCustomerById(id: string): Promise<Customer | undefined> {
+  if (USE_SUPABASE) {
+    return Promise.resolve(undefined)
+  }
+  return Promise.resolve(getCustomer(id))
+}

--- a/lib/supabase/billService.ts
+++ b/lib/supabase/billService.ts
@@ -1,0 +1,16 @@
+import type { AdminBill } from '@/mock/bills'
+
+export async function getBillFromSupabase(id: string): Promise<AdminBill | null> {
+  // TODO: connect to Supabase
+  return Promise.resolve(null)
+}
+
+export async function getBillsFromSupabase(): Promise<AdminBill[]> {
+  // TODO: connect to Supabase
+  return Promise.resolve([])
+}
+
+export async function saveBillToSupabase(_bill: AdminBill): Promise<void> {
+  // TODO: connect to Supabase
+  return Promise.resolve()
+}

--- a/mockDB/bills.ts
+++ b/mockDB/bills.ts
@@ -1,0 +1,13 @@
+import bills from '@/mock/store/bills.json'
+
+export type BillRecord = (typeof bills)[number]
+
+export const mockBills: readonly BillRecord[] = bills as BillRecord[]
+
+export function getBill(id: string): BillRecord | undefined {
+  return mockBills.find(b => b.id === id)
+}
+
+export function getBills(): readonly BillRecord[] {
+  return mockBills
+}

--- a/mockDB/customers.ts
+++ b/mockDB/customers.ts
@@ -1,0 +1,13 @@
+import customers from '@/mock/store/customers.json'
+
+export type CustomerRecord = (typeof customers)[number]
+
+export const mockCustomers: readonly CustomerRecord[] = customers as CustomerRecord[]
+
+export function getCustomer(id: string): CustomerRecord | undefined {
+  return mockCustomers.find(c => c.id === id)
+}
+
+export function getCustomers(): readonly CustomerRecord[] {
+  return mockCustomers
+}


### PR DESCRIPTION
## Summary
- add `USE_SUPABASE` switch in `lib/config.ts`
- introduce central data layer for bills and customers
- create placeholder Supabase bill service
- expose mockDB readonly access
- refactor pages and hooks to load data through the new layer

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882fb8d3afc83258d474df22163fbea