### PR TITLE
Restore admin routes and optional mock UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,8 @@ import type { Collection } from "@/types/collection"
 import { RecentProductsSection } from "@/components/RecentProductsSection"
 import { promises as fs } from "fs"
 import { join } from "path"
+import QuickEntryMock from "@/components/home/QuickEntryMock"
+import { ENABLE_MOCK_UI } from "@/lib/config"
 
 export default async function HomePage() {
   const featuredProducts = mockProducts.slice(0, 4)
@@ -30,6 +32,7 @@ export default async function HomePage() {
       <Navbar />
 
       <HeroBannerSection />
+      {ENABLE_MOCK_UI && <QuickEntryMock />}
 
       {curatedProducts.length > 0 && (
         <section className="py-16">

--- a/components/customers/CustomerCard.tsx
+++ b/components/customers/CustomerCard.tsx
@@ -16,7 +16,7 @@ export default function CustomerCard({ customer }: { customer: Customer }) {
   const status =
     customer.tier === "VIP" ? "VIP" : (customer.points ?? 0) > 50 ? "returning" : "new"
   return (
-    <Link href={`/dashboard/customers/${customer.id}`} className="block">
+    <Link href={`/admin/customers/${customer.id}`} className="block">
       <Card className="hover:bg-muted/50">
         <CardHeader>
           <CardTitle className="flex items-center justify-between">

--- a/components/home/QuickEntryMock.tsx
+++ b/components/home/QuickEntryMock.tsx
@@ -1,0 +1,32 @@
+"use client"
+import Link from "next/link"
+import { ShoppingCart, ImageIcon, MessageCircle, Percent, Book } from "lucide-react"
+
+const menu = [
+  { href: "/admin/openbill/quick", label: "เปิดบิลเร็ว", icon: ShoppingCart },
+  { href: "/admin/fabrics", label: "ลายผ้า", icon: ImageIcon },
+  { href: "/admin/chat", label: "คุยกับลูกค้า", icon: MessageCircle },
+  { href: "/admin/promos", label: "โปรโมชัน", icon: Percent },
+  { href: "/catalog", label: "แคตตาล็อก", icon: Book },
+]
+
+export default function QuickEntryMock() {
+  return (
+    <section className="py-8 bg-gray-50">
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-4 text-center">
+          {menu.map(({ href, label, icon: Icon }) => (
+            <Link
+              key={label}
+              href={href}
+              className="bg-white rounded-lg p-4 flex flex-col items-center shadow hover:bg-gray-100"
+            >
+              <Icon className="w-6 h-6 mb-2" />
+              <span className="text-sm">{label}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/order/OrderCard.tsx
+++ b/components/order/OrderCard.tsx
@@ -18,7 +18,7 @@ export default function OrderCard({ order, onCancel }: { order: SimpleOrder; onC
         </p>
         <p>ยอดรวม: ฿{order.total.toLocaleString()}</p>
         <div className="flex gap-2 pt-2">
-          <Link href={`/dashboard/orders/${order.id}`}>
+          <Link href={`/admin/orders/${order.id}`}>
             <Button variant="outline" size="sm">ดู</Button>
           </Link>
           <Button

--- a/components/ui/sidebar.config.ts
+++ b/components/ui/sidebar.config.ts
@@ -15,7 +15,7 @@ export const sidebarSections: SidebarSectionConfig[] = [
   {
     section: "General",
     items: [
-      { label: "Dashboard", icon: require("lucide-react").Home, href: "/dashboard" },
+      { label: "Dashboard", icon: require("lucide-react").Home, href: "/admin" },
       { label: "Orders", icon: require("lucide-react").ShoppingCart, href: "/orders" },
     ],
   },
@@ -23,17 +23,17 @@ export const sidebarSections: SidebarSectionConfig[] = [
     section: "Inventory",
     items: [
       { label: "Products", icon: require("lucide-react").Package, href: "/products" },
-      { label: "Stock", icon: require("lucide-react").ClipboardList, href: "/dashboard/stock" },
+      { label: "Stock", icon: require("lucide-react").ClipboardList, href: "/admin/stock" },
     ],
   },
   {
     section: "System",
     items: [
-      { label: "Access Log", icon: require("lucide-react").List, href: "/dashboard/logs/access" },
-      { label: "Performance", icon: require("lucide-react").BarChart3, href: "/dashboard/insight/performance" },
-      { label: "Campaigns", icon: require("lucide-react").Target, href: "/dashboard/campaigns" },
-      { label: "Lock", icon: require("lucide-react").Lock, href: "/dashboard/settings/lock" },
-      { label: "Backup", icon: require("lucide-react").Database, href: "/dashboard/settings/system-backup" },
+      { label: "Access Log", icon: require("lucide-react").List, href: "/admin/logs/access" },
+      { label: "Performance", icon: require("lucide-react").BarChart3, href: "/admin/insight/performance" },
+      { label: "Campaigns", icon: require("lucide-react").Target, href: "/admin/campaigns" },
+      { label: "Lock", icon: require("lucide-react").Lock, href: "/admin/settings/lock" },
+      { label: "Backup", icon: require("lucide-react").Database, href: "/admin/settings/system-backup" },
     ],
   },
 ]

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,6 +11,7 @@ export interface StoreProfile {
 
 export const USE_SUPABASE = false
 export const ENABLE_MOCK_DASHBOARD = false
+export const ENABLE_MOCK_UI = false
 
 export const dataMode: 'mock' | 'real' =
   (process.env.NEXT_PUBLIC_DATA_MODE as 'mock' | 'real') || 'mock'


### PR DESCRIPTION
## Summary
- add optional `ENABLE_MOCK_UI` flag
- show QuickEntryMock section on Home when enabled
- fix links that still referenced `/dashboard` routes
- update example sidebar config to use `/admin` paths

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68830adc6c048325b66697492d478e0e