### PR TITLE
Improve bill view UX

### DIFF
--- a/components/bill/BillActionButtons.tsx
+++ b/components/bill/BillActionButtons.tsx
@@ -1,0 +1,19 @@
+"use client"
+import Link from 'next/link'
+import { Button } from '@/components/ui/buttons/button'
+
+export default function BillActionButtons({ billId }: { billId: string }) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:gap-4">
+      <Link href={`/thankyou/${billId}`} className="flex-1">
+        <Button className="w-full">แจ้งโอน</Button>
+      </Link>
+      <Link href={`/customer/edit-address?billId=${billId}`} className="flex-1">
+        <Button variant="outline" className="w-full">แก้ที่อยู่</Button>
+      </Link>
+      <a href="#timeline" className="flex-1">
+        <Button variant="outline" className="w-full">ติดตามสถานะ</Button>
+      </a>
+    </div>
+  )
+}

--- a/components/bill/BillTimeline.tsx
+++ b/components/bill/BillTimeline.tsx
@@ -10,11 +10,17 @@ const steps = [
   { key: 'done', label: 'เสร็จสิ้น', icon: CircleCheck },
 ] as const
 
-export default function BillTimeline({ status }: { status: ProductionStatus }) {
+interface Props {
+  status: ProductionStatus
+  timeline?: Array<{ timestamp: string }>
+}
+
+export default function BillTimeline({ status, timeline }: Props) {
   const key = status
   const current = steps.findIndex(s => s.key === key)
   return (
-    <div className="flex items-center justify-between relative">
+    <div id="timeline" className="flex flex-col space-y-1">
+      <div className="flex items-center justify-between relative">
       {steps.map((step, index) => {
         const StepIcon = step.icon
         const isDone = index <= current
@@ -46,6 +52,10 @@ export default function BillTimeline({ status }: { status: ProductionStatus }) {
           </div>
         )
       })}
+      </div>
+      {timeline && timeline.length === 0 && (
+        <p className="text-xs text-center text-gray-500">ยังไม่มีข้อมูล</p>
+      )}
     </div>
   )
 }

--- a/components/bill/ReceiptCard.tsx
+++ b/components/bill/ReceiptCard.tsx
@@ -24,7 +24,7 @@ export default function ReceiptCard({ url, note }: Props) {
             isImage(url) && <img src={url} alt="receipt" className="w-full" />
           )
         ) : (
-          <p className="text-sm text-gray-500">ยังไม่มีใบเสร็จแนบ</p>
+          <p className="text-sm text-gray-500">ยังไม่มีข้อมูล</p>
         )}
         {note && <p className="text-sm text-gray-500">{note}</p>}
       </CardContent>

--- a/lib/data/bills.ts
+++ b/lib/data/bills.ts
@@ -1,5 +1,8 @@
 import { USE_SUPABASE } from '../config'
 import type { AdminBill } from '@/mock/bills'
+
+// Public Bill interface for future real database
+export type Bill = AdminBill
 import { getBill, getBills } from '@/mockDB/bills'
 import { getBillFromSupabase, getBillsFromSupabase } from '../supabase/billService'
 

--- a/lib/hooks/useBill.ts
+++ b/lib/hooks/useBill.ts
@@ -1,0 +1,19 @@
+"use client"
+import { useEffect, useState } from 'react'
+import type { Bill } from '../data/bills'
+import { getBillById } from '../data/bills'
+
+export function useBill(id: string) {
+  const [bill, setBill] = useState<Bill | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    getBillById(id).then(b => {
+      setBill(b)
+      setLoading(false)
+    })
+  }, [id])
+
+  return { bill, loading }
+}


### PR DESCRIPTION
## Summary
- show bill status badge and add better timeline fallback
- add BillActionButtons component with primary actions
- add useBill hook for fetching bills
- tweak receipt fallback text
- export unified Bill type

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6882fe53457883259c691731b0997396